### PR TITLE
Add data loading module with MNIST IDX parser and mini-batch DataLoader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 ron = "0.8"
 log = "0.4"
 env_logger = "0.11"
+flate2 = "1"
 
 [[example]]
 name = "mnist"

--- a/examples/mnist.rs
+++ b/examples/mnist.rs
@@ -3,9 +3,15 @@
 /// Demonstrates the full pipeline:
 ///   Graph definition → autodiff → egglog optimization → compile → GPU execution
 ///
-/// This example uses synthetic data since we don't bundle MNIST files.
-/// Replace with real MNIST loading for actual training.
-use meganeura::{Graph, build_session};
+/// If MNIST data files are present in `data/`, loads them automatically.
+/// Otherwise falls back to synthetic data. Download MNIST from:
+///   <https://yann.lecun.com/exdb/mnist/>
+///
+/// Expected files (gzipped or raw):
+///   data/train-images-idx3-ubyte.gz  (or without .gz)
+///   data/train-labels-idx1-ubyte.gz  (or without .gz)
+use meganeura::{DataLoader, Graph, MnistDataset, build_session};
+use std::path::Path;
 
 fn main() {
     env_logger::init();
@@ -15,8 +21,12 @@ fn main() {
     let hidden = 128;
     let classes = 10;
     let epochs = 10;
-    let steps_per_epoch = 100;
     let lr = 0.01_f32;
+
+    // --- Load data ---
+    let mut loader = load_mnist_or_synthetic(batch, input_dim, classes);
+    let steps_per_epoch = loader.num_batches();
+    println!("{} samples, {} batches/epoch", loader.len(), steps_per_epoch);
 
     // --- Build the model graph ---
     let mut g = Graph::new();
@@ -69,12 +79,13 @@ fn main() {
     // --- Training loop ---
     println!("training...");
     for epoch in 0..epochs {
+        loader.shuffle(epoch as u64);
+        loader.reset();
         let mut total_loss = 0.0_f32;
-        for step in 0..steps_per_epoch {
-            // Generate synthetic batch
-            let (images, targets) = synthetic_batch(batch, input_dim, classes);
-            session.set_input("x", &images);
-            session.set_input("labels", &targets);
+        let mut step = 0;
+        while let Some(batch) = loader.next_batch() {
+            session.set_input("x", batch.data);
+            session.set_input("labels", batch.labels);
 
             // Forward + backward
             session.step();
@@ -89,15 +100,57 @@ fn main() {
             if step % 50 == 0 {
                 println!("  epoch {} step {}: loss = {:.4}", epoch, step, loss_val);
             }
+            step += 1;
         }
         println!(
             "epoch {}: avg_loss = {:.4}",
             epoch,
-            total_loss / steps_per_epoch as f32
+            total_loss / step as f32
         );
     }
 
     println!("done!");
+}
+
+fn load_mnist_or_synthetic(batch: usize, input_dim: usize, classes: usize) -> DataLoader {
+    let data_dir = Path::new("data");
+
+    // Try gzipped files first, then raw
+    let gz_images = data_dir.join("train-images-idx3-ubyte.gz");
+    let gz_labels = data_dir.join("train-labels-idx1-ubyte.gz");
+    let raw_images = data_dir.join("train-images-idx3-ubyte");
+    let raw_labels = data_dir.join("train-labels-idx1-ubyte");
+
+    if gz_images.exists() && gz_labels.exists() {
+        println!("loading MNIST from {} (gzipped)...", data_dir.display());
+        let mnist = MnistDataset::load_gz(&gz_images, &gz_labels)
+            .expect("failed to parse MNIST gz files");
+        println!("loaded {} MNIST images", mnist.n);
+        return mnist.loader(batch);
+    }
+
+    if raw_images.exists() && raw_labels.exists() {
+        println!("loading MNIST from {} (raw)...", data_dir.display());
+        let mnist = MnistDataset::load(&raw_images, &raw_labels)
+            .expect("failed to parse MNIST files");
+        println!("loaded {} MNIST images", mnist.n);
+        return mnist.loader(batch);
+    }
+
+    println!("MNIST not found in data/, using synthetic data");
+    let n = 3200; // enough for 100 batches of 32
+    synthetic_loader(n, input_dim, classes, batch)
+}
+
+fn synthetic_loader(n: usize, input_dim: usize, classes: usize, batch: usize) -> DataLoader {
+    let images: Vec<f32> = (0..n * input_dim)
+        .map(|i| ((i % 256) as f32) / 255.0)
+        .collect();
+    let mut labels = vec![0.0_f32; n * classes];
+    for b in 0..n {
+        labels[b * classes + (b % classes)] = 1.0;
+    }
+    DataLoader::new(images, labels, input_dim, classes, batch)
 }
 
 fn xavier_init(fan_in: usize, fan_out: usize) -> Vec<f32> {
@@ -111,18 +164,4 @@ fn xavier_init(fan_in: usize, fan_out: usize) -> Vec<f32> {
             (x * PI * 2.0).sin() * scale
         })
         .collect()
-}
-
-fn synthetic_batch(batch: usize, input_dim: usize, classes: usize) -> (Vec<f32>, Vec<f32>) {
-    let images: Vec<f32> = (0..batch * input_dim)
-        .map(|i| ((i % 256) as f32) / 255.0)
-        .collect();
-
-    // One-hot labels
-    let mut labels = vec![0.0_f32; batch * classes];
-    for b in 0..batch {
-        labels[b * classes + (b % classes)] = 1.0;
-    }
-
-    (images, labels)
 }

--- a/src/data/mnist.rs
+++ b/src/data/mnist.rs
@@ -1,0 +1,232 @@
+//! MNIST IDX file format parser.
+//!
+//! Supports both raw and gzip-compressed files.
+
+use super::DataLoader;
+use std::io::{self, Read};
+use std::path::Path;
+
+/// MNIST dataset loaded into memory.
+///
+/// Images are flattened to `[N, 784]` as `f32` in `[0, 1]`.
+/// Labels are one-hot encoded to `[N, 10]`.
+pub struct MnistDataset {
+    /// Flattened image data, shape `[n, 784]`, values in `[0, 1]`.
+    pub images: Vec<f32>,
+    /// One-hot label data, shape `[n, 10]`.
+    pub labels: Vec<f32>,
+    /// Number of samples.
+    pub n: usize,
+}
+
+impl MnistDataset {
+    /// Load MNIST from the standard IDX files.
+    ///
+    /// * `images_path` – path to `train-images-idx3-ubyte` (or `t10k-…`).
+    /// * `labels_path` – path to `train-labels-idx1-ubyte` (or `t10k-…`).
+    pub fn load(images_path: &Path, labels_path: &Path) -> io::Result<Self> {
+        let images_raw = std::fs::read(images_path)?;
+        let labels_raw = std::fs::read(labels_path)?;
+        Self::from_buffers(&images_raw, &labels_raw)
+    }
+
+    /// Load gzip-compressed IDX files (the common download format).
+    pub fn load_gz(images_path: &Path, labels_path: &Path) -> io::Result<Self> {
+        let images_raw = read_gz(images_path)?;
+        let labels_raw = read_gz(labels_path)?;
+        Self::from_buffers(&images_raw, &labels_raw)
+    }
+
+    fn from_buffers(images_raw: &[u8], labels_raw: &[u8]) -> io::Result<Self> {
+        let images = parse_idx_images(images_raw)?;
+        let labels = parse_idx_labels(labels_raw)?;
+
+        if images.n != labels.n {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "image count ({}) != label count ({})",
+                    images.n, labels.n
+                ),
+            ));
+        }
+
+        Ok(Self {
+            images: images.data,
+            labels: labels.data,
+            n: images.n,
+        })
+    }
+
+    /// Create a [`DataLoader`] from this dataset.
+    pub fn loader(self, batch_size: usize) -> DataLoader {
+        DataLoader::new(self.images, self.labels, 784, 10, batch_size)
+    }
+}
+
+fn read_gz(path: &Path) -> io::Result<Vec<u8>> {
+    let file = std::fs::File::open(path)?;
+    let mut decoder = flate2::read::GzDecoder::new(file);
+    let mut buf = Vec::new();
+    decoder.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+struct ParsedImages {
+    data: Vec<f32>,
+    n: usize,
+}
+
+struct ParsedLabels {
+    data: Vec<f32>,
+    n: usize,
+}
+
+fn read_u32_be(buf: &[u8], offset: usize) -> u32 {
+    u32::from_be_bytes([
+        buf[offset],
+        buf[offset + 1],
+        buf[offset + 2],
+        buf[offset + 3],
+    ])
+}
+
+fn parse_idx_images(buf: &[u8]) -> io::Result<ParsedImages> {
+    if buf.len() < 16 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "IDX image file too short",
+        ));
+    }
+    let magic = read_u32_be(buf, 0);
+    if magic != 0x00000803 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "bad IDX image magic: 0x{:08x}, expected 0x00000803",
+                magic
+            ),
+        ));
+    }
+    let n = read_u32_be(buf, 4) as usize;
+    let rows = read_u32_be(buf, 8) as usize;
+    let cols = read_u32_be(buf, 12) as usize;
+    let pixels = rows * cols; // 784 for MNIST
+    let expected = 16 + n * pixels;
+    if buf.len() < expected {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "IDX image file truncated: need {} bytes, got {}",
+                expected,
+                buf.len()
+            ),
+        ));
+    }
+    let data: Vec<f32> = buf[16..16 + n * pixels]
+        .iter()
+        .map(|&b| b as f32 / 255.0)
+        .collect();
+    Ok(ParsedImages { data, n })
+}
+
+fn parse_idx_labels(buf: &[u8]) -> io::Result<ParsedLabels> {
+    if buf.len() < 8 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "IDX label file too short",
+        ));
+    }
+    let magic = read_u32_be(buf, 0);
+    if magic != 0x00000801 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "bad IDX label magic: 0x{:08x}, expected 0x00000801",
+                magic
+            ),
+        ));
+    }
+    let n = read_u32_be(buf, 4) as usize;
+    let expected = 8 + n;
+    if buf.len() < expected {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "IDX label file truncated: need {} bytes, got {}",
+                expected,
+                buf.len()
+            ),
+        ));
+    }
+    // One-hot encode to 10 classes
+    let mut data = vec![0.0_f32; n * 10];
+    for i in 0..n {
+        let label = buf[8 + i] as usize;
+        if label >= 10 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("label {} out of range at index {}", label, i),
+            ));
+        }
+        data[i * 10 + label] = 1.0;
+    }
+    Ok(ParsedLabels { data, n })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_idx_images() {
+        // Construct a minimal IDX image file: 2 images of 2x2 pixels
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0x00000803_u32.to_be_bytes()); // magic
+        buf.extend_from_slice(&2_u32.to_be_bytes()); // n
+        buf.extend_from_slice(&2_u32.to_be_bytes()); // rows
+        buf.extend_from_slice(&2_u32.to_be_bytes()); // cols
+        buf.extend_from_slice(&[0, 128, 255, 64, 32, 96, 192, 160]); // pixel data
+
+        let parsed = parse_idx_images(&buf).unwrap();
+        assert_eq!(parsed.n, 2);
+        assert_eq!(parsed.data.len(), 8); // 2 * 2 * 2
+        assert_eq!(parsed.data[0], 0.0);
+        assert!((parsed.data[1] - 128.0 / 255.0).abs() < 1e-6);
+        assert!((parsed.data[2] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_parse_idx_labels() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0x00000801_u32.to_be_bytes()); // magic
+        buf.extend_from_slice(&3_u32.to_be_bytes()); // n
+        buf.extend_from_slice(&[7, 2, 0]); // labels
+
+        let parsed = parse_idx_labels(&buf).unwrap();
+        assert_eq!(parsed.n, 3);
+        assert_eq!(parsed.data.len(), 30); // 3 * 10
+        // Sample 0: label=7
+        assert_eq!(parsed.data[7], 1.0);
+        assert_eq!(parsed.data[0], 0.0);
+        // Sample 1: label=2
+        assert_eq!(parsed.data[10 + 2], 1.0);
+        // Sample 2: label=0
+        assert_eq!(parsed.data[20], 1.0);
+    }
+
+    #[test]
+    fn test_parse_idx_bad_magic() {
+        let buf = [0, 0, 0, 0, 0, 0, 0, 1, 0];
+        assert!(parse_idx_labels(&buf).is_err());
+    }
+
+    #[test]
+    fn test_parse_idx_truncated() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0x00000801_u32.to_be_bytes());
+        buf.extend_from_slice(&100_u32.to_be_bytes()); // claims 100 labels
+        buf.extend_from_slice(&[0, 1]); // only 2 bytes of data
+        assert!(parse_idx_labels(&buf).is_err());
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,0 +1,212 @@
+//! Data loading utilities for training.
+//!
+//! Provides a [`DataLoader`] that yields mini-batches from an in-memory
+//! dataset, and an [`MnistDataset`] that reads the standard IDX file format.
+
+pub mod mnist;
+
+pub use mnist::MnistDataset;
+
+/// A single batch of input data and labels.
+pub struct Batch<'a> {
+    pub data: &'a [f32],
+    pub labels: &'a [f32],
+}
+
+/// Iterates over a dataset in mini-batches, with optional shuffling.
+///
+/// Data is stored as flat `f32` slices in row-major order. Each sample
+/// occupies `sample_size` contiguous elements in `data` and `label_size`
+/// elements in `labels`.
+pub struct DataLoader {
+    data: Vec<f32>,
+    labels: Vec<f32>,
+    sample_size: usize,
+    label_size: usize,
+    batch_size: usize,
+    /// Permutation of sample indices (shuffled each epoch).
+    indices: Vec<usize>,
+    pos: usize,
+    /// Scratch buffers for gathering shuffled batches.
+    batch_data: Vec<f32>,
+    batch_labels: Vec<f32>,
+}
+
+impl DataLoader {
+    /// Create a loader from pre-loaded flat arrays.
+    ///
+    /// * `data` – all samples concatenated, length must be `n * sample_size`.
+    /// * `labels` – all labels concatenated, length must be `n * label_size`.
+    /// * `batch_size` – number of samples per batch.
+    pub fn new(
+        data: Vec<f32>,
+        labels: Vec<f32>,
+        sample_size: usize,
+        label_size: usize,
+        batch_size: usize,
+    ) -> Self {
+        let n = data.len() / sample_size;
+        assert_eq!(
+            data.len(),
+            n * sample_size,
+            "data length not divisible by sample_size"
+        );
+        assert_eq!(
+            labels.len(),
+            n * label_size,
+            "labels length not divisible by label_size"
+        );
+        assert!(
+            n >= batch_size,
+            "dataset ({n} samples) smaller than batch_size ({batch_size})"
+        );
+        let indices: Vec<usize> = (0..n).collect();
+        Self {
+            data,
+            labels,
+            sample_size,
+            label_size,
+            batch_size,
+            indices,
+            pos: 0,
+            batch_data: vec![0.0; batch_size * sample_size],
+            batch_labels: vec![0.0; batch_size * label_size],
+        }
+    }
+
+    /// Number of samples in the dataset.
+    pub fn len(&self) -> usize {
+        self.indices.len()
+    }
+
+    /// Whether the dataset is empty.
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+
+    /// Number of complete batches per epoch.
+    pub fn num_batches(&self) -> usize {
+        self.len() / self.batch_size
+    }
+
+    /// Shuffle sample order using a simple LCG seeded with `seed`.
+    pub fn shuffle(&mut self, seed: u64) {
+        // Fisher-Yates shuffle with a lightweight LCG PRNG.
+        let n = self.indices.len();
+        let mut state = seed.wrapping_add(1);
+        for i in (1..n).rev() {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let j = (state >> 33) as usize % (i + 1);
+            self.indices.swap(i, j);
+        }
+    }
+
+    /// Reset the iterator to the beginning (without shuffling).
+    pub fn reset(&mut self) {
+        self.pos = 0;
+    }
+
+    /// Return the next mini-batch, or `None` if the epoch is exhausted.
+    ///
+    /// The returned slices borrow internal scratch buffers and are valid
+    /// until the next call to `next_batch`, `shuffle`, or `reset`.
+    pub fn next_batch(&mut self) -> Option<Batch<'_>> {
+        let remaining = self.len() - self.pos;
+        if remaining < self.batch_size {
+            return None;
+        }
+        // Gather samples according to the current permutation.
+        for b in 0..self.batch_size {
+            let idx = self.indices[self.pos + b];
+            let src = idx * self.sample_size..(idx + 1) * self.sample_size;
+            let dst = b * self.sample_size..(b + 1) * self.sample_size;
+            self.batch_data[dst].copy_from_slice(&self.data[src]);
+
+            let lsrc = idx * self.label_size..(idx + 1) * self.label_size;
+            let ldst = b * self.label_size..(b + 1) * self.label_size;
+            self.batch_labels[ldst].copy_from_slice(&self.labels[lsrc]);
+        }
+        self.pos += self.batch_size;
+        Some(Batch {
+            data: &self.batch_data,
+            labels: &self.batch_labels,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dataloader_basic() {
+        // 8 samples, sample_size=3, label_size=2, batch_size=4
+        let data: Vec<f32> = (0..24).map(|i| i as f32).collect();
+        let labels: Vec<f32> = (0..16).map(|i| i as f32 * 0.1).collect();
+        let mut loader = DataLoader::new(data, labels, 3, 2, 4);
+
+        assert_eq!(loader.len(), 8);
+        assert_eq!(loader.num_batches(), 2);
+
+        let b1 = loader.next_batch().unwrap();
+        assert_eq!(b1.data.len(), 12); // 4 * 3
+        assert_eq!(b1.labels.len(), 8); // 4 * 2
+        // First batch should be samples 0..4 in order (no shuffle)
+        assert_eq!(b1.data[0], 0.0);
+        assert_eq!(b1.data[3], 3.0); // start of sample 1
+
+        let b2 = loader.next_batch().unwrap();
+        assert_eq!(b2.data[0], 12.0); // start of sample 4
+
+        // Epoch exhausted
+        assert!(loader.next_batch().is_none());
+    }
+
+    #[test]
+    fn test_dataloader_reset() {
+        let data: Vec<f32> = (0..12).map(|i| i as f32).collect();
+        let labels: Vec<f32> = (0..8).map(|i| i as f32).collect();
+        let mut loader = DataLoader::new(data, labels, 3, 2, 2);
+
+        let _ = loader.next_batch();
+        loader.reset();
+        let b = loader.next_batch().unwrap();
+        assert_eq!(b.data[0], 0.0); // back to start
+    }
+
+    #[test]
+    fn test_dataloader_shuffle() {
+        let data: Vec<f32> = (0..30).map(|i| i as f32).collect();
+        let labels: Vec<f32> = (0..10).map(|i| i as f32).collect();
+        let mut loader = DataLoader::new(data, labels, 3, 1, 5);
+
+        loader.shuffle(42);
+        let b = loader.next_batch().unwrap();
+        // Just check the batch is valid — 5 samples of size 3
+        assert_eq!(b.data.len(), 15);
+        assert_eq!(b.labels.len(), 5);
+    }
+
+    #[test]
+    fn test_dataloader_partial_last_batch_dropped() {
+        // 5 samples, batch_size=2 → 2 full batches, last sample dropped
+        let data: Vec<f32> = vec![0.0; 10];
+        let labels: Vec<f32> = vec![0.0; 5];
+        let mut loader = DataLoader::new(data, labels, 2, 1, 2);
+
+        assert_eq!(loader.num_batches(), 2);
+        assert!(loader.next_batch().is_some());
+        assert!(loader.next_batch().is_some());
+        assert!(loader.next_batch().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "dataset")]
+    fn test_dataloader_too_small() {
+        let data = vec![0.0; 6]; // 2 samples
+        let labels = vec![0.0; 2];
+        DataLoader::new(data, labels, 3, 1, 5); // batch_size > n
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,13 @@ pub mod autodiff;
 pub mod cache;
 pub mod codegen;
 pub mod compile;
+pub mod data;
 pub mod graph;
 pub mod optimize;
 pub mod runtime;
 pub mod train;
 
+pub use data::{DataLoader, MnistDataset};
 pub use graph::{DType, Graph, NodeId, TensorType};
 pub use optimize::OptimizeReport;
 pub use runtime::Session;


### PR DESCRIPTION
- DataLoader: shuffled mini-batch iteration over in-memory datasets
- data/mnist: parses IDX image/label files (raw or gzip-compressed)
- One-hot label encoding, [0,1] pixel normalization
- Update MNIST example to auto-detect data/ files with synthetic fallback
- 9 new tests for batching, shuffling, IDX parsing, error handling

https://claude.ai/code/session_01Y2oLNvquvu1WhJzAnQmigG