### PR TITLE
Expand test coverage from 14 to 62 tests across all modules

### DIFF
--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -251,4 +251,114 @@ mod tests {
         // outputs: [loss, grad_w1, grad_b1, grad_w2]
         assert_eq!(diff.outputs().len(), 4, "expected loss + 3 param grads");
     }
+
+    #[test]
+    fn test_sigmoid_autodiff() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let y = g.matmul(x, w);
+        let s = g.sigmoid(y);
+        let loss = g.mean_all(s);
+        g.set_outputs(vec![loss]);
+
+        let diff = differentiate(&g);
+        // outputs: [loss, grad_w]
+        assert_eq!(diff.outputs().len(), 2);
+        // Sigmoid backward creates: neg, add (1-y), mul (y*(1-y)), mul (dL * dy)
+        // Check gradient node shapes
+        let grad_w = diff.outputs()[1];
+        assert_eq!(diff.node(grad_w).ty.shape, vec![8, 4]);
+    }
+
+    #[test]
+    fn test_neg_autodiff() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let y = g.matmul(x, w);
+        let n = g.neg(y);
+        let loss = g.sum_all(n);
+        g.set_outputs(vec![loss]);
+
+        let diff = differentiate(&g);
+        assert_eq!(diff.outputs().len(), 2);
+        let grad_w = diff.outputs()[1];
+        assert_eq!(diff.node(grad_w).ty.shape, vec![8, 4]);
+    }
+
+    #[test]
+    fn test_transpose_autodiff() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 3]);
+        let y = g.matmul(x, w);
+        let t = g.transpose(y);
+        // t is [3, 4], need to reduce to scalar
+        let loss = g.mean_all(t);
+        g.set_outputs(vec![loss]);
+
+        let diff = differentiate(&g);
+        assert_eq!(diff.outputs().len(), 2);
+        let grad_w = diff.outputs()[1];
+        assert_eq!(diff.node(grad_w).ty.shape, vec![8, 3]);
+    }
+
+    #[test]
+    fn test_mul_autodiff() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let y = g.matmul(x, w);
+        // element-wise mul with itself: y * y
+        let sq = g.mul(y, y);
+        let loss = g.mean_all(sq);
+        g.set_outputs(vec![loss]);
+
+        let diff = differentiate(&g);
+        assert_eq!(diff.outputs().len(), 2);
+        // When multiplying y*y, gradient accumulates from both inputs
+        let grad_w = diff.outputs()[1];
+        assert_eq!(diff.node(grad_w).ty.shape, vec![8, 4]);
+    }
+
+    #[test]
+    fn test_multi_path_gradient_accumulation() {
+        // w is used in two separate matmuls — gradients should accumulate
+        let mut g = Graph::new();
+        let x1 = g.input("x1", &[4, 8]);
+        let x2 = g.input("x2", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let y1 = g.matmul(x1, w);
+        let y2 = g.matmul(x2, w);
+        let sum = g.add(y1, y2);
+        let loss = g.mean_all(sum);
+        g.set_outputs(vec![loss]);
+
+        let diff = differentiate(&g);
+        assert_eq!(diff.outputs().len(), 2); // loss + grad_w
+        let grad_w = diff.outputs()[1];
+        // Gradient should be accumulated (Add node)
+        assert!(
+            matches!(diff.node(grad_w).op, Op::Add),
+            "expected gradient accumulation via Add, got {:?}",
+            diff.node(grad_w).op
+        );
+        assert_eq!(diff.node(grad_w).ty.shape, vec![8, 4]);
+    }
+
+    #[test]
+    fn test_no_grad_for_inputs() {
+        // Inputs should not appear in gradient outputs
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 3]);
+        let w = g.parameter("w", &[3, 2]);
+        let y = g.matmul(x, w);
+        let loss = g.sum_all(y);
+        g.set_outputs(vec![loss]);
+
+        let diff = differentiate(&g);
+        // Only loss + grad_w (not grad_x)
+        assert_eq!(diff.outputs().len(), 2);
+    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -113,4 +113,71 @@ mod tests {
         // Cleanup
         let _ = std::fs::remove_file(&path);
     }
+
+    #[test]
+    fn test_load_missing_file() {
+        let g = Graph::new();
+        let path = std::env::temp_dir().join("meganeura_nonexistent_cache.ron");
+        let result = load_plan(&g, &path).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_load_corrupt_file() {
+        let dir = std::env::temp_dir().join("meganeura_test_cache_corrupt");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("corrupt.ron");
+        std::fs::write(&path, "this is not valid RON").unwrap();
+
+        let g = Graph::new();
+        let result = load_plan(&g, &path);
+        assert!(result.is_err());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_hash_graph_deterministic() {
+        let build = || {
+            let mut g = Graph::new();
+            let x = g.input("x", &[4, 8]);
+            let w = g.parameter("w", &[8, 4]);
+            let y = g.matmul(x, w);
+            g.set_outputs(vec![y]);
+            g
+        };
+        let h1 = hash_graph(&build());
+        let h2 = hash_graph(&build());
+        assert_eq!(h1, h2, "same graph should produce same hash");
+    }
+
+    #[test]
+    fn test_hash_graph_differs_on_change() {
+        let mut g1 = Graph::new();
+        let x = g1.input("x", &[4, 8]);
+        let w = g1.parameter("w", &[8, 4]);
+        let y = g1.matmul(x, w);
+        g1.set_outputs(vec![y]);
+
+        let mut g2 = Graph::new();
+        let x2 = g2.input("x", &[4, 8]);
+        let w2 = g2.parameter("w", &[8, 5]); // different shape
+        let y2 = g2.matmul(x2, w2);
+        g2.set_outputs(vec![y2]);
+
+        assert_ne!(hash_graph(&g1), hash_graph(&g2));
+    }
+
+    #[test]
+    fn test_hash_graph_differs_on_name_change() {
+        let mut g1 = Graph::new();
+        let x = g1.input("x", &[4, 8]);
+        g1.set_outputs(vec![x]);
+
+        let mut g2 = Graph::new();
+        let x = g2.input("y", &[4, 8]); // different name
+        g2.set_outputs(vec![x]);
+
+        assert_ne!(hash_graph(&g1), hash_graph(&g2));
+    }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -427,4 +427,216 @@ mod tests {
         assert_eq!(plan.dispatches.len(), 1);
         assert_eq!(plan.dispatches[0].shader, ShaderEntry::MatMulRelu);
     }
+
+    #[test]
+    fn test_compile_all_unary_ops() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let r = g.relu(x);
+        let s = g.sigmoid(x);
+        let n = g.neg(x);
+        g.set_outputs(vec![r, s, n]);
+
+        let plan = compile(&g);
+        assert_eq!(plan.dispatches.len(), 3);
+        assert_eq!(plan.dispatches[0].shader, ShaderEntry::Relu);
+        assert_eq!(plan.dispatches[1].shader, ShaderEntry::Sigmoid);
+        assert_eq!(plan.dispatches[2].shader, ShaderEntry::Neg);
+        // All unary ops: params = [len, 0, 0, 0]
+        for d in &plan.dispatches {
+            assert_eq!(d.params[0], 32); // 4*8
+            assert_eq!(d.input_buffers.len(), 1);
+        }
+    }
+
+    #[test]
+    fn test_compile_all_binary_ops() {
+        let mut g = Graph::new();
+        let a = g.input("a", &[4, 8]);
+        let b = g.input("b", &[4, 8]);
+        let add = g.add(a, b);
+        let mul = g.mul(a, b);
+        let gt = g.greater(a, b);
+        g.set_outputs(vec![add, mul, gt]);
+
+        let plan = compile(&g);
+        assert_eq!(plan.dispatches.len(), 3);
+        assert_eq!(plan.dispatches[0].shader, ShaderEntry::Add);
+        assert_eq!(plan.dispatches[1].shader, ShaderEntry::Mul);
+        assert_eq!(plan.dispatches[2].shader, ShaderEntry::Greater);
+        for d in &plan.dispatches {
+            assert_eq!(d.input_buffers.len(), 2);
+            assert_eq!(d.params[0], 32);
+        }
+    }
+
+    #[test]
+    fn test_compile_bias_add() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 128]);
+        let b = g.parameter("b", &[128]);
+        let out = g.bias_add(x, b);
+        g.set_outputs(vec![out]);
+
+        let plan = compile(&g);
+        assert_eq!(plan.dispatches.len(), 1);
+        assert_eq!(plan.dispatches[0].shader, ShaderEntry::BiasAdd);
+        assert_eq!(plan.dispatches[0].params[0], 512); // 4*128
+        assert_eq!(plan.dispatches[0].params[1], 128); // bias len
+    }
+
+    #[test]
+    fn test_compile_reductions() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let sa = g.sum_all(x);
+        let ma = g.mean_all(x);
+        g.set_outputs(vec![sa, ma]);
+
+        let plan = compile(&g);
+        assert_eq!(plan.dispatches.len(), 2);
+        assert_eq!(plan.dispatches[0].shader, ShaderEntry::SumAll);
+        assert_eq!(plan.dispatches[1].shader, ShaderEntry::MeanAll);
+        // params = [len, 0, 0, 0]
+        for d in &plan.dispatches {
+            assert_eq!(d.params[0], 32);
+        }
+    }
+
+    #[test]
+    fn test_compile_softmax() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 10]);
+        let sm = g.softmax(x);
+        g.set_outputs(vec![sm]);
+
+        let plan = compile(&g);
+        assert_eq!(plan.dispatches.len(), 1);
+        assert_eq!(plan.dispatches[0].shader, ShaderEntry::Softmax);
+        assert_eq!(plan.dispatches[0].params[0], 4);  // batch
+        assert_eq!(plan.dispatches[0].params[1], 10); // features
+    }
+
+    #[test]
+    fn test_compile_cross_entropy() {
+        let mut g = Graph::new();
+        let logits = g.input("logits", &[4, 10]);
+        let labels = g.input("labels", &[4, 10]);
+        let loss = g.cross_entropy_loss(logits, labels);
+        g.set_outputs(vec![loss]);
+
+        let plan = compile(&g);
+        assert_eq!(plan.dispatches.len(), 1);
+        assert_eq!(plan.dispatches[0].shader, ShaderEntry::CrossEntropyLoss);
+        assert_eq!(plan.dispatches[0].workgroups, [1, 1, 1]);
+        assert_eq!(plan.dispatches[0].params[0], 4);
+        assert_eq!(plan.dispatches[0].params[1], 10);
+    }
+
+    #[test]
+    fn test_compile_transpose() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let t = g.transpose(x);
+        g.set_outputs(vec![t]);
+
+        let plan = compile(&g);
+        assert_eq!(plan.dispatches.len(), 1);
+        assert_eq!(plan.dispatches[0].shader, ShaderEntry::Transpose);
+        assert_eq!(plan.dispatches[0].params[0], 4); // m
+        assert_eq!(plan.dispatches[0].params[1], 8); // n
+    }
+
+    #[test]
+    fn test_compile_matmul_workgroups() {
+        let mut g = Graph::new();
+        let a = g.input("a", &[33, 64]);
+        let b = g.input("b", &[64, 17]);
+        let y = g.matmul(a, b);
+        g.set_outputs(vec![y]);
+
+        let plan = compile(&g);
+        let d = &plan.dispatches[0];
+        // workgroups = [ceil(N/16), ceil(M/16), 1] = [ceil(17/16), ceil(33/16), 1] = [2, 3, 1]
+        assert_eq!(d.workgroups, [2, 3, 1]);
+        assert_eq!(d.params, vec![33, 64, 17, 0]);
+    }
+
+    #[test]
+    fn test_compile_loss_buffer() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let loss = g.mean_all(x);
+        g.set_outputs(vec![loss]);
+
+        let plan = compile(&g);
+        assert!(plan.loss_buffer.is_some());
+    }
+
+    #[test]
+    fn test_compile_param_grad_pairs() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 3]);
+        let w = g.parameter("w", &[3, 2]);
+        let y = g.matmul(x, w);
+        let loss = g.mean_all(y);
+        g.set_outputs(vec![loss]);
+
+        let diff = crate::autodiff::differentiate(&g);
+        let plan = compile(&diff);
+        assert_eq!(plan.param_grad_pairs.len(), 1);
+        // param buffer and grad buffer should be different
+        assert_ne!(plan.param_grad_pairs[0].0, plan.param_grad_pairs[0].1);
+    }
+
+    #[test]
+    fn test_compile_nop_skipped() {
+        use crate::graph::{Op, TensorType};
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let _nop = g.add_raw_node(Op::Nop, vec![], TensorType::f32(vec![1]));
+        let r = g.relu(x);
+        g.set_outputs(vec![r]);
+
+        let plan = compile(&g);
+        // Nop should produce no dispatch
+        assert_eq!(plan.dispatches.len(), 1);
+        assert_eq!(plan.dispatches[0].shader, ShaderEntry::Relu);
+    }
+
+    #[test]
+    fn test_compile_fused_matmul_bias_relu() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let b = g.parameter("b", &[4]);
+        let mm = g.matmul(x, w);
+        let ba = g.bias_add(mm, b);
+        let h = g.relu(ba);
+        g.set_outputs(vec![h]);
+
+        let opt = crate::optimize::optimize(&g);
+        let plan = compile(&opt);
+        assert_eq!(plan.dispatches.len(), 1);
+        assert_eq!(plan.dispatches[0].shader, ShaderEntry::MatMulBiasRelu);
+        assert_eq!(plan.dispatches[0].input_buffers.len(), 3); // a, b, bias
+    }
+
+    #[test]
+    fn test_shader_entry_mappings() {
+        // Verify all shader entries have valid group and entry_point
+        let entries = [
+            ShaderEntry::MatMul, ShaderEntry::MatMulRelu, ShaderEntry::MatMulBiasRelu,
+            ShaderEntry::Relu, ShaderEntry::Sigmoid, ShaderEntry::Neg,
+            ShaderEntry::Add, ShaderEntry::Mul, ShaderEntry::Greater,
+            ShaderEntry::BiasAdd, ShaderEntry::SgdUpdate,
+            ShaderEntry::SumAll, ShaderEntry::MeanAll,
+            ShaderEntry::Softmax, ShaderEntry::CrossEntropyLoss, ShaderEntry::Transpose,
+        ];
+        for entry in &entries {
+            let _group = entry.shader_group();
+            let ep = entry.entry_point();
+            assert!(!ep.is_empty());
+        }
+    }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -319,4 +319,154 @@ mod tests {
         assert_eq!(t.num_elements(), 32 * 784);
         assert_eq!(t.size_bytes(), 32 * 784 * 4);
     }
+
+    #[test]
+    fn tensor_type_rank() {
+        assert_eq!(TensorType::f32(vec![4, 3]).rank(), 2);
+        assert_eq!(TensorType::f32(vec![1]).rank(), 1);
+        assert_eq!(TensorType::f32(vec![2, 3, 4]).rank(), 3);
+    }
+
+    #[test]
+    fn build_all_unary_ops() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let r = g.relu(x);
+        let s = g.sigmoid(x);
+        let n = g.neg(x);
+        let t = g.transpose(x);
+        g.set_outputs(vec![r, s, n, t]);
+
+        assert_eq!(g.node(r).ty.shape, vec![4, 8]);
+        assert_eq!(g.node(s).ty.shape, vec![4, 8]);
+        assert_eq!(g.node(n).ty.shape, vec![4, 8]);
+        assert_eq!(g.node(t).ty.shape, vec![8, 4]); // transposed
+    }
+
+    #[test]
+    fn build_all_binary_ops() {
+        let mut g = Graph::new();
+        let a = g.input("a", &[4, 8]);
+        let b = g.input("b", &[4, 8]);
+        let add = g.add(a, b);
+        let mul = g.mul(a, b);
+        let gt = g.greater(a, b);
+        g.set_outputs(vec![add, mul, gt]);
+
+        for &id in &[add, mul, gt] {
+            assert_eq!(g.node(id).ty.shape, vec![4, 8]);
+        }
+    }
+
+    #[test]
+    fn build_bias_add() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 128]);
+        let b = g.parameter("b", &[128]);
+        let out = g.bias_add(x, b);
+        assert_eq!(g.node(out).ty.shape, vec![4, 128]);
+    }
+
+    #[test]
+    fn build_reductions() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let sa = g.sum_all(x);
+        let ma = g.mean_all(x);
+        let sm = g.softmax(x);
+        let lsm = g.log_softmax(x);
+        g.set_outputs(vec![sa, ma, sm, lsm]);
+
+        assert_eq!(g.node(sa).ty.shape, vec![1]);
+        assert_eq!(g.node(ma).ty.shape, vec![1]);
+        assert_eq!(g.node(sm).ty.shape, vec![4, 8]);
+        assert_eq!(g.node(lsm).ty.shape, vec![4, 8]);
+    }
+
+    #[test]
+    fn build_cross_entropy_loss() {
+        let mut g = Graph::new();
+        let logits = g.input("logits", &[4, 10]);
+        let labels = g.input("labels", &[4, 10]);
+        let loss = g.cross_entropy_loss(logits, labels);
+        assert_eq!(g.node(loss).ty.shape, vec![1]);
+    }
+
+    #[test]
+    fn build_constant_and_scalar() {
+        let mut g = Graph::new();
+        let c = g.constant(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]);
+        let s = g.scalar(42.0);
+        assert_eq!(g.node(c).ty.shape, vec![2, 2]);
+        assert_eq!(g.node(s).ty.shape, vec![1]);
+        if let Op::Constant { ref data } = g.node(s).op {
+            assert_eq!(data, &[42.0]);
+        } else {
+            panic!("expected Constant");
+        }
+    }
+
+    #[test]
+    fn graph_display() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[2, 3]);
+        let w = g.parameter("w", &[3, 4]);
+        let y = g.matmul(x, w);
+        g.set_outputs(vec![y]);
+        let display = format!("{}", g);
+        assert!(display.contains("%0"));
+        assert!(display.contains("%2"));
+        assert!(display.contains("outputs: %2"));
+    }
+
+    #[test]
+    fn add_raw_node() {
+        let mut g = Graph::new();
+        let id = g.add_raw_node(
+            Op::Input { name: "raw".to_string() },
+            vec![],
+            TensorType::f32(vec![2, 3]),
+        );
+        assert_eq!(id, 0);
+        assert_eq!(g.nodes().len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "matmul inner dimensions must match")]
+    fn matmul_shape_mismatch() {
+        let mut g = Graph::new();
+        let a = g.input("a", &[4, 3]);
+        let b = g.input("b", &[5, 2]); // 5 != 3
+        g.matmul(a, b);
+    }
+
+    #[test]
+    #[should_panic(expected = "add requires matching shapes")]
+    fn add_shape_mismatch() {
+        let mut g = Graph::new();
+        let a = g.input("a", &[4, 3]);
+        let b = g.input("b", &[4, 5]);
+        g.add(a, b);
+    }
+
+    #[test]
+    #[should_panic(expected = "transpose requires 2D tensor")]
+    fn transpose_non_2d() {
+        let mut g = Graph::new();
+        let x = g.add_raw_node(
+            Op::Input { name: "x".to_string() },
+            vec![],
+            TensorType::f32(vec![2, 3, 4]),
+        );
+        g.transpose(x);
+    }
+
+    #[test]
+    #[should_panic(expected = "bias must be 1D")]
+    fn bias_add_wrong_bias_rank() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let b = g.input("b", &[4, 8]); // 2D, not 1D
+        g.bias_add(x, b);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub mod train;
 pub use graph::{DType, Graph, NodeId, TensorType};
 pub use optimize::OptimizeReport;
 pub use runtime::Session;
-pub use train::{build_session, build_session_cached, build_session_with_report, TrainConfig};
+pub use train::{build_session, build_session_cached, build_session_with_report, compile_training_graph, TrainConfig};

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -439,4 +439,131 @@ mod tests {
         let mut egraph = egglog::EGraph::default();
         egraph.parse_and_run_program(None, &program).unwrap();
     }
+
+    #[test]
+    fn test_no_fusion_when_not_applicable() {
+        // Graph with no fusable patterns should pass through unchanged
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let s = g.sigmoid(x); // sigmoid(input) — not fusable
+        g.set_outputs(vec![s]);
+
+        let opt = optimize(&g);
+        let output_id = opt.outputs()[0];
+        assert!(
+            matches!(opt.node(output_id).op, Op::Sigmoid),
+            "sigmoid should remain unfused"
+        );
+    }
+
+    #[test]
+    fn test_optimize_preserves_non_fusable_graph() {
+        let mut g = Graph::new();
+        let a = g.input("a", &[4, 8]);
+        let b = g.input("b", &[4, 8]);
+        let sum = g.add(a, b);
+        let neg = g.neg(sum);
+        g.set_outputs(vec![neg]);
+
+        let opt = optimize(&g);
+        assert_eq!(opt.nodes().len(), g.nodes().len());
+        let out = opt.node(opt.outputs()[0]);
+        assert!(matches!(out.op, Op::Neg));
+    }
+
+    #[test]
+    fn test_optimize_report_no_fusions() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let s = g.sigmoid(x);
+        g.set_outputs(vec![s]);
+
+        let (_opt, report) = optimize_with_report(&g);
+        assert!(report.fusions_applied.is_empty());
+        assert!(report.rules_fired.is_empty());
+        assert_eq!(report.nodes_before, report.nodes_after);
+    }
+
+    #[test]
+    fn test_optimize_deep_chain_multiple_fusions() {
+        // 3-layer MLP: each matmul+relu should fuse independently
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 16]);
+        let w1 = g.parameter("w1", &[16, 8]);
+        let mm1 = g.matmul(x, w1);
+        let h1 = g.relu(mm1);
+        let w2 = g.parameter("w2", &[8, 4]);
+        let mm2 = g.matmul(h1, w2);
+        let h2 = g.relu(mm2);
+        let w3 = g.parameter("w3", &[4, 2]);
+        let mm3 = g.matmul(h2, w3);
+        let h3 = g.relu(mm3);
+        g.set_outputs(vec![h3]);
+
+        let (_opt, report) = optimize_with_report(&g);
+        assert_eq!(report.fusions_applied.len(), 3);
+        assert!(report.fusions_applied.iter().all(|(n, _)| n == "FusedMatMulRelu"));
+    }
+
+    #[test]
+    fn test_dump_egglog_program() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let y = g.matmul(x, w);
+        let h = g.relu(y);
+        g.set_outputs(vec![h]);
+
+        let program = dump_egglog_program(&g);
+        assert!(program.contains("(datatype Op"));
+        assert!(program.contains("(rewrite (Relu (MatMul ?a ?b)) (FusedMatMulRelu ?a ?b))"));
+        assert!(program.contains("(extract n"));
+    }
+
+    #[test]
+    fn test_egglog_all_ops() {
+        // Verify egglog program generation and parsing for all op types
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let _c = g.constant(vec![0.0; 32], &[4, 8]);
+        let mm = g.matmul(x, w);
+        let _a = g.add(mm, mm);
+        let _m = g.mul(mm, mm);
+        let b = g.parameter("b", &[4]);
+        let _ba = g.bias_add(mm, b);
+        let _r = g.relu(mm);
+        let _s = g.sigmoid(mm);
+        let _n = g.neg(mm);
+        let _t = g.transpose(mm);
+        let _sm = g.softmax(mm);
+        let _lsm = g.log_softmax(mm);
+        let sa = g.sum_all(mm);
+        let _ma = g.mean_all(mm);
+        let _gt = g.greater(mm, mm);
+        let _cel = g.cross_entropy_loss(mm, mm);
+        g.set_outputs(vec![sa]);
+
+        let program = graph_to_egglog(&g);
+        let mut egraph = egglog::EGraph::default();
+        egraph.parse_and_run_program(None, &program).unwrap();
+    }
+
+    #[test]
+    fn test_clone_graph_preserves_structure() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let y = g.matmul(x, w);
+        g.set_outputs(vec![y]);
+
+        let cloned = clone_graph(&g);
+        assert_eq!(cloned.nodes().len(), g.nodes().len());
+        assert_eq!(cloned.outputs(), g.outputs());
+        for (a, b) in cloned.nodes().iter().zip(g.nodes().iter()) {
+            assert_eq!(a.id, b.id);
+            assert_eq!(a.inputs, b.inputs);
+            assert_eq!(a.ty.shape, b.ty.shape);
+        }
+    }
 }

--- a/src/train.rs
+++ b/src/train.rs
@@ -71,6 +71,16 @@ pub fn build_session_with_report(forward_graph: &Graph) -> (Session, OptimizeRep
 ///
 /// If the cache exists and the graph hash matches, skip autodiff/optimize/compile.
 /// Otherwise, run the full pipeline and save the result.
+/// Run the full pipeline (autodiff → optimize → compile) without creating a GPU session.
+///
+/// Useful for testing the compilation pipeline in environments without GPU access.
+pub fn compile_training_graph(forward_graph: &Graph) -> (crate::compile::ExecutionPlan, OptimizeReport) {
+    let full_graph = autodiff::differentiate(forward_graph);
+    let (optimized, report) = optimize::optimize_with_report(&full_graph);
+    let plan = compile::compile(&optimized);
+    (plan, report)
+}
+
 pub fn build_session_cached(forward_graph: &Graph, cache_path: &Path) -> Session {
     match cache::load_plan(forward_graph, cache_path) {
         Ok(Some(plan)) => {
@@ -102,4 +112,84 @@ pub fn build_session_cached(forward_graph: &Graph, cache_path: &Path) -> Session
 
     log::info!("{}", report);
     Session::new(plan)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::Graph;
+
+    #[test]
+    fn test_compile_training_graph_simple() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 3]);
+        let w = g.parameter("w", &[3, 2]);
+        let y = g.matmul(x, w);
+        let loss = g.mean_all(y);
+        g.set_outputs(vec![loss]);
+
+        let (plan, report) = compile_training_graph(&g);
+        assert!(!plan.dispatches.is_empty());
+        assert!(plan.loss_buffer.is_some());
+        assert_eq!(plan.param_grad_pairs.len(), 1);
+        assert_eq!(plan.param_buffers.len(), 1);
+        assert_eq!(plan.input_buffers.len(), 1);
+        assert!(report.nodes_before > 0);
+    }
+
+    #[test]
+    fn test_compile_training_graph_mlp() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 784]);
+        let w1 = g.parameter("w1", &[784, 128]);
+        let b1 = g.parameter("b1", &[128]);
+        let mm1 = g.matmul(x, w1);
+        let h1 = g.bias_add(mm1, b1);
+        let a1 = g.relu(h1);
+        let w2 = g.parameter("w2", &[128, 10]);
+        let mm2 = g.matmul(a1, w2);
+        let labels = g.input("labels", &[4, 10]);
+        let loss = g.cross_entropy_loss(mm2, labels);
+        g.set_outputs(vec![loss]);
+
+        let (plan, report) = compile_training_graph(&g);
+        // 3 parameters → 3 grad pairs
+        assert_eq!(plan.param_grad_pairs.len(), 3);
+        assert_eq!(plan.param_buffers.len(), 3);
+        assert_eq!(plan.input_buffers.len(), 2); // x and labels
+        assert!(plan.loss_buffer.is_some());
+        // Should have fusions
+        assert!(!report.fusions_applied.is_empty());
+    }
+
+    #[test]
+    fn test_train_config_default() {
+        let config = TrainConfig::default();
+        assert_eq!(config.learning_rate, 0.01);
+        assert_eq!(config.log_interval, 100);
+    }
+
+    #[test]
+    fn test_compile_and_cache_roundtrip() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 3]);
+        let w = g.parameter("w", &[3, 2]);
+        let y = g.matmul(x, w);
+        let loss = g.mean_all(y);
+        g.set_outputs(vec![loss]);
+
+        let (plan, _) = compile_training_graph(&g);
+
+        let dir = std::env::temp_dir().join("meganeura_test_train_cache");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("train_plan.ron");
+
+        cache::save_plan(&plan, &g, &path).unwrap();
+        let loaded = cache::load_plan(&g, &path).unwrap().unwrap();
+        assert_eq!(loaded.dispatches.len(), plan.dispatches.len());
+        assert_eq!(loaded.buffers.len(), plan.buffers.len());
+        assert_eq!(loaded.param_grad_pairs.len(), plan.param_grad_pairs.len());
+
+        let _ = std::fs::remove_file(&path);
+    }
 }


### PR DESCRIPTION
- graph: all ops, Display, shape validation panics, constants
- autodiff: sigmoid/neg/transpose/mul gradients, multi-path accumulation
- compile: all 15 shader dispatches, workgroups, param-grad pairs, Nop
- optimize: deep chains, no-fusion passthrough, egglog all-ops, clone
- cache: missing file, corrupt file, hash determinism/sensitivity
- train: full pipeline (autodiff→optimize→compile), cache roundtrip

https://claude.ai/code/session_01Y2oLNvquvu1WhJzAnQmigG