### PR TITLE
Diffusion and tracing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ flate2 = "1"
 safetensors = "0.4"
 hf-hub = { version = "0.4", default-features = false, features = ["ureq", "native-tls"] }
 tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [[example]]
 name = "mnist"

--- a/examples/diffusion.rs
+++ b/examples/diffusion.rs
@@ -18,6 +18,12 @@ use std::time::Instant;
 fn main() {
     env_logger::init();
 
+    // Set up Perfetto profiling when MEGANEURA_PROFILE is set.
+    let profiling = std::env::var("MEGANEURA_PROFILE").is_ok();
+    if profiling {
+        meganeura::profiler::init();
+    }
+
     let batch = 64;
     let img_dim = 784; // 28×28 flattened
     let hidden = 256;
@@ -142,6 +148,13 @@ fn main() {
     }
     if let Some(final_loss) = history.final_loss() {
         println!("final loss:      {:.6}", final_loss);
+    }
+
+    // Save Perfetto trace when profiling.
+    if profiling {
+        let path = std::path::Path::new("trace.pftrace");
+        meganeura::profiler::save(path).expect("failed to save profile");
+        println!("profile saved to {}", path.display());
     }
 }
 

--- a/examples/diffusion.rs
+++ b/examples/diffusion.rs
@@ -18,9 +18,9 @@ use std::time::Instant;
 fn main() {
     env_logger::init();
 
-    // Set up Perfetto profiling when MEGANEURA_PROFILE is set.
-    let profiling = std::env::var("MEGANEURA_PROFILE").is_ok();
-    if profiling {
+    // Set up Perfetto profiling: MEGANEURA_TRACE=path.pftrace
+    let trace_path = std::env::var("MEGANEURA_TRACE").ok();
+    if trace_path.is_some() {
         meganeura::profiler::init();
     }
 
@@ -151,8 +151,8 @@ fn main() {
     }
 
     // Save Perfetto trace when profiling.
-    if profiling {
-        let path = std::path::Path::new("trace.pftrace");
+    if let Some(ref trace_file) = trace_path {
+        let path = std::path::Path::new(trace_file);
         meganeura::profiler::save(path).expect("failed to save profile");
         println!("profile saved to {}", path.display());
     }

--- a/examples/huggingface.rs
+++ b/examples/huggingface.rs
@@ -22,6 +22,12 @@ use std::path::{Path, PathBuf};
 fn main() {
     env_logger::init();
 
+    // Set up Perfetto profiling: MEGANEURA_TRACE=path.pftrace
+    let trace_path = std::env::var("MEGANEURA_TRACE").ok();
+    if trace_path.is_some() {
+        meganeura::profiler::init();
+    }
+
     let batch = 1;
     let input_dim = 784;
     let hidden = 256;
@@ -85,7 +91,8 @@ fn main() {
 
     // --- Load weights from safetensors ---
     // PyTorch Linear stores weights as (out_features, in_features),
-    // meganeura matmul expects (in_features, out_features) → transpose.
+    // but meganeura matmul expects (in_features, out_features).
+    // Weight matrices need transposing; biases are loaded as-is.
     println!("loading weights...");
     for name in ["input_layer.weight", "mid_layer.weight", "output_layer.weight"] {
         let data = hf
@@ -107,11 +114,13 @@ fn main() {
     println!("loaded {} MNIST test images", mnist.n);
 
     // --- Run inference on all test images ---
+    // Feed each 28×28 image one at a time (batch=1), applying the same
+    // normalization the model was trained with (MNIST channel statistics).
     let mut correct = 0usize;
     let mut total = 0usize;
 
     for i in 0..mnist.n {
-        // Extract and normalize one image: (pixel - 0.1307) / 0.3081
+        // Normalize with MNIST channel mean / std used during training.
         let raw = &mnist.images[i * 784..(i + 1) * 784];
         let image: Vec<f32> = raw.iter().map(|&v| (v - 0.1307) / 0.3081).collect();
 
@@ -159,6 +168,13 @@ fn main() {
         "\naccuracy: {}/{} ({:.2}%)",
         correct, total, accuracy
     );
+
+    // Save Perfetto trace when profiling.
+    if let Some(ref trace_file) = trace_path {
+        let path = Path::new(trace_file);
+        meganeura::profiler::save(path).expect("failed to save profile");
+        println!("profile saved to {}", path.display());
+    }
 }
 
 fn load_mnist_test(data_dir: &Path) -> MnistDataset {

--- a/examples/mnist.rs
+++ b/examples/mnist.rs
@@ -16,9 +16,9 @@ use std::path::Path;
 fn main() {
     env_logger::init();
 
-    // Set up Perfetto profiling when MEGANEURA_PROFILE is set.
-    let profiling = std::env::var("MEGANEURA_PROFILE").is_ok();
-    if profiling {
+    // Set up Perfetto profiling: MEGANEURA_TRACE=path.pftrace
+    let trace_path = std::env::var("MEGANEURA_TRACE").ok();
+    if trace_path.is_some() {
         meganeura::profiler::init();
     }
 
@@ -99,8 +99,8 @@ fn main() {
     }
 
     // Save Perfetto trace when profiling.
-    if profiling {
-        let path = Path::new("trace.pftrace");
+    if let Some(ref trace_file) = trace_path {
+        let path = Path::new(trace_file);
         meganeura::profiler::save(path).expect("failed to save profile");
         println!("profile saved to {}", path.display());
     }

--- a/examples/mnist.rs
+++ b/examples/mnist.rs
@@ -16,6 +16,12 @@ use std::path::Path;
 fn main() {
     env_logger::init();
 
+    // Set up Perfetto profiling when MEGANEURA_PROFILE is set.
+    let profiling = std::env::var("MEGANEURA_PROFILE").is_ok();
+    if profiling {
+        meganeura::profiler::init();
+    }
+
     let batch = 32;
     let input_dim = 784; // 28x28
     let hidden = 128;
@@ -90,6 +96,13 @@ fn main() {
         println!("done! final avg_loss = {:.4}", final_loss);
     } else {
         println!("done! (no epochs ran)");
+    }
+
+    // Save Perfetto trace when profiling.
+    if profiling {
+        let path = Path::new("trace.pftrace");
+        meganeura::profiler::save(path).expect("failed to save profile");
+        println!("profile saved to {}", path.display());
     }
 }
 

--- a/examples/smollm2.rs
+++ b/examples/smollm2.rs
@@ -16,6 +16,12 @@ const REPO_ID: &str = "HuggingFaceTB/SmolLM2-135M";
 fn main() {
     env_logger::init();
 
+    // Set up Perfetto profiling: MEGANEURA_TRACE=path.pftrace
+    let trace_path = std::env::var("MEGANEURA_TRACE").ok();
+    if trace_path.is_some() {
+        meganeura::profiler::init();
+    }
+
     let prompt = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "The meaning of life is".to_string());
@@ -74,6 +80,8 @@ fn main() {
     );
 
     // --- Load weights ---
+    // HuggingFace Linear layers store weights as (out, in) but meganeura
+    // matmul expects (in, out), so certain tensors need transposing.
     println!("loading weights...");
     let transposed = smollm2::transposed_weight_names(&config);
     let transposed_set: std::collections::HashSet<&str> =
@@ -81,7 +89,9 @@ fn main() {
 
     for (name, _) in session.plan().param_buffers.clone() {
         if name == "lm_head.weight" {
-            // lm_head is often tied to embed_tokens
+            // The language-model head is often weight-tied to the token
+            // embedding table. If a dedicated lm_head tensor exists in the
+            // file we load it; otherwise we reuse embed_tokens transposed.
             if model.tensor_info().contains_key("lm_head.weight") {
                 let data = if transposed_set.contains(name.as_str()) {
                     model.tensor_f32_auto_transposed(&name)
@@ -111,26 +121,29 @@ fn main() {
     }
     println!("weights loaded.");
 
-    // --- Generate tokens ---
+    // --- Generate tokens (greedy, autoregressive) ---
+    // Each step feeds the full sequence (prompt + generated so far,
+    // zero-padded to seq_len) through the model, then picks the
+    // highest-probability next token from the logits at the current
+    // position.
     println!("generating...\n");
 
-    // Pad input_ids to seq_len with 0s
     let mut tokens = vec![0u32; seq_len];
     tokens[..input_ids.len()].copy_from_slice(&input_ids);
 
     let mut generated = input_ids.clone();
 
     for step in 0..max_new_tokens {
-        // Set full token sequence
         session.set_input_u32("token_ids", &tokens);
         session.step();
         session.wait();
 
-        // Read logits: [seq_len, vocab_size]
+        // The model outputs logits shaped [seq_len, vocab_size].
+        // We only care about the position just before the next token
+        // we want to predict (causal: position N-1 predicts token N).
         let vocab = config.vocab_size;
         let all_logits = session.read_output(seq_len * vocab);
 
-        // Get logits for the current position (last non-padding token)
         let cur_pos = input_ids.len() + step;
         let pos_logits = &all_logits[(cur_pos - 1) * vocab..cur_pos * vocab];
 
@@ -158,4 +171,11 @@ fn main() {
         .decode(&generated, true)
         .unwrap_or_else(|_| "decode error".to_string());
     println!("\n--- Full output ---\n{}", full_text);
+
+    // Save Perfetto trace when profiling.
+    if let Some(ref trace_file) = trace_path {
+        let path = std::path::Path::new(trace_file);
+        meganeura::profiler::save(path).expect("failed to save profile");
+        println!("profile saved to {}", path.display());
+    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,10 +1,11 @@
-use crate::compile::ExecutionPlan;
-use crate::graph::Graph;
+use crate::{compile::ExecutionPlan, graph::Graph};
 use serde::{Deserialize, Serialize};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::io;
-use std::path::Path;
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    io,
+    path::Path,
+};
 
 /// Cached execution plan with a graph fingerprint for invalidation.
 #[derive(Serialize, Deserialize)]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -51,28 +51,6 @@ impl ShaderEntry {
         }
     }
 
-    /// Human-readable name for this shader, used in profiling traces.
-    pub fn name(&self) -> &'static str {
-        match *self {
-            ShaderEntry::MatMul => "matmul",
-            ShaderEntry::MatMulRelu => "matmul_relu",
-            ShaderEntry::MatMulBiasRelu => "matmul_bias_relu",
-            ShaderEntry::Relu => "relu",
-            ShaderEntry::Sigmoid => "sigmoid",
-            ShaderEntry::Neg => "neg",
-            ShaderEntry::Add => "add",
-            ShaderEntry::Mul => "mul",
-            ShaderEntry::Greater => "greater",
-            ShaderEntry::BiasAdd => "bias_add",
-            ShaderEntry::SgdUpdate => "sgd_update",
-            ShaderEntry::SumAll => "sum_all",
-            ShaderEntry::MeanAll => "mean_all",
-            ShaderEntry::Softmax => "softmax",
-            ShaderEntry::CrossEntropyLoss => "cross_entropy_loss",
-            ShaderEntry::Transpose => "transpose",
-        }
-    }
-
     pub fn entry_point(&self) -> &'static str {
         match *self {
             ShaderEntry::MatMul

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -51,6 +51,28 @@ impl ShaderEntry {
         }
     }
 
+    /// Human-readable name for this shader, used in profiling traces.
+    pub fn name(&self) -> &'static str {
+        match *self {
+            ShaderEntry::MatMul => "matmul",
+            ShaderEntry::MatMulRelu => "matmul_relu",
+            ShaderEntry::MatMulBiasRelu => "matmul_bias_relu",
+            ShaderEntry::Relu => "relu",
+            ShaderEntry::Sigmoid => "sigmoid",
+            ShaderEntry::Neg => "neg",
+            ShaderEntry::Add => "add",
+            ShaderEntry::Mul => "mul",
+            ShaderEntry::Greater => "greater",
+            ShaderEntry::BiasAdd => "bias_add",
+            ShaderEntry::SgdUpdate => "sgd_update",
+            ShaderEntry::SumAll => "sum_all",
+            ShaderEntry::MeanAll => "mean_all",
+            ShaderEntry::Softmax => "softmax",
+            ShaderEntry::CrossEntropyLoss => "cross_entropy_loss",
+            ShaderEntry::Transpose => "transpose",
+        }
+    }
+
     pub fn entry_point(&self) -> &'static str {
         match *self {
             ShaderEntry::MatMul

--- a/src/data/mnist.rs
+++ b/src/data/mnist.rs
@@ -3,8 +3,10 @@
 //! Supports both raw and gzip-compressed files.
 
 use super::DataLoader;
-use std::io::{self, Read};
-use std::path::Path;
+use std::{
+    io::{self, Read},
+    path::Path,
+};
 
 /// MNIST dataset loaded into memory.
 ///

--- a/src/data/safetensors.rs
+++ b/src/data/safetensors.rs
@@ -129,12 +129,14 @@ impl SafeTensorsModel {
                 Ok(floats)
             }
             safetensors::Dtype::BF16 => {
+                // BF16 is a truncated F32: same sign + exponent bits,
+                // fewer mantissa bits. Widening is a simple 16-bit left
+                // shift (zero-fills the lower mantissa bits).
                 let bytes = view.data();
                 let floats: Vec<f32> = bytes
                     .chunks_exact(2)
                     .map(|chunk| {
                         let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
-                        // BF16 → F32: just shift left by 16 bits
                         f32::from_bits((bits as u32) << 16)
                     })
                     .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod data;
 pub mod graph;
 pub mod models;
 pub mod optimize;
+pub mod profiler;
 pub mod runtime;
 pub mod train;
 

--- a/src/models/smollm2.rs
+++ b/src/models/smollm2.rs
@@ -5,14 +5,26 @@
 
 use crate::graph::{Graph, NodeId};
 
+/// Hyperparameters for a SmolLM2 model instance.
+///
+/// Values correspond to the `config.json` published alongside the
+/// HuggingFace model weights.
 pub struct SmolLM2Config {
+    /// Vocabulary size (number of token embeddings).
     pub vocab_size: usize,
+    /// Dimensionality of the transformer hidden state.
     pub hidden_size: usize,
+    /// Number of transformer decoder blocks.
     pub num_hidden_layers: usize,
+    /// Number of query heads in grouped-query attention (GQA).
     pub num_attention_heads: u32,
+    /// Number of key/value heads (fewer than query heads for GQA).
     pub num_key_value_heads: u32,
+    /// Inner dimension of the SwiGLU feed-forward network.
     pub intermediate_size: usize,
+    /// Epsilon for RMSNorm numerical stability.
     pub rms_norm_eps: f32,
+    /// Base frequency for Rotary Position Embeddings (RoPE).
     pub rope_theta: f32,
 }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,6 +1,5 @@
 use crate::graph::{Graph, Node, NodeId, Op, TensorType};
-use std::fmt;
-use std::time::Instant;
+use std::{fmt, time::Instant};
 
 /// Report from the e-graph optimization pass.
 pub struct OptimizeReport {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1,0 +1,431 @@
+//! Profiling infrastructure producing Perfetto binary traces (`.pftrace`).
+//!
+//! CPU-side work is captured automatically via [`tracing`] spans. GPU pass
+//! durations come from blade-graphics hardware timestamp queries. Both land
+//! on separate tracks in the resulting trace, viewable in
+//! [Perfetto UI](https://ui.perfetto.dev).
+//!
+//! # Quick start
+//!
+//! ```ignore
+//! meganeura::profiler::init();          // sets up tracing subscriber
+//! // ... build session, train ...
+//! meganeura::profiler::save("trace.pftrace").unwrap();
+//! ```
+
+use std::path::Path;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use tracing::span;
+use tracing::Subscriber;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+// ---- Track IDs ----
+
+const CPU_TRACK_UUID: u64 = 1;
+const GPU_TRACK_UUID: u64 = 2;
+
+// ---- Trace event model ----
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+enum EventKind {
+    SliceBegin = 1,
+    SliceEnd = 2,
+    Instant = 3,
+}
+
+struct TraceEvent {
+    name: String,
+    timestamp_ns: u64,
+    track_uuid: u64,
+    kind: EventKind,
+}
+
+// ---- Shared profiler state ----
+
+struct ProfilerInner {
+    epoch: Instant,
+    events: Vec<TraceEvent>,
+}
+
+impl ProfilerInner {
+    fn now_ns(&self) -> u64 {
+        self.epoch.elapsed().as_nanos() as u64
+    }
+}
+
+static PROFILER: OnceLock<Arc<Mutex<ProfilerInner>>> = OnceLock::new();
+
+fn get_or_init() -> &'static Arc<Mutex<ProfilerInner>> {
+    PROFILER.get_or_init(|| {
+        Arc::new(Mutex::new(ProfilerInner {
+            epoch: Instant::now(),
+            events: Vec::with_capacity(8192),
+        }))
+    })
+}
+
+// ---- Public API ----
+
+/// Initialize profiling: installs a global [`tracing`] subscriber that records
+/// spans as Perfetto slice events on the CPU track.
+///
+/// Safe to call multiple times (subsequent calls are no-ops).
+/// Must be called *before* any tracing spans you want captured.
+pub fn init() {
+    let inner = get_or_init().clone();
+    let layer = ProfileLayer { inner };
+    let subscriber = tracing_subscriber::registry().with(layer);
+    // Ignore error if a subscriber is already set.
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+/// Record GPU pass timing events on the GPU track.
+///
+/// `submit_offset_ns` is the nanosecond offset (relative to profiler epoch)
+/// when the GPU work was submitted. Pass durations are laid out sequentially
+/// starting from that offset.
+pub fn record_gpu_passes(submit_offset_ns: u64, passes: &[(String, Duration)]) {
+    if let Some(inner) = PROFILER.get() {
+        let mut guard = inner.lock().unwrap();
+        let mut offset = submit_offset_ns;
+        for (name, dur) in passes {
+            guard.events.push(TraceEvent {
+                name: name.clone(),
+                timestamp_ns: offset,
+                track_uuid: GPU_TRACK_UUID,
+                kind: EventKind::SliceBegin,
+            });
+            offset += dur.as_nanos() as u64;
+            guard.events.push(TraceEvent {
+                name: name.clone(),
+                timestamp_ns: offset,
+                track_uuid: GPU_TRACK_UUID,
+                kind: EventKind::SliceEnd,
+            });
+        }
+    }
+}
+
+/// Record a single CPU event (for use outside tracing spans).
+pub fn record_instant(name: &str) {
+    if let Some(inner) = PROFILER.get() {
+        let mut guard = inner.lock().unwrap();
+        let ts = guard.now_ns();
+        guard.events.push(TraceEvent {
+            name: name.to_string(),
+            timestamp_ns: ts,
+            track_uuid: CPU_TRACK_UUID,
+            kind: EventKind::Instant,
+        });
+    }
+}
+
+/// Return the nanosecond offset from the profiler epoch (for GPU timing placement).
+pub fn now_ns() -> u64 {
+    PROFILER
+        .get()
+        .map(|inner| inner.lock().unwrap().now_ns())
+        .unwrap_or(0)
+}
+
+/// Number of recorded events (including both CPU spans and GPU passes).
+pub fn event_count() -> usize {
+    PROFILER
+        .get()
+        .map(|inner| inner.lock().unwrap().events.len())
+        .unwrap_or(0)
+}
+
+/// Write all collected events to a Perfetto `.pftrace` binary trace file.
+pub fn save(path: impl AsRef<Path>) -> std::io::Result<()> {
+    let inner = PROFILER.get().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::Other, "profiler not initialized")
+    })?;
+    let guard = inner.lock().unwrap();
+    write_pftrace(path.as_ref(), &guard.events)
+}
+
+// ---- Tracing Layer ----
+
+/// A [`tracing_subscriber::Layer`] that captures span enter/exit as Perfetto
+/// slice events on the CPU track.
+pub struct ProfileLayer {
+    inner: Arc<Mutex<ProfilerInner>>,
+}
+
+impl<S> Layer<S> for ProfileLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut guard = self.inner.lock().unwrap();
+            let ts = guard.now_ns();
+            guard.events.push(TraceEvent {
+                name: span.name().to_string(),
+                timestamp_ns: ts,
+                track_uuid: CPU_TRACK_UUID,
+                kind: EventKind::SliceBegin,
+            });
+        }
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut guard = self.inner.lock().unwrap();
+            let ts = guard.now_ns();
+            guard.events.push(TraceEvent {
+                name: span.name().to_string(),
+                timestamp_ns: ts,
+                track_uuid: CPU_TRACK_UUID,
+                kind: EventKind::SliceEnd,
+            });
+        }
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut guard = self.inner.lock().unwrap();
+        let ts = guard.now_ns();
+        guard.events.push(TraceEvent {
+            name: event.metadata().name().to_string(),
+            timestamp_ns: ts,
+            track_uuid: CPU_TRACK_UUID,
+            kind: EventKind::Instant,
+        });
+    }
+}
+
+// ---- Perfetto binary trace writer ----
+//
+// Minimal protobuf encoder — just enough to produce valid .pftrace files
+// without pulling in prost or other heavy dependencies.
+
+/// Write a Perfetto trace file from collected events.
+fn write_pftrace(path: &Path, events: &[TraceEvent]) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut trace = ProtoBuf::new();
+
+    // Process descriptor packet.
+    let mut proc_desc = ProtoBuf::new();
+    proc_desc.uint32(1, std::process::id()); // pid
+    let mut track_desc = ProtoBuf::new();
+    track_desc.uint64(1, 0); // uuid (process track)
+    track_desc.message(3, &proc_desc); // process
+    track_desc.string(2, "meganeura"); // name
+    let mut pkt = ProtoBuf::new();
+    pkt.message(60, &track_desc); // track_descriptor
+    pkt.uint32(10, 1); // trusted_packet_sequence_id
+    trace.message(1, &pkt); // Trace.packet
+
+    // CPU track descriptor.
+    let mut td = ProtoBuf::new();
+    td.uint64(1, CPU_TRACK_UUID);
+    td.uint64(5, 0); // parent_uuid → process
+    td.string(2, "CPU");
+    let mut pkt = ProtoBuf::new();
+    pkt.message(60, &td);
+    pkt.uint32(10, 1);
+    trace.message(1, &pkt);
+
+    // GPU track descriptor.
+    let mut td = ProtoBuf::new();
+    td.uint64(1, GPU_TRACK_UUID);
+    td.uint64(5, 0); // parent_uuid → process
+    td.string(2, "GPU");
+    let mut pkt = ProtoBuf::new();
+    pkt.message(60, &td);
+    pkt.uint32(10, 1);
+    trace.message(1, &pkt);
+
+    // Event packets.
+    for ev in events {
+        let mut te = ProtoBuf::new();
+        te.uint64(11, ev.track_uuid); // track_uuid
+        te.int32(9, ev.kind as i32); // type enum
+        te.string(23, &ev.name); // name
+
+        let mut pkt = ProtoBuf::new();
+        pkt.uint64(8, ev.timestamp_ns); // timestamp
+        pkt.message(11, &te); // track_event
+        pkt.uint32(10, 1); // trusted_packet_sequence_id
+        trace.message(1, &pkt);
+    }
+
+    let mut f = std::io::BufWriter::new(std::fs::File::create(path)?);
+    f.write_all(&trace.buf)?;
+    Ok(())
+}
+
+// ---- Minimal protobuf encoder ----
+
+struct ProtoBuf {
+    buf: Vec<u8>,
+}
+
+impl ProtoBuf {
+    fn new() -> Self {
+        Self {
+            buf: Vec::with_capacity(128),
+        }
+    }
+
+    fn write_varint(&mut self, mut val: u64) {
+        loop {
+            let byte = (val & 0x7F) as u8;
+            val >>= 7;
+            if val == 0 {
+                self.buf.push(byte);
+                return;
+            }
+            self.buf.push(byte | 0x80);
+        }
+    }
+
+    fn tag(&mut self, field: u32, wire_type: u32) {
+        self.write_varint(((field as u64) << 3) | wire_type as u64);
+    }
+
+    fn uint64(&mut self, field: u32, val: u64) {
+        self.tag(field, 0);
+        self.write_varint(val);
+    }
+
+    fn uint32(&mut self, field: u32, val: u32) {
+        self.tag(field, 0);
+        self.write_varint(val as u64);
+    }
+
+    fn int32(&mut self, field: u32, val: i32) {
+        self.tag(field, 0);
+        // Protobuf int32 uses varint with sign extension to 64 bits.
+        self.write_varint(val as u32 as u64);
+    }
+
+    fn string(&mut self, field: u32, val: &str) {
+        self.tag(field, 2);
+        self.write_varint(val.len() as u64);
+        self.buf.extend_from_slice(val.as_bytes());
+    }
+
+    fn message(&mut self, field: u32, msg: &ProtoBuf) {
+        self.tag(field, 2);
+        self.write_varint(msg.buf.len() as u64);
+        self.buf.extend_from_slice(&msg.buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_varint_encoding() {
+        let mut pb = ProtoBuf::new();
+        pb.write_varint(0);
+        assert_eq!(pb.buf, &[0]);
+
+        let mut pb = ProtoBuf::new();
+        pb.write_varint(1);
+        assert_eq!(pb.buf, &[1]);
+
+        let mut pb = ProtoBuf::new();
+        pb.write_varint(300);
+        assert_eq!(pb.buf, &[0xAC, 0x02]);
+    }
+
+    #[test]
+    fn test_save_produces_nonempty_file() {
+        // Initialize the profiler for this test.
+        let inner = get_or_init();
+        {
+            let mut guard = inner.lock().unwrap();
+            guard.events.push(TraceEvent {
+                name: "test_span".into(),
+                timestamp_ns: 1000,
+                track_uuid: CPU_TRACK_UUID,
+                kind: EventKind::SliceBegin,
+            });
+            guard.events.push(TraceEvent {
+                name: "test_span".into(),
+                timestamp_ns: 2000,
+                track_uuid: CPU_TRACK_UUID,
+                kind: EventKind::SliceEnd,
+            });
+            guard.events.push(TraceEvent {
+                name: "matmul".into(),
+                timestamp_ns: 1200,
+                track_uuid: GPU_TRACK_UUID,
+                kind: EventKind::SliceBegin,
+            });
+            guard.events.push(TraceEvent {
+                name: "matmul".into(),
+                timestamp_ns: 1800,
+                track_uuid: GPU_TRACK_UUID,
+                kind: EventKind::SliceEnd,
+            });
+        }
+
+        let dir = std::env::temp_dir().join("meganeura_profiler_test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("test.pftrace");
+        save(&path).unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        // Should be a non-trivial protobuf file.
+        assert!(bytes.len() > 50, "trace file too small: {} bytes", bytes.len());
+        // First byte should be a protobuf tag for field 1, wire type 2 (length-delimited).
+        assert_eq!(bytes[0] & 0x07, 2, "expected length-delimited wire type");
+        assert_eq!(bytes[0] >> 3, 1, "expected field number 1 (Trace.packet)");
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+
+        // Clean up events for other tests.
+        inner.lock().unwrap().events.clear();
+    }
+
+    #[test]
+    fn test_record_gpu_passes() {
+        let inner = get_or_init();
+        inner.lock().unwrap().events.clear();
+
+        record_gpu_passes(
+            5000,
+            &[
+                ("relu".into(), Duration::from_nanos(100)),
+                ("matmul".into(), Duration::from_nanos(500)),
+            ],
+        );
+
+        let guard = inner.lock().unwrap();
+        assert_eq!(guard.events.len(), 4); // 2 begin + 2 end
+        assert_eq!(guard.events[0].name, "relu");
+        assert_eq!(guard.events[0].timestamp_ns, 5000);
+        assert_eq!(guard.events[0].kind, EventKind::SliceBegin);
+        assert_eq!(guard.events[1].timestamp_ns, 5100); // 5000 + 100
+        assert_eq!(guard.events[1].kind, EventKind::SliceEnd);
+        assert_eq!(guard.events[2].name, "matmul");
+        assert_eq!(guard.events[2].timestamp_ns, 5100);
+        assert_eq!(guard.events[3].timestamp_ns, 5600); // 5100 + 500
+
+        drop(guard);
+        inner.lock().unwrap().events.clear();
+    }
+
+    #[test]
+    fn test_now_ns_increases() {
+        let _ = get_or_init();
+        let t1 = now_ns();
+        for _ in 0..1000 {
+            std::hint::black_box(0);
+        }
+        let t2 = now_ns();
+        assert!(t2 >= t1);
+    }
+}

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -13,16 +13,13 @@
 //! meganeura::profiler::save("trace.pftrace").unwrap();
 //! ```
 
-use std::path::Path;
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, Instant};
-
-use tracing::span;
-use tracing::Subscriber;
-use tracing_subscriber::layer::Context;
-use tracing_subscriber::prelude::*;
-use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::Layer;
+use std::{
+    path::Path,
+    sync::{Arc, Mutex, OnceLock},
+    time::{Duration, Instant},
+};
+use tracing::{span, Subscriber};
+use tracing_subscriber::{layer::Context, prelude::*, registry::LookupSpan, Layer};
 
 // ---- Track IDs ----
 
@@ -94,7 +91,7 @@ pub fn record_gpu_passes(submit_offset_ns: u64, passes: &[(String, Duration)]) {
     if let Some(inner) = PROFILER.get() {
         let mut guard = inner.lock().unwrap();
         let mut offset = submit_offset_ns;
-        for (name, dur) in passes {
+        for &(ref name, dur) in passes {
             guard.events.push(TraceEvent {
                 name: name.clone(),
                 timestamp_ns: offset,
@@ -145,7 +142,7 @@ pub fn event_count() -> usize {
 /// Write all collected events to a Perfetto `.pftrace` binary trace file.
 pub fn save(path: impl AsRef<Path>) -> std::io::Result<()> {
     let inner = PROFILER.get().ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::Other, "profiler not initialized")
+        std::io::Error::other("profiler not initialized")
     })?;
     let guard = inner.lock().unwrap();
     write_pftrace(path.as_ref(), &guard.events)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -411,7 +411,7 @@ impl Session {
         for i in 0..self.plan.dispatches.len() {
             let dispatch = &self.plan.dispatches[i];
             let pipeline = self.pipelines.get(&dispatch.shader);
-            let mut pass = self.encoder.compute(dispatch.shader.name());
+            let mut pass = self.encoder.compute(&format!("{:?}", dispatch.shader));
             let mut pc = pass.with(pipeline);
             Self::bind_dispatch(&self.buffers, dispatch, &mut pc);
             pc.dispatch(dispatch.workgroups);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -261,6 +261,9 @@ pub struct Session {
     plan: ExecutionPlan,
     encoder: blade_graphics::CommandEncoder,
     sync_point: Option<blade_graphics::SyncPoint>,
+    /// Nanosecond offset (in profiler time) of the most recent GPU submit,
+    /// used to place GPU pass timings on the GPU track.
+    last_submit_ns: u64,
 }
 
 impl Session {
@@ -271,6 +274,7 @@ impl Session {
         let gpu = unsafe {
             blade_graphics::Context::init(blade_graphics::ContextDesc {
                 validation: cfg!(debug_assertions),
+                timing: true,
                 capture: false,
                 overlay: false,
                 device_id: 0,
@@ -306,6 +310,7 @@ impl Session {
             plan,
             encoder,
             sync_point: None,
+            last_submit_ns: 0,
         }
     }
 
@@ -389,24 +394,30 @@ impl Session {
     /// Wait for any pending GPU work.
     pub fn wait(&mut self) {
         if let Some(sp) = self.sync_point.take() {
+            let _span = tracing::info_span!("wait").entered();
             self.gpu.wait_for(&sp, !0);
         }
     }
 
     /// Execute the full dispatch sequence (forward + backward + update).
     pub fn step(&mut self) {
+        let _span = tracing::info_span!("step").entered();
         self.wait();
+
         self.encoder.start();
+        // After start(), blade exposes GPU timings from the *previous* submission.
+        self.drain_gpu_timings();
 
         for i in 0..self.plan.dispatches.len() {
             let dispatch = &self.plan.dispatches[i];
             let pipeline = self.pipelines.get(&dispatch.shader);
-            let mut pass = self.encoder.compute(dispatch.shader.entry_point());
+            let mut pass = self.encoder.compute(dispatch.shader.name());
             let mut pc = pass.with(pipeline);
             Self::bind_dispatch(&self.buffers, dispatch, &mut pc);
             pc.dispatch(dispatch.workgroups);
         }
 
+        self.last_submit_ns = crate::profiler::now_ns();
         self.sync_point = Some(self.gpu.submit(&mut self.encoder));
     }
 
@@ -642,15 +653,26 @@ impl Session {
         }
     }
 
+    /// Read GPU pass timings from the encoder (available after `encoder.start()`)
+    /// and record them on the GPU profiling track.
+    fn drain_gpu_timings(&self) {
+        let timings = self.encoder.timings();
+        if !timings.is_empty() {
+            crate::profiler::record_gpu_passes(self.last_submit_ns, timings);
+        }
+    }
+
     /// Apply SGD updates to all parameters on the GPU.
     pub fn sgd_step(&mut self, learning_rate: f32) {
+        let _span = tracing::info_span!("sgd_step").entered();
         self.wait();
         self.encoder.start();
+        self.drain_gpu_timings();
 
         for &(param_buf, grad_buf) in &self.plan.param_grad_pairs {
             let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
             let pipeline = self.pipelines.get(&ShaderEntry::SgdUpdate);
-            let mut pass = self.encoder.compute("sgd");
+            let mut pass = self.encoder.compute("sgd_update");
             let mut pc = pass.with(pipeline);
             pc.bind(
                 0,
@@ -669,11 +691,13 @@ impl Session {
             pc.dispatch([len.div_ceil(256), 1, 1]);
         }
 
+        self.last_submit_ns = crate::profiler::now_ns();
         self.sync_point = Some(self.gpu.submit(&mut self.encoder));
     }
 
     /// CPU-fallback SGD update.
     pub fn sgd_step_cpu(&mut self, learning_rate: f32) {
+        let _span = tracing::info_span!("sgd_step_cpu").entered();
         self.wait();
         for &(param_buf, grad_buf) in &self.plan.param_grad_pairs {
             let size = self.plan.buffers[param_buf.0 as usize] / 4;

--- a/src/train.rs
+++ b/src/train.rs
@@ -1,11 +1,10 @@
-use crate::autodiff;
-use crate::cache;
-use crate::compile;
-use crate::data::DataLoader;
-use crate::graph::Graph;
-use crate::optimize;
-use crate::optimize::OptimizeReport;
-use crate::runtime::Session;
+use crate::{
+    autodiff, cache, compile,
+    data::DataLoader,
+    graph::Graph,
+    optimize::{self, OptimizeReport},
+    runtime::Session,
+};
 use std::path::Path;
 
 /// Configuration for training.

--- a/src/train.rs
+++ b/src/train.rs
@@ -83,6 +83,7 @@ impl Trainer {
 
     /// Run a single epoch, returning its statistics.
     pub fn train_epoch(&mut self, loader: &mut DataLoader, epoch: usize) -> EpochStats {
+        let _span = tracing::info_span!("train_epoch", epoch).entered();
         loader.shuffle(epoch as u64);
         loader.reset();
 
@@ -90,9 +91,12 @@ impl Trainer {
         let mut steps = 0usize;
 
         while let Some(batch) = loader.next_batch() {
-            self.session.set_input(&self.config.data_input, batch.data);
-            self.session
-                .set_input(&self.config.label_input, batch.labels);
+            {
+                let _span = tracing::info_span!("set_input").entered();
+                self.session.set_input(&self.config.data_input, batch.data);
+                self.session
+                    .set_input(&self.config.label_input, batch.labels);
+            }
 
             self.session.step();
             self.session.wait();
@@ -176,13 +180,22 @@ pub fn build_session(forward_graph: &Graph) -> Session {
 }
 
 /// Like `build_session`, but also returns the optimization report.
+///
+/// Build-phase stages (autodiff, egglog, compile, gpu_init) are captured
+/// as tracing spans and will appear in Perfetto traces when profiling is
+/// active.
 pub fn build_session_with_report(forward_graph: &Graph) -> (Session, OptimizeReport) {
+    let _span = tracing::info_span!("build_session").entered();
+
     log::info!("building training session...");
     log::info!("forward graph:\n{}", forward_graph);
 
     // Step 1: Autodiff
     log::info!("running autodiff...");
-    let full_graph = autodiff::differentiate(forward_graph);
+    let full_graph = {
+        let _span = tracing::info_span!("autodiff").entered();
+        autodiff::differentiate(forward_graph)
+    };
     log::info!(
         "full graph (forward + backward): {} nodes",
         full_graph.nodes().len()
@@ -190,12 +203,18 @@ pub fn build_session_with_report(forward_graph: &Graph) -> (Session, OptimizeRep
 
     // Step 2: Optimize with egglog
     log::info!("running egglog optimization...");
-    let (optimized, report) = optimize::optimize_with_report(&full_graph);
+    let (optimized, report) = {
+        let _span = tracing::info_span!("egglog_optimize").entered();
+        optimize::optimize_with_report(&full_graph)
+    };
     log::info!("optimized graph: {} nodes", optimized.nodes().len());
 
     // Step 3: Compile to execution plan
     log::info!("compiling execution plan...");
-    let plan = compile::compile(&optimized);
+    let plan = {
+        let _span = tracing::info_span!("compile").entered();
+        compile::compile(&optimized)
+    };
     log::info!(
         "execution plan: {} buffers, {} dispatches",
         plan.buffers.len(),
@@ -204,7 +223,12 @@ pub fn build_session_with_report(forward_graph: &Graph) -> (Session, OptimizeRep
 
     // Step 4: Create GPU session
     log::info!("initializing GPU session...");
-    (Session::new(plan), report)
+    let session = {
+        let _span = tracing::info_span!("gpu_init").entered();
+        Session::new(plan)
+    };
+
+    (session, report)
 }
 
 /// Build a session, using a cache file if available.


### PR DESCRIPTION
Summary
	∙	End-to-end neural network training on the GPU via blade-graphics: graph IR → autodiff → e-graph optimization (egglog) → Naga IR codegen → GPU dispatch
	∙	MNIST and diffusion denoising examples demonstrating the full pipeline
	∙	Perfetto profiling with MEGANEURA_TRACE=path.pftrace for CPU + GPU traces
What’s included
	∙	Graph IR (<graph.rs>): typed tensor graph with standard NN ops (matmul, relu, sigmoid, softmax, cross-entropy, etc.)
	∙	Autodiff (<autodiff.rs>): reverse-mode differentiation over the graph
	∙	E-graph optimizer (<optimize.rs>): egglog-based rewrite rules (fused matmul+relu, fused matmul+bias+relu, constant folding)
	∙	Naga codegen (<codegen.rs>): programmatic Naga IR emission for all shader groups — no static WGSL files
	∙	Compiler (<compile.rs>): graph → execution plan with buffer allocation and dispatch scheduling
	∙	Runtime (<runtime.rs>): blade-graphics GPU session, buffer management, and execution
	∙	Training loop (<train.rs>): Trainer with epoch/batch iteration, SGD, and compilation caching (RON)
	∙	Data loading (data/): MNIST IDX parser (raw + gzip), mini-batch DataLoader with shuffling
	∙	Profiler (<profiler.rs>): Perfetto binary trace output with CPU spans and GPU timestamp tracks
	∙	76 unit tests + 1 GPU smoke test
Test plan
	∙	cargo test — 76 tests pass
	∙	GPU smoke test compiles shaders and runs a forward pass
	∙	cargo run --example mnist with MNIST data files in data/
	∙	MEGANEURA_TRACE=out.pftrace cargo run --example mnist produces a valid trace