### PR TITLE
Add HuggingFace model loading and inference support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: GPU smoke test (lavapipe)
         run: cargo test --test gpu_smoke
+
+      - name: Cache + inference roundtrip test (lavapipe)
+        run: cargo test --test cache_inference

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+data/mnist-mlp.safetensors
+data/*.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ ron = "0.8"
 log = "0.4"
 env_logger = "0.11"
 flate2 = "1"
+safetensors = "0.4"
+hf-hub = { version = "0.4", default-features = false, features = ["ureq", "native-tls"] }
 
 [[example]]
 name = "mnist"
@@ -29,3 +31,7 @@ path = "examples/mnist.rs"
 [[example]]
 name = "diffusion"
 path = "examples/diffusion.rs"
+
+[[example]]
+name = "huggingface"
+path = "examples/huggingface.rs"

--- a/examples/huggingface.rs
+++ b/examples/huggingface.rs
@@ -1,0 +1,183 @@
+/// Load a pre-trained MNIST MLP from HuggingFace and run inference.
+///
+/// Downloads `dacorvo/mnist-mlp` — a 3-layer MLP (784→256→256→10)
+/// trained on MNIST — from the HuggingFace Hub, loads the safetensors
+/// weights into a meganeura graph, and classifies real MNIST test images.
+///
+/// The model expects flattened 28×28 images normalized with
+/// mean=0.1307, std=0.3081.
+///
+/// Usage:
+///   cargo run --example huggingface [model.safetensors]
+///
+/// MNIST test data is expected in `data/` (gzipped or raw):
+///   data/t10k-images-idx3-ubyte.gz
+///   data/t10k-labels-idx1-ubyte.gz
+use meganeura::data::huggingface::HfModel;
+use meganeura::{Graph, MnistDataset, build_inference_session};
+use std::path::{Path, PathBuf};
+
+fn main() {
+    env_logger::init();
+
+    let batch = 1;
+    let input_dim = 784;
+    let hidden = 256;
+    let classes = 10;
+
+    // --- Load model: CLI path or download from HuggingFace ---
+    let hf = if let Some(path) = std::env::args().nth(1) {
+        println!("loading model from {}...", path);
+        HfModel::load(PathBuf::from(path)).expect("failed to load model")
+    } else {
+        println!("downloading dacorvo/mnist-mlp from HuggingFace Hub...");
+        HfModel::download("dacorvo/mnist-mlp").expect("failed to download model")
+    };
+
+    // Print tensor info
+    println!("model tensors:");
+    let mut names: Vec<_> = hf.tensor_info().keys().collect();
+    names.sort();
+    for name in &names {
+        let info = &hf.tensor_info()[*name];
+        println!("  {}: shape={:?} dtype={:?}", name, info.shape, info.dtype);
+    }
+
+    // --- Build the inference graph ---
+    // Architecture: Linear(784,256)+ReLU → Linear(256,256)+ReLU → Linear(256,10)+Softmax
+    let mut g = Graph::new();
+
+    let x = g.input("x", &[batch, input_dim]);
+
+    // Layer 1: input_layer
+    let w1 = g.parameter("input_layer.weight", &[input_dim, hidden]);
+    let b1 = g.parameter("input_layer.bias", &[hidden]);
+    let h1 = g.matmul(x, w1);
+    let h1 = g.bias_add(h1, b1);
+    let h1 = g.relu(h1);
+
+    // Layer 2: mid_layer
+    let w2 = g.parameter("mid_layer.weight", &[hidden, hidden]);
+    let b2 = g.parameter("mid_layer.bias", &[hidden]);
+    let h2 = g.matmul(h1, w2);
+    let h2 = g.bias_add(h2, b2);
+    let h2 = g.relu(h2);
+
+    // Layer 3: output_layer + softmax
+    let w3 = g.parameter("output_layer.weight", &[hidden, classes]);
+    let b3 = g.parameter("output_layer.bias", &[classes]);
+    let logits = g.matmul(h2, w3);
+    let logits = g.bias_add(logits, b3);
+    let probs = g.softmax(logits);
+
+    g.set_outputs(vec![probs]);
+
+    // --- Build inference session ---
+    println!("compiling inference session...");
+    let mut session = build_inference_session(&g);
+    println!(
+        "session ready: {} buffers, {} dispatches",
+        session.plan().buffers.len(),
+        session.plan().dispatches.len()
+    );
+
+    // --- Load weights from safetensors ---
+    // PyTorch Linear stores weights as (out_features, in_features),
+    // meganeura matmul expects (in_features, out_features) → transpose.
+    println!("loading weights...");
+    for name in ["input_layer.weight", "mid_layer.weight", "output_layer.weight"] {
+        let data = hf
+            .tensor_f32_transposed(name)
+            .unwrap_or_else(|e| panic!("failed to load {}: {}", name, e));
+        session.set_parameter(name, &data);
+    }
+    for name in ["input_layer.bias", "mid_layer.bias", "output_layer.bias"] {
+        let data = hf
+            .tensor_f32(name)
+            .unwrap_or_else(|e| panic!("failed to load {}: {}", name, e));
+        session.set_parameter(name, &data);
+    }
+    println!("weights loaded.");
+
+    // --- Load MNIST test data ---
+    let data_dir = Path::new("data");
+    let mnist = load_mnist_test(data_dir);
+    println!("loaded {} MNIST test images", mnist.n);
+
+    // --- Run inference on all test images ---
+    let mut correct = 0usize;
+    let mut total = 0usize;
+
+    for i in 0..mnist.n {
+        // Extract and normalize one image: (pixel - 0.1307) / 0.3081
+        let raw = &mnist.images[i * 784..(i + 1) * 784];
+        let image: Vec<f32> = raw.iter().map(|&v| (v - 0.1307) / 0.3081).collect();
+
+        // True label (argmax of one-hot)
+        let label_slice = &mnist.labels[i * 10..(i + 1) * 10];
+        let true_label = label_slice
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .unwrap()
+            .0;
+
+        session.set_input("x", &image);
+        session.step();
+        session.wait();
+
+        let probs = session.read_output(classes);
+        let predicted = probs
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .unwrap()
+            .0;
+
+        if predicted == true_label {
+            correct += 1;
+        }
+        total += 1;
+
+        // Show first 10 predictions in detail
+        if i < 10 {
+            println!(
+                "  sample {:>5}: true={}, predicted={}, confidence={:.1}% {}",
+                i,
+                true_label,
+                predicted,
+                probs[predicted] * 100.0,
+                if predicted == true_label { "OK" } else { "WRONG" }
+            );
+        }
+    }
+
+    let accuracy = correct as f64 / total as f64 * 100.0;
+    println!(
+        "\naccuracy: {}/{} ({:.2}%)",
+        correct, total, accuracy
+    );
+}
+
+fn load_mnist_test(data_dir: &Path) -> MnistDataset {
+    let gz_images = data_dir.join("t10k-images-idx3-ubyte.gz");
+    let gz_labels = data_dir.join("t10k-labels-idx1-ubyte.gz");
+    let raw_images = data_dir.join("t10k-images-idx3-ubyte");
+    let raw_labels = data_dir.join("t10k-labels-idx1-ubyte");
+
+    if gz_images.exists() && gz_labels.exists() {
+        return MnistDataset::load_gz(&gz_images, &gz_labels)
+            .expect("failed to parse MNIST gz files");
+    }
+    if raw_images.exists() && raw_labels.exists() {
+        return MnistDataset::load(&raw_images, &raw_labels)
+            .expect("failed to parse MNIST files");
+    }
+    panic!(
+        "MNIST test data not found in {}.\n\
+         Download from https://yann.lecun.com/exdb/mnist/ :\n  \
+         t10k-images-idx3-ubyte.gz\n  \
+         t10k-labels-idx1-ubyte.gz",
+        data_dir.display()
+    );
+}

--- a/src/data/huggingface.rs
+++ b/src/data/huggingface.rs
@@ -1,0 +1,145 @@
+//! HuggingFace Hub integration for loading pre-trained models.
+//!
+//! Downloads safetensors model weights from the HuggingFace Hub and
+//! provides them as named tensors that can be loaded into a [`Session`].
+//!
+//! # Example
+//!
+//! ```no_run
+//! use meganeura::data::huggingface::HfModel;
+//!
+//! let model = HfModel::download("dacorvo/mnist-mlp").unwrap();
+//! for (name, info) in model.tensor_info() {
+//!     println!("{}: shape={:?}", name, info.shape);
+//! }
+//! let data = model.tensor_f32("input_layer.weight").unwrap();
+//! ```
+
+use safetensors::SafeTensors;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Information about a tensor in a safetensors file.
+#[derive(Debug, Clone)]
+pub struct TensorInfo {
+    pub shape: Vec<usize>,
+    pub dtype: safetensors::Dtype,
+}
+
+/// A downloaded HuggingFace model with parsed safetensors weights.
+pub struct HfModel {
+    /// Raw bytes of the safetensors file (kept alive for zero-copy access).
+    data: Vec<u8>,
+    /// Cached tensor metadata.
+    info: HashMap<String, TensorInfo>,
+}
+
+impl HfModel {
+    /// Download a model from HuggingFace Hub by repository ID.
+    ///
+    /// Downloads `model.safetensors` from the given repo (e.g. `"dacorvo/mnist-mlp"`).
+    pub fn download(repo_id: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::download_file(repo_id, "model.safetensors")
+    }
+
+    /// Download a specific safetensors file from a HuggingFace Hub repo.
+    pub fn download_file(
+        repo_id: &str,
+        filename: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        log::info!("downloading {}/{} from HuggingFace Hub...", repo_id, filename);
+        let api = hf_hub::api::sync::Api::new()?;
+        let repo = api.model(repo_id.to_string());
+        let path = repo.get(filename)?;
+        log::info!("cached at: {}", path.display());
+        Self::load(path)
+    }
+
+    /// Load a model from a local safetensors file.
+    pub fn load(path: PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
+        let data = std::fs::read(&path)?;
+        let tensors = SafeTensors::deserialize(&data)?;
+
+        let mut info = HashMap::new();
+        for (name, view) in tensors.iter() {
+            info.insert(
+                name.to_string(),
+                TensorInfo {
+                    shape: view.shape().to_vec(),
+                    dtype: view.dtype(),
+                },
+            );
+        }
+
+        log::info!("loaded {} tensors from {}", info.len(), path.display());
+        Ok(Self { data, info })
+    }
+
+    /// List all tensor names and their metadata.
+    pub fn tensor_info(&self) -> &HashMap<String, TensorInfo> {
+        &self.info
+    }
+
+    /// Read a tensor as f32 data.
+    ///
+    /// For F32 tensors this is a direct reinterpretation. Other dtypes
+    /// are not currently supported and will return an error.
+    pub fn tensor_f32(&self, name: &str) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+        let tensors = SafeTensors::deserialize(&self.data)?;
+        let view = tensors
+            .tensor(name)
+            .map_err(|e| format!("tensor '{}': {}", name, e))?;
+
+        if view.dtype() != safetensors::Dtype::F32 {
+            return Err(format!(
+                "tensor '{}' has dtype {:?}, expected F32",
+                name,
+                view.dtype()
+            )
+            .into());
+        }
+
+        let bytes = view.data();
+        // safetensors stores data in little-endian, which matches x86/ARM
+        let floats: Vec<f32> = bytes
+            .chunks_exact(4)
+            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect();
+
+        Ok(floats)
+    }
+
+    /// Read a tensor as f32 and transpose it from (rows, cols) to (cols, rows).
+    ///
+    /// PyTorch Linear layers store weights as (out_features, in_features),
+    /// but meganeura's matmul expects (in_features, out_features).
+    pub fn tensor_f32_transposed(
+        &self,
+        name: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+        let info = self
+            .info
+            .get(name)
+            .ok_or_else(|| format!("tensor '{}' not found", name))?;
+
+        if info.shape.len() != 2 {
+            return Err(format!(
+                "tensor '{}' has {} dims, expected 2 for transpose",
+                name,
+                info.shape.len()
+            )
+            .into());
+        }
+
+        let data = self.tensor_f32(name)?;
+        let rows = info.shape[0];
+        let cols = info.shape[1];
+        let mut transposed = vec![0.0_f32; rows * cols];
+        for r in 0..rows {
+            for c in 0..cols {
+                transposed[c * rows + r] = data[r * cols + c];
+            }
+        }
+        Ok(transposed)
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -3,6 +3,7 @@
 //! Provides a [`DataLoader`] that yields mini-batches from an in-memory
 //! dataset, and an [`MnistDataset`] that reads the standard IDX file format.
 
+pub mod huggingface;
 pub mod mnist;
 
 pub use mnist::MnistDataset;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,6 @@ pub use graph::{DType, Graph, NodeId, TensorType};
 pub use optimize::OptimizeReport;
 pub use runtime::Session;
 pub use train::{
-    EpochStats, TrainConfig, TrainHistory, Trainer, build_session, build_session_cached,
-    build_session_with_report, compile_training_graph,
+    EpochStats, TrainConfig, TrainHistory, Trainer, build_inference_session, build_session,
+    build_session_cached, build_session_with_report, compile_training_graph,
 };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -315,6 +315,20 @@ impl Session {
         }
     }
 
+    /// Read back the output tensor (first graph output).
+    ///
+    /// Returns the data as a `Vec<f32>`. For inference graphs this is the
+    /// model's prediction; for training graphs it's the loss scalar.
+    pub fn read_output(&self, len: usize) -> Vec<f32> {
+        if let Some(buf_ref) = self.plan.loss_buffer {
+            let mut out = vec![0.0_f32; len];
+            self.read_buffer(buf_ref, &mut out);
+            out
+        } else {
+            Vec::new()
+        }
+    }
+
     /// Read back a buffer's contents.
     pub fn read_buffer(&self, buf_ref: BufferRef, out: &mut [f32]) {
         let buffer = &self.buffers[buf_ref.0 as usize];

--- a/src/train.rs
+++ b/src/train.rs
@@ -135,6 +135,33 @@ impl Trainer {
     }
 }
 
+/// Build an inference-only session from a forward-pass graph.
+///
+/// Skips autodiff (no backward pass). Runs egglog optimization and
+/// compiles the graph to a GPU session ready for forward evaluation.
+pub fn build_inference_session(forward_graph: &Graph) -> Session {
+    log::info!("building inference session...");
+    log::info!("forward graph:\n{}", forward_graph);
+
+    // Optimize with egglog (fusions still help for inference)
+    log::info!("running egglog optimization...");
+    let optimized = optimize::optimize(forward_graph);
+    log::info!("optimized graph: {} nodes", optimized.nodes().len());
+
+    // Compile to execution plan
+    log::info!("compiling execution plan...");
+    let plan = compile::compile(&optimized);
+    log::info!(
+        "execution plan: {} buffers, {} dispatches",
+        plan.buffers.len(),
+        plan.dispatches.len()
+    );
+
+    // Create GPU session
+    log::info!("initializing GPU session...");
+    Session::new(plan)
+}
+
 /// Build a complete training session from a forward-pass graph.
 ///
 /// This is the main entry point. It:

--- a/tests/cache_inference.rs
+++ b/tests/cache_inference.rs
@@ -1,0 +1,100 @@
+/// Test that an optimized execution plan can be saved to disk, reloaded,
+/// and produce identical inference results.
+///
+/// Pipeline: build graph → optimize → compile → save plan →
+///           load plan → verify structure → infer from loaded plan.
+use meganeura::compile::ExecutionPlan;
+use meganeura::runtime::Session;
+use meganeura::{Graph, cache, compile, optimize};
+
+fn build_graph() -> Graph {
+    let batch = 2;
+    let mut g = Graph::new();
+    let x = g.input("x", &[batch, 8]);
+    let w1 = g.parameter("w1", &[8, 5]);
+    let b1 = g.parameter("b1", &[5]);
+    let mm1 = g.matmul(x, w1);
+    let h1 = g.bias_add(mm1, b1);
+    let a1 = g.relu(h1);
+    let w2 = g.parameter("w2", &[5, 3]);
+    let b2 = g.parameter("b2", &[3]);
+    let mm2 = g.matmul(a1, w2);
+    let out = g.bias_add(mm2, b2);
+    g.set_outputs(vec![out]);
+    g
+}
+
+fn optimize_and_compile(g: &Graph) -> ExecutionPlan {
+    let optimized = optimize::optimize(g);
+    compile::compile(&optimized)
+}
+
+#[test]
+fn cache_roundtrip_preserves_plan() {
+    let g = build_graph();
+    let plan = optimize_and_compile(&g);
+
+    // Save plan to disk
+    let dir = std::env::temp_dir().join("meganeura_test_cache_inference");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("inference_plan.ron");
+    cache::save_plan(&plan, &g, &path).unwrap();
+
+    // Load it back
+    let loaded = cache::load_plan(&g, &path).unwrap().expect("cache should hit");
+
+    // Every field must match
+    assert_eq!(plan.buffers, loaded.buffers, "buffer sizes");
+    assert_eq!(plan.param_buffers, loaded.param_buffers, "param_buffers");
+    assert_eq!(plan.input_buffers, loaded.input_buffers, "input_buffers");
+    assert_eq!(plan.loss_buffer, loaded.loss_buffer, "loss_buffer");
+    assert_eq!(plan.param_grad_pairs, loaded.param_grad_pairs, "param_grad_pairs");
+    assert_eq!(plan.dispatches.len(), loaded.dispatches.len(), "dispatch count");
+    for (i, (a, b)) in plan.dispatches.iter().zip(loaded.dispatches.iter()).enumerate() {
+        assert_eq!(a.shader, b.shader, "dispatch[{}] shader", i);
+        assert_eq!(a.workgroups, b.workgroups, "dispatch[{}] workgroups", i);
+        assert_eq!(a.input_buffers, b.input_buffers, "dispatch[{}] inputs", i);
+        assert_eq!(a.output_buffer, b.output_buffer, "dispatch[{}] output", i);
+        assert_eq!(a.params, b.params, "dispatch[{}] params", i);
+    }
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn infer_from_loaded_plan() {
+    let g = build_graph();
+    let plan = optimize_and_compile(&g);
+
+    // Save and reload
+    let dir = std::env::temp_dir().join("meganeura_test_cache_inference2");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("inference_plan2.ron");
+    cache::save_plan(&plan, &g, &path).unwrap();
+    let loaded = cache::load_plan(&g, &path).unwrap().expect("cache should hit");
+
+    // Build a GPU session from the loaded plan and run inference
+    let mut session = Session::new(loaded);
+
+    session.set_parameter("w1", &vec![0.1_f32; 8 * 5]);
+    session.set_parameter("b1", &vec![0.01_f32; 5]);
+    session.set_parameter("w2", &vec![0.2_f32; 5 * 3]);
+    session.set_parameter("b2", &vec![0.02_f32; 3]);
+
+    let x_data: Vec<f32> = (0..2 * 8).map(|i| (i as f32) * 0.1).collect();
+    session.set_input("x", &x_data);
+
+    session.step();
+    session.wait();
+
+    let output = session.read_output(2 * 3);
+    assert_eq!(output.len(), 6, "expected 2*3 output elements");
+
+    // All outputs should be finite and non-zero (matmul+bias with non-zero weights/input)
+    for (i, &v) in output.iter().enumerate() {
+        assert!(v.is_finite(), "output[{}] = {} is not finite", i, v);
+        assert!(v.abs() > 1e-10, "output[{}] = {} is unexpectedly zero", i, v);
+    }
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
Summary
	∙	Add HfModel struct for downloading and parsing safetensors weights from HuggingFace Hub, with local file fallback
	∙	Add build_inference_session() for forward-only graph compilation (skip autodiff)
	∙	Add Session::read_output() convenience method for reading inference results
	∙	Add huggingface example that downloads dacorvo/mnist-mlp, classifies real MNIST test images, and reports accuracy
	∙	Add cache + inference roundtrip integration test verifying plan serialization fidelity
	∙	Update CI workflow to run the new integration test