### PR TITLE
Add SmolLM2-135M inference support with transformer ops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.11"
 flate2 = "1"
 safetensors = "0.4"
 hf-hub = { version = "0.4", default-features = false, features = ["ureq", "native-tls"] }
+tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
 
 [[example]]
 name = "mnist"
@@ -35,3 +36,7 @@ path = "examples/diffusion.rs"
 [[example]]
 name = "huggingface"
 path = "examples/huggingface.rs"
+
+[[example]]
+name = "smollm2"
+path = "examples/smollm2.rs"

--- a/examples/huggingface.rs
+++ b/examples/huggingface.rs
@@ -13,8 +13,10 @@
 /// MNIST test data is expected in `data/` (gzipped or raw):
 ///   data/t10k-images-idx3-ubyte.gz
 ///   data/t10k-labels-idx1-ubyte.gz
-use meganeura::data::huggingface::HfModel;
-use meganeura::{Graph, MnistDataset, build_inference_session};
+use meganeura::{
+    Graph, MnistDataset, build_inference_session,
+    data::safetensors::SafeTensorsModel,
+};
 use std::path::{Path, PathBuf};
 
 fn main() {
@@ -28,10 +30,10 @@ fn main() {
     // --- Load model: CLI path or download from HuggingFace ---
     let hf = if let Some(path) = std::env::args().nth(1) {
         println!("loading model from {}...", path);
-        HfModel::load(PathBuf::from(path)).expect("failed to load model")
+        SafeTensorsModel::load(PathBuf::from(path)).expect("failed to load model")
     } else {
         println!("downloading dacorvo/mnist-mlp from HuggingFace Hub...");
-        HfModel::download("dacorvo/mnist-mlp").expect("failed to download model")
+        SafeTensorsModel::download("dacorvo/mnist-mlp").expect("failed to download model")
     };
 
     // Print tensor info

--- a/examples/smollm2.rs
+++ b/examples/smollm2.rs
@@ -1,0 +1,161 @@
+/// Run SmolLM2-135M inference using meganeura.
+///
+/// Downloads the model and tokenizer from HuggingFace Hub,
+/// builds the computation graph, loads weights, and generates text.
+///
+/// Usage:
+///   cargo run --release --example smollm2 [-- "Your prompt here"]
+use meganeura::{
+    Graph, build_inference_session,
+    data::safetensors::SafeTensorsModel,
+    models::smollm2::{self, SmolLM2Config},
+};
+
+const REPO_ID: &str = "HuggingFaceTB/SmolLM2-135M";
+
+fn main() {
+    env_logger::init();
+
+    let prompt = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "The meaning of life is".to_string());
+    let max_new_tokens = 32;
+
+    let config = SmolLM2Config::smollm2_135m();
+
+    // --- Download model and tokenizer ---
+    println!("downloading {} from HuggingFace Hub...", REPO_ID);
+    let model = SafeTensorsModel::download(REPO_ID).expect("failed to download model");
+
+    println!("model tensors:");
+    let mut names: Vec<_> = model.tensor_info().keys().collect();
+    names.sort();
+    for name in names.iter().take(5) {
+        let info = &model.tensor_info()[*name];
+        println!("  {}: shape={:?} dtype={:?}", name, info.shape, info.dtype);
+    }
+    if names.len() > 5 {
+        println!("  ... and {} more", names.len() - 5);
+    }
+
+    // Load tokenizer
+    println!("loading tokenizer...");
+    let api = hf_hub::api::sync::Api::new().expect("failed to create HF API");
+    let repo = api.model(REPO_ID.to_string());
+    let tokenizer_path = repo.get("tokenizer.json").expect("failed to download tokenizer.json");
+    let tokenizer =
+        tokenizers::Tokenizer::from_file(tokenizer_path).expect("failed to load tokenizer");
+
+    // Encode prompt
+    let encoding = tokenizer.encode(prompt.as_str(), false).expect("tokenization failed");
+    let input_ids: Vec<u32> = encoding.get_ids().to_vec();
+    let seq_len = input_ids.len() + max_new_tokens;
+    println!(
+        "prompt: \"{}\" ({} tokens), generating {} more (seq_len={})",
+        prompt,
+        input_ids.len(),
+        max_new_tokens,
+        seq_len
+    );
+
+    // --- Build graph ---
+    println!("building computation graph...");
+    let mut g = Graph::new();
+    let logits = smollm2::build_graph(&mut g, &config, seq_len);
+    g.set_outputs(vec![logits]);
+
+    // --- Compile ---
+    println!("compiling inference session...");
+    let mut session = build_inference_session(&g);
+    println!(
+        "session ready: {} buffers, {} dispatches",
+        session.plan().buffers.len(),
+        session.plan().dispatches.len()
+    );
+
+    // --- Load weights ---
+    println!("loading weights...");
+    let transposed = smollm2::transposed_weight_names(&config);
+    let transposed_set: std::collections::HashSet<&str> =
+        transposed.iter().map(|s| s.as_str()).collect();
+
+    for (name, _) in session.plan().param_buffers.clone() {
+        if name == "lm_head.weight" {
+            // lm_head is often tied to embed_tokens
+            if model.tensor_info().contains_key("lm_head.weight") {
+                let data = if transposed_set.contains(name.as_str()) {
+                    model.tensor_f32_auto_transposed(&name)
+                } else {
+                    model.tensor_f32_auto(&name)
+                };
+                session.set_parameter(&name, &data.unwrap_or_else(|e| panic!("{}: {}", name, e)));
+            } else {
+                // Tied weights: use embed_tokens transposed
+                println!("  lm_head tied to embed_tokens, transposing...");
+                let data = model
+                    .tensor_f32_auto_transposed("model.embed_tokens.weight")
+                    .expect("failed to load embed_tokens for lm_head");
+                session.set_parameter("lm_head.weight", &data);
+            }
+        } else if transposed_set.contains(name.as_str()) {
+            let data = model
+                .tensor_f32_auto_transposed(&name)
+                .unwrap_or_else(|e| panic!("{}: {}", name, e));
+            session.set_parameter(&name, &data);
+        } else {
+            let data = model
+                .tensor_f32_auto(&name)
+                .unwrap_or_else(|e| panic!("{}: {}", name, e));
+            session.set_parameter(&name, &data);
+        }
+    }
+    println!("weights loaded.");
+
+    // --- Generate tokens ---
+    println!("generating...\n");
+
+    // Pad input_ids to seq_len with 0s
+    let mut tokens = vec![0u32; seq_len];
+    tokens[..input_ids.len()].copy_from_slice(&input_ids);
+
+    let mut generated = input_ids.clone();
+
+    for step in 0..max_new_tokens {
+        // Set full token sequence
+        session.set_input_u32("token_ids", &tokens);
+        session.step();
+        session.wait();
+
+        // Read logits: [seq_len, vocab_size]
+        let vocab = config.vocab_size;
+        let all_logits = session.read_output(seq_len * vocab);
+
+        // Get logits for the current position (last non-padding token)
+        let cur_pos = input_ids.len() + step;
+        let pos_logits = &all_logits[(cur_pos - 1) * vocab..cur_pos * vocab];
+
+        // Argmax
+        let next_token = pos_logits
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .unwrap()
+            .0 as u32;
+
+        tokens[cur_pos] = next_token;
+        generated.push(next_token);
+
+        // Decode and print incrementally
+        let decoded = tokenizer
+            .decode(&[next_token], false)
+            .unwrap_or_else(|_| "?".to_string());
+        print!("{}", decoded);
+    }
+    println!();
+
+    // Print full output
+    let full_text = tokenizer
+        .decode(&generated, true)
+        .unwrap_or_else(|_| "decode error".to_string());
+    println!("\n--- Full output ---\n{}", full_text);
+}

--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -152,6 +152,17 @@ pub fn differentiate(forward: &Graph) -> Graph {
             Op::FusedMatMulRelu | Op::FusedMatMulBiasRelu => {
                 log::warn!("autodiff should run before fusion optimization");
             }
+            // Transformer ops: inference-only, no autodiff support
+            Op::Silu
+            | Op::RmsNorm { .. }
+            | Op::Embedding
+            | Op::RoPE { .. }
+            | Op::CausalAttention { .. } => {
+                log::warn!(
+                    "autodiff not supported for {:?}, inference-only op",
+                    node.op
+                );
+            }
         }
     }
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -205,6 +205,34 @@ impl Builder {
         });
     }
 
+    /// Add a storage buffer global variable for u32 array (read-only).
+    fn storage_ro_u32(&mut self) -> Handle<GlobalVariable> {
+        let ty_arr_u32 = self.m.types.insert(
+            Type {
+                name: None,
+                inner: TypeInner::Array {
+                    base: self.ty_u32,
+                    size: ArraySize::Dynamic,
+                    stride: 4,
+                },
+            },
+            S,
+        );
+        self.m.global_variables.append(
+            GlobalVariable {
+                name: Some("indices".to_string()),
+                space: AddressSpace::Storage {
+                    access: StorageAccess::LOAD,
+                },
+                binding: None,
+                ty: ty_arr_u32,
+                init: None,
+                memory_decorations: MemoryDecorations::empty(),
+            },
+            S,
+        )
+    }
+
     fn finish(self) -> Module {
         self.m
     }
@@ -476,6 +504,10 @@ pub enum ShaderGroup {
     Reduce,
     Softmax,
     CrossEntropy,
+    RmsNorm,
+    Embedding,
+    RoPE,
+    CausalAttention,
 }
 
 /// Generate a `naga::Module` for a shader group.
@@ -492,6 +524,10 @@ pub fn generate_module(group: ShaderGroup) -> Module {
         ShaderGroup::Reduce => gen_reduce(),
         ShaderGroup::Softmax => gen_softmax(),
         ShaderGroup::CrossEntropy => gen_cross_entropy(),
+        ShaderGroup::RmsNorm => gen_rms_norm(),
+        ShaderGroup::Embedding => gen_embedding(),
+        ShaderGroup::RoPE => gen_rope(),
+        ShaderGroup::CausalAttention => gen_causal_attention(),
     }
 }
 
@@ -610,6 +646,39 @@ fn gen_unary() -> Module {
         f.f.body.push(f.store(dst_elem, result), S);
 
         b.entry_point("neg", [256, 1, 1], f.finish());
+    }
+
+    // silu: x * sigmoid(x) = x / (1 + exp(-x))
+    {
+        let mut f = FnBuilder::new(&b);
+        let gid = f.arg_gid();
+        let i = f.vec_x(gid);
+        f.label("i", i);
+        let params_ptr = f.global(gv_params);
+        let len_ptr = f.field(params_ptr, 0);
+        let len = f.load(len_ptr);
+        let cond = f.binary(BinaryOperator::GreaterEqual, i, len);
+        let src_ptr = f.global(gv_src);
+        let elem_ptr = f.index(src_ptr, i);
+        let val = f.load(elem_ptr);
+        let neg_val = f.unary(UnaryOperator::Negate, val);
+        let exp_neg = f.math1(MathFunction::Exp, neg_val);
+        let one = f.literal_f32(1.0);
+        let denom = f.binary(BinaryOperator::Add, one, exp_neg);
+        let one2 = f.literal_f32(1.0);
+        let sigmoid = f.binary(BinaryOperator::Divide, one2, denom);
+        let result = f.binary(BinaryOperator::Multiply, val, sigmoid);
+        let dst_ptr = f.global(gv_dst);
+        let dst_elem = f.index(dst_ptr, i);
+
+        f.emit(i, i);
+        f.emit(len_ptr, cond);
+        f.f.body.push(f.if_return(cond), S);
+        f.emit(src_ptr, result);
+        f.emit(dst_elem, dst_elem);
+        f.f.body.push(f.store(dst_elem, result), S);
+
+        b.entry_point("silu", [256, 1, 1], f.finish());
     }
 
     b.finish()
@@ -1748,6 +1817,729 @@ fn gen_cross_entropy() -> Module {
 }
 
 // ---------------------------------------------------------------------------
+// rms_norm.wgsl: y[i,j] = x[i,j] / sqrt(mean(x[i,:]²) + eps) * weight[j]
+// ---------------------------------------------------------------------------
+
+fn gen_rms_norm() -> Module {
+    let mut b = Builder::new();
+    // params: rows, cols, eps_bits, _pad
+    let ty_params = b.params_u32x4("Params", &["rows", "cols", "eps_bits", "_pad"]);
+    let gv_src = b.storage_ro("src");
+    let gv_weight = b.storage_ro("bias"); // named "bias" to match blade binding convention
+    let gv_dst = b.storage_rw("dst");
+    let gv_params = b.uniform("params", ty_params);
+
+    let mut f = FnBuilder::new(&b);
+    let gid = f.arg_gid();
+    let row = f.vec_x(gid);
+    f.label("row", row);
+    f.emit(row, row);
+
+    let params_ptr = f.global(gv_params);
+    let rows_ptr = f.field(params_ptr, 0);
+    let rows = f.load(rows_ptr);
+    let cols_ptr = f.field(params_ptr, 1);
+    let cols = f.load(cols_ptr);
+    let eps_ptr = f.field(params_ptr, 2);
+    let eps_bits = f.load(eps_ptr);
+    let eps = f.expr(Expression::As {
+        expr: eps_bits,
+        kind: ScalarKind::Float,
+        convert: None, // bitcast
+    });
+    f.emit(params_ptr, eps);
+
+    let cond = f.binary(BinaryOperator::GreaterEqual, row, rows);
+    f.emit(cond, cond);
+    f.f.body.push(f.if_return(cond), S);
+
+    // offset = row * cols
+    let offset = f.binary(BinaryOperator::Multiply, row, cols);
+    f.emit(offset, offset);
+
+    // Compute sum of squares: var ss = 0.0; for j in 0..cols { ss += x[offset+j]² }
+    let ss_var = f.local_var("ss", b.ty_f32, None);
+    let ss_ptr = f.local_ptr(ss_var);
+    let zero_f = f.literal_f32(0.0);
+    f.emit(zero_f, zero_f);
+    f.f.body.push(f.store(ss_ptr, zero_f), S);
+
+    let j_var = f.local_var("j", b.ty_u32, None);
+    let j_ptr = f.local_ptr(j_var);
+    let zero_u = f.literal_u32(0);
+    f.emit(zero_u, zero_u);
+    f.f.body.push(f.store(j_ptr, zero_u), S);
+
+    {
+        let mut body = Block::new();
+        let j = f.load(j_ptr);
+        let brk = f.binary(BinaryOperator::GreaterEqual, j, cols);
+        let idx = f.binary(BinaryOperator::Add, offset, j);
+        let src_ptr = f.global(gv_src);
+        let elem = f.index(src_ptr, idx);
+        let val = f.load(elem);
+        let sq = f.binary(BinaryOperator::Multiply, val, val);
+        let old_ss = f.load(ss_ptr);
+        let new_ss = f.binary(BinaryOperator::Add, old_ss, sq);
+        push_emit(&f.f.expressions, &mut body, j, new_ss);
+        body.push(f.store(ss_ptr, new_ss), S);
+
+        let one = f.literal_u32(1);
+        let j2 = f.load(j_ptr);
+        let jn = f.binary(BinaryOperator::Add, j2, one);
+        push_emit(&f.f.expressions, &mut body, one, jn);
+        body.push(f.store(j_ptr, jn), S);
+
+        f.f.body.push(
+            Statement::Loop {
+                body,
+                continuing: Block::new(),
+                break_if: Some(brk),
+            },
+            S,
+        );
+    }
+
+    // rms = 1.0 / sqrt(ss / cols_f + eps)
+    let ss_val = f.load(ss_ptr);
+    let cols_f = f.cast_f32(cols);
+    let mean_sq = f.binary(BinaryOperator::Divide, ss_val, cols_f);
+    let mean_sq_eps = f.binary(BinaryOperator::Add, mean_sq, eps);
+    let rsqrt = f.math1(MathFunction::InverseSqrt, mean_sq_eps);
+    f.emit(ss_val, rsqrt);
+
+    // Normalize loop: dst[offset+j] = x[offset+j] * rsqrt * weight[j]
+    let j2_var = f.local_var("j2", b.ty_u32, None);
+    let j2_ptr = f.local_ptr(j2_var);
+    let zero_u2 = f.literal_u32(0);
+    f.emit(zero_u2, zero_u2);
+    f.f.body.push(f.store(j2_ptr, zero_u2), S);
+
+    {
+        let mut body = Block::new();
+        let j = f.load(j2_ptr);
+        let brk = f.binary(BinaryOperator::GreaterEqual, j, cols);
+        let idx = f.binary(BinaryOperator::Add, offset, j);
+        let src_ptr = f.global(gv_src);
+        let elem = f.index(src_ptr, idx);
+        let val = f.load(elem);
+        let normed = f.binary(BinaryOperator::Multiply, val, rsqrt);
+        let w_ptr = f.global(gv_weight);
+        let w_elem = f.index(w_ptr, j);
+        let w_val = f.load(w_elem);
+        let result = f.binary(BinaryOperator::Multiply, normed, w_val);
+        push_emit(&f.f.expressions, &mut body, j, result);
+
+        let dst_ptr = f.global(gv_dst);
+        let dst_elem = f.index(dst_ptr, idx);
+        push_emit(&f.f.expressions, &mut body, dst_elem, dst_elem);
+        body.push(f.store(dst_elem, result), S);
+
+        let one = f.literal_u32(1);
+        let j3 = f.load(j2_ptr);
+        let jn = f.binary(BinaryOperator::Add, j3, one);
+        push_emit(&f.f.expressions, &mut body, one, jn);
+        body.push(f.store(j2_ptr, jn), S);
+
+        f.f.body.push(
+            Statement::Loop {
+                body,
+                continuing: Block::new(),
+                break_if: Some(brk),
+            },
+            S,
+        );
+    }
+
+    b.entry_point("main", [256, 1, 1], f.finish());
+    b.finish()
+}
+
+// ---------------------------------------------------------------------------
+// embedding.wgsl: dst[i*hidden+j] = table[indices[i]*hidden+j]
+// ---------------------------------------------------------------------------
+
+fn gen_embedding() -> Module {
+    let mut b = Builder::new();
+    let ty_params = b.params_u32x4("Params", &["seq", "hidden", "_pad0", "_pad1"]);
+    let gv_indices = b.storage_ro_u32();
+    let gv_table = b.storage_ro("src");
+    let gv_dst = b.storage_rw("dst");
+    let gv_params = b.uniform("params", ty_params);
+
+    let mut f = FnBuilder::new(&b);
+    let gid = f.arg_gid();
+    let i = f.vec_x(gid);
+    f.label("i", i);
+    f.emit(i, i);
+
+    let params_ptr = f.global(gv_params);
+    let seq_ptr = f.field(params_ptr, 0);
+    let seq = f.load(seq_ptr);
+    let hidden_ptr = f.field(params_ptr, 1);
+    let hidden = f.load(hidden_ptr);
+    f.emit(params_ptr, hidden);
+
+    // total = seq * hidden
+    let total = f.binary(BinaryOperator::Multiply, seq, hidden);
+    let cond = f.binary(BinaryOperator::GreaterEqual, i, total);
+    f.emit(total, cond);
+    f.f.body.push(f.if_return(cond), S);
+
+    // row = i / hidden, col = i % hidden
+    let row = f.binary(BinaryOperator::Divide, i, hidden);
+    let col = f.binary(BinaryOperator::Modulo, i, hidden);
+
+    // token_id = indices[row]
+    let idx_ptr = f.global(gv_indices);
+    let idx_elem = f.index(idx_ptr, row);
+    let token_id = f.load(idx_elem);
+
+    // src_idx = token_id * hidden + col
+    let tok_off = f.binary(BinaryOperator::Multiply, token_id, hidden);
+    let src_idx = f.binary(BinaryOperator::Add, tok_off, col);
+    let tbl_ptr = f.global(gv_table);
+    let tbl_elem = f.index(tbl_ptr, src_idx);
+    let val = f.load(tbl_elem);
+
+    let dst_ptr = f.global(gv_dst);
+    let dst_elem = f.index(dst_ptr, i);
+
+    f.emit(row, val);
+    f.emit(dst_elem, dst_elem);
+    f.f.body.push(f.store(dst_elem, val), S);
+
+    b.entry_point("main", [256, 1, 1], f.finish());
+    b.finish()
+}
+
+// ---------------------------------------------------------------------------
+// rope.wgsl: Rotary position embeddings
+// For each position pos and pair (2i, 2i+1):
+//   cos_t = cos(pos * theta^(-2i/dim))
+//   sin_t = sin(pos * theta^(-2i/dim))
+//   out[2i]   = x[2i]*cos_t - x[2i+1]*sin_t
+//   out[2i+1] = x[2i]*sin_t + x[2i+1]*cos_t
+// ---------------------------------------------------------------------------
+
+fn gen_rope() -> Module {
+    let mut b = Builder::new();
+    // params: seq, dim, theta_bits, _pad
+    let ty_params = b.params_u32x4("Params", &["seq", "dim", "theta_bits", "_pad"]);
+    let gv_src = b.storage_ro("src");
+    let gv_dst = b.storage_rw("dst");
+    let gv_params = b.uniform("params", ty_params);
+
+    let mut f = FnBuilder::new(&b);
+    let gid = f.arg_gid();
+    let i = f.vec_x(gid);
+    f.label("i", i);
+    f.emit(i, i);
+
+    let params_ptr = f.global(gv_params);
+    let seq_ptr = f.field(params_ptr, 0);
+    let seq = f.load(seq_ptr);
+    let dim_ptr = f.field(params_ptr, 1);
+    let dim = f.load(dim_ptr);
+    let theta_ptr = f.field(params_ptr, 2);
+    let theta_bits = f.load(theta_ptr);
+    let theta = f.expr(Expression::As {
+        expr: theta_bits,
+        kind: ScalarKind::Float,
+        convert: None, // bitcast
+    });
+    f.emit(params_ptr, theta);
+
+    // half_dim = dim / 2
+    let two_u = f.literal_u32(2);
+    let half_dim = f.binary(BinaryOperator::Divide, dim, two_u);
+    let total = f.binary(BinaryOperator::Multiply, seq, half_dim);
+    let cond = f.binary(BinaryOperator::GreaterEqual, i, total);
+    f.emit(two_u, cond);
+    f.f.body.push(f.if_return(cond), S);
+
+    // pos = i / half_dim, pair_idx = i % half_dim
+    let pos = f.binary(BinaryOperator::Divide, i, half_dim);
+    let pair_idx = f.binary(BinaryOperator::Modulo, i, half_dim);
+
+    // freq = pos * pow(theta, -2.0 * pair_idx / dim)
+    let two_f = f.literal_f32(2.0);
+    let pair_f = f.cast_f32(pair_idx);
+    let dim_f = f.cast_f32(dim);
+    let exponent = f.binary(BinaryOperator::Multiply, two_f, pair_f);
+    let exponent = f.binary(BinaryOperator::Divide, exponent, dim_f);
+    let exponent = f.unary(UnaryOperator::Negate, exponent);
+    let inv_freq = f.math2(MathFunction::Pow, theta, exponent);
+    let pos_f = f.cast_f32(pos);
+    let angle = f.binary(BinaryOperator::Multiply, pos_f, inv_freq);
+
+    let cos_val = f.math1(MathFunction::Cos, angle);
+    let sin_val = f.math1(MathFunction::Sin, angle);
+
+    // src indices: base = pos * dim + pair_idx * 2
+    let pos_dim = f.binary(BinaryOperator::Multiply, pos, dim);
+    let pair2 = f.binary(BinaryOperator::Multiply, pair_idx, two_u);
+    let idx0 = f.binary(BinaryOperator::Add, pos_dim, pair2);
+    let one_u = f.literal_u32(1);
+    let idx1 = f.binary(BinaryOperator::Add, idx0, one_u);
+
+    let src_ptr = f.global(gv_src);
+    let s0 = f.index(src_ptr, idx0);
+    let v0 = f.load(s0);
+    let s1 = f.index(src_ptr, idx1);
+    let v1 = f.load(s1);
+
+    // out[idx0] = v0 * cos - v1 * sin
+    let v0_cos = f.binary(BinaryOperator::Multiply, v0, cos_val);
+    let v1_sin = f.binary(BinaryOperator::Multiply, v1, sin_val);
+    let r0 = f.binary(BinaryOperator::Subtract, v0_cos, v1_sin);
+
+    // out[idx1] = v0 * sin + v1 * cos
+    let v0_sin = f.binary(BinaryOperator::Multiply, v0, sin_val);
+    let v1_cos = f.binary(BinaryOperator::Multiply, v1, cos_val);
+    let r1 = f.binary(BinaryOperator::Add, v0_sin, v1_cos);
+
+    let dst_ptr = f.global(gv_dst);
+    let d0 = f.index(dst_ptr, idx0);
+    let d1 = f.index(dst_ptr, idx1);
+
+    f.emit(pos, r1);
+    f.emit(d0, d1);
+    f.f.body.push(f.store(d0, r0), S);
+    f.f.body.push(f.store(d1, r1), S);
+
+    b.entry_point("main", [256, 1, 1], f.finish());
+    b.finish()
+}
+
+// ---------------------------------------------------------------------------
+// causal_attention.wgsl: Fused multi-head causal attention with GQA
+// One workgroup per (position, head) pair.
+// params: seq, num_heads, num_kv_heads, head_dim
+// inputs: q[seq, num_heads*head_dim], k[seq, num_kv_heads*head_dim], v[seq, ...]
+// output: [seq, num_heads*head_dim]
+// ---------------------------------------------------------------------------
+
+fn gen_causal_attention() -> Module {
+    let mut b = Builder::new();
+    let ty_params = b.params_u32x4("Params", &["seq", "num_heads", "num_kv_heads", "head_dim"]);
+    let gv_q = b.storage_ro("src_a"); // q
+    let gv_k = b.storage_ro("src_b"); // k
+    let gv_v = b.storage_ro("bias");  // v (reusing binding slot name)
+    let gv_dst = b.storage_rw("dst");
+    let gv_params = b.uniform("params", ty_params);
+
+    let mut f = FnBuilder::new(&b);
+    let gid = f.arg_gid();
+
+    // pos = gid.x, head = gid.y
+    let pos = f.vec_x(gid);
+    f.label("pos", pos);
+    let head = f.vec_y(gid);
+    f.label("head", head);
+    f.emit(pos, head);
+
+    let params_ptr = f.global(gv_params);
+    let seq_ptr = f.field(params_ptr, 0);
+    let seq = f.load(seq_ptr);
+    let nh_ptr = f.field(params_ptr, 1);
+    let num_heads = f.load(nh_ptr);
+    let nkv_ptr = f.field(params_ptr, 2);
+    let num_kv_heads = f.load(nkv_ptr);
+    let hd_ptr = f.field(params_ptr, 3);
+    let head_dim = f.load(hd_ptr);
+    f.emit(params_ptr, head_dim);
+
+    // Bounds check
+    let cond_pos = f.binary(BinaryOperator::GreaterEqual, pos, seq);
+    let cond_head = f.binary(BinaryOperator::GreaterEqual, head, num_heads);
+    let cond = f.binary(BinaryOperator::LogicalOr, cond_pos, cond_head);
+    f.emit(cond_pos, cond);
+    f.f.body.push(f.if_return(cond), S);
+
+    // GQA: kv_head = head / (num_heads / num_kv_heads)
+    let heads_per_kv = f.binary(BinaryOperator::Divide, num_heads, num_kv_heads);
+    let kv_head = f.binary(BinaryOperator::Divide, head, heads_per_kv);
+
+    // q_dim = num_heads * head_dim
+    let q_dim = f.binary(BinaryOperator::Multiply, num_heads, head_dim);
+    // kv_dim = num_kv_heads * head_dim
+    let kv_dim = f.binary(BinaryOperator::Multiply, num_kv_heads, head_dim);
+
+    // q_base = pos * q_dim + head * head_dim
+    let pos_q = f.binary(BinaryOperator::Multiply, pos, q_dim);
+    let head_off = f.binary(BinaryOperator::Multiply, head, head_dim);
+    let q_base = f.binary(BinaryOperator::Add, pos_q, head_off);
+
+    // scale = 1.0 / sqrt(head_dim)
+    let hd_f = f.cast_f32(head_dim);
+    let scale = f.math1(MathFunction::InverseSqrt, hd_f);
+
+    // causal_len = pos + 1
+    let one_cl = f.literal_u32(1);
+    let causal_len = f.binary(BinaryOperator::Add, pos, one_cl);
+
+    f.emit(heads_per_kv, causal_len);
+
+    // Store key values in local vars so inner scopes can load them fresh
+    let q_base_var = f.local_var("q_base", b.ty_u32, None);
+    let q_base_ptr = f.local_ptr(q_base_var);
+    f.f.body.push(f.store(q_base_ptr, q_base), S);
+
+    let kv_head_var = f.local_var("kv_head", b.ty_u32, None);
+    let kv_head_ptr = f.local_ptr(kv_head_var);
+    f.f.body.push(f.store(kv_head_ptr, kv_head), S);
+
+    let kv_dim_var = f.local_var("kv_dim", b.ty_u32, None);
+    let kv_dim_ptr = f.local_ptr(kv_dim_var);
+    f.f.body.push(f.store(kv_dim_ptr, kv_dim), S);
+
+    let head_dim_var = f.local_var("hd", b.ty_u32, None);
+    let head_dim_ptr = f.local_ptr(head_dim_var);
+    f.f.body.push(f.store(head_dim_ptr, head_dim), S);
+
+    let scale_var = f.local_var("scale", b.ty_f32, None);
+    let scale_ptr = f.local_ptr(scale_var);
+    f.f.body.push(f.store(scale_ptr, scale), S);
+
+    let causal_var = f.local_var("clen", b.ty_u32, None);
+    let causal_ptr = f.local_ptr(causal_var);
+    f.f.body.push(f.store(causal_ptr, causal_len), S);
+
+    let pos_q_var = f.local_var("pos_q", b.ty_u32, None);
+    let pos_q_ptr = f.local_ptr(pos_q_var);
+    f.f.body.push(f.store(pos_q_ptr, pos_q), S);
+
+    let head_off_var = f.local_var("head_off", b.ty_u32, None);
+    let head_off_ptr = f.local_ptr(head_off_var);
+    f.f.body.push(f.store(head_off_ptr, head_off), S);
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_dot_loop(
+        f: &mut FnBuilder,
+        parent: &mut Block,
+        gv_q: Handle<GlobalVariable>,
+        gv_k: Handle<GlobalVariable>,
+        q_base_ptr: Handle<Expression>,
+        head_dim_ptr: Handle<Expression>,
+        k_base: Handle<Expression>,  // already in scope of parent
+        dot_ptr: Handle<Expression>,
+        ty_u32: Handle<Type>,
+        d_name: &str,
+    ) {
+        let d_var = f.local_var(d_name, ty_u32, None);
+        let d_ptr = f.local_ptr(d_var);
+        let zero_d = f.literal_u32(0);
+        push_emit(&f.f.expressions, parent, zero_d, zero_d);
+        parent.push(f.store(d_ptr, zero_d), S);
+
+        let mut inner = Block::new();
+        let d = f.load(d_ptr);
+        let hd = f.load(head_dim_ptr);
+        let dbrk = f.binary(BinaryOperator::GreaterEqual, d, hd);
+
+        let qb = f.load(q_base_ptr);
+        let q_idx = f.binary(BinaryOperator::Add, qb, d);
+        let q_gp = f.global(gv_q);
+        let q_elem = f.index(q_gp, q_idx);
+        let q_val = f.load(q_elem);
+
+        let k_idx = f.binary(BinaryOperator::Add, k_base, d);
+        let k_gp = f.global(gv_k);
+        let k_elem = f.index(k_gp, k_idx);
+        let k_val = f.load(k_elem);
+
+        let prod = f.binary(BinaryOperator::Multiply, q_val, k_val);
+        let old_dot = f.load(dot_ptr);
+        let new_dot = f.binary(BinaryOperator::Add, old_dot, prod);
+        push_emit(&f.f.expressions, &mut inner, d, new_dot);
+        inner.push(f.store(dot_ptr, new_dot), S);
+
+        let one_d = f.literal_u32(1);
+        let d2 = f.load(d_ptr);
+        let dn = f.binary(BinaryOperator::Add, d2, one_d);
+        push_emit(&f.f.expressions, &mut inner, one_d, dn);
+        inner.push(f.store(d_ptr, dn), S);
+
+        parent.push(
+            Statement::Loop {
+                body: inner,
+                continuing: Block::new(),
+                break_if: Some(dbrk),
+            },
+            S,
+        );
+    }
+
+    // Helper: compute k_base = t * kv_dim + kv_head * head_dim, emit into block
+    fn compute_k_base(
+        f: &mut FnBuilder,
+        block: &mut Block,
+        t: Handle<Expression>,
+        kv_dim_ptr: Handle<Expression>,
+        kv_head_ptr: Handle<Expression>,
+        head_dim_ptr: Handle<Expression>,
+    ) -> Handle<Expression> {
+        let kvd = f.load(kv_dim_ptr);
+        let t_kv = f.binary(BinaryOperator::Multiply, t, kvd);
+        let kvh = f.load(kv_head_ptr);
+        let hd = f.load(head_dim_ptr);
+        let kvh_off = f.binary(BinaryOperator::Multiply, kvh, hd);
+        let k_base = f.binary(BinaryOperator::Add, t_kv, kvh_off);
+        push_emit(&f.f.expressions, block, kvd, k_base);
+        k_base
+    }
+
+    // === Pass 1: find max score ===
+    let max_var = f.local_var("max_score", b.ty_f32, None);
+    let max_ptr = f.local_ptr(max_var);
+    let neg_inf = f.literal_f32(-1.0e30);
+    f.emit(neg_inf, neg_inf);
+    f.f.body.push(f.store(max_ptr, neg_inf), S);
+
+    let t_var = f.local_var("t", b.ty_u32, None);
+    let t_ptr = f.local_ptr(t_var);
+    let zero_u = f.literal_u32(0);
+    f.emit(zero_u, zero_u);
+    f.f.body.push(f.store(t_ptr, zero_u), S);
+
+    {
+        let mut body = Block::new();
+        let t = f.load(t_ptr);
+        let cl = f.load(causal_ptr);
+        let brk = f.binary(BinaryOperator::GreaterEqual, t, cl);
+
+        let dot_var = f.local_var("dot", b.ty_f32, None);
+        let dot_ptr = f.local_ptr(dot_var);
+        let zero_f = f.literal_f32(0.0);
+        push_emit(&f.f.expressions, &mut body, t, zero_f);
+        body.push(f.store(dot_ptr, zero_f), S);
+
+        let k_base = compute_k_base(
+            &mut f, &mut body, t, kv_dim_ptr, kv_head_ptr, head_dim_ptr,
+        );
+
+        build_dot_loop(
+            &mut f, &mut body, gv_q, gv_k,
+            q_base_ptr, head_dim_ptr, k_base, dot_ptr,
+            b.ty_u32, "d1",
+        );
+
+        // score = dot * scale; max_score = max(max_score, score)
+        let dot_val = f.load(dot_ptr);
+        let sc = f.load(scale_ptr);
+        let score = f.binary(BinaryOperator::Multiply, dot_val, sc);
+        let old_max = f.load(max_ptr);
+        let new_max = f.math2(MathFunction::Max, old_max, score);
+        push_emit(&f.f.expressions, &mut body, dot_val, new_max);
+        body.push(f.store(max_ptr, new_max), S);
+
+        let one_t = f.literal_u32(1);
+        let t2 = f.load(t_ptr);
+        let tn = f.binary(BinaryOperator::Add, t2, one_t);
+        push_emit(&f.f.expressions, &mut body, one_t, tn);
+        body.push(f.store(t_ptr, tn), S);
+
+        f.f.body.push(
+            Statement::Loop {
+                body,
+                continuing: Block::new(),
+                break_if: Some(brk),
+            },
+            S,
+        );
+    }
+
+    // === Pass 2: compute exp sum ===
+    let sum_var = f.local_var("sum_exp", b.ty_f32, None);
+    let sum_ptr_local = f.local_ptr(sum_var);
+    let zero_f2 = f.literal_f32(0.0);
+    f.emit(zero_f2, zero_f2);
+    f.f.body.push(f.store(sum_ptr_local, zero_f2), S);
+
+    let t2_var = f.local_var("t2", b.ty_u32, None);
+    let t2_ptr = f.local_ptr(t2_var);
+    let zero_t2 = f.literal_u32(0);
+    f.emit(zero_t2, zero_t2);
+    f.f.body.push(f.store(t2_ptr, zero_t2), S);
+
+    {
+        let mut body = Block::new();
+        let t = f.load(t2_ptr);
+        let cl = f.load(causal_ptr);
+        let brk = f.binary(BinaryOperator::GreaterEqual, t, cl);
+
+        let dot_var2 = f.local_var("dot2", b.ty_f32, None);
+        let dot_ptr2 = f.local_ptr(dot_var2);
+        let zero_f3 = f.literal_f32(0.0);
+        push_emit(&f.f.expressions, &mut body, t, zero_f3);
+        body.push(f.store(dot_ptr2, zero_f3), S);
+
+        let k_base = compute_k_base(
+            &mut f, &mut body, t, kv_dim_ptr, kv_head_ptr, head_dim_ptr,
+        );
+
+        build_dot_loop(
+            &mut f, &mut body, gv_q, gv_k,
+            q_base_ptr, head_dim_ptr, k_base, dot_ptr2,
+            b.ty_u32, "d2",
+        );
+
+        let dot_val = f.load(dot_ptr2);
+        let sc = f.load(scale_ptr);
+        let score = f.binary(BinaryOperator::Multiply, dot_val, sc);
+        let mx = f.load(max_ptr);
+        let shifted = f.binary(BinaryOperator::Subtract, score, mx);
+        let e = f.math1(MathFunction::Exp, shifted);
+        let old_sum = f.load(sum_ptr_local);
+        let new_sum = f.binary(BinaryOperator::Add, old_sum, e);
+        push_emit(&f.f.expressions, &mut body, dot_val, new_sum);
+        body.push(f.store(sum_ptr_local, new_sum), S);
+
+        let one_t = f.literal_u32(1);
+        let t3 = f.load(t2_ptr);
+        let tn = f.binary(BinaryOperator::Add, t3, one_t);
+        push_emit(&f.f.expressions, &mut body, one_t, tn);
+        body.push(f.store(t2_ptr, tn), S);
+
+        f.f.body.push(
+            Statement::Loop {
+                body,
+                continuing: Block::new(),
+                break_if: Some(brk),
+            },
+            S,
+        );
+    }
+
+    // === Pass 3: weighted sum of values ===
+    let d3_var = f.local_var("d3", b.ty_u32, None);
+    let d3_ptr = f.local_ptr(d3_var);
+    let zero_d3 = f.literal_u32(0);
+    f.emit(zero_d3, zero_d3);
+    f.f.body.push(f.store(d3_ptr, zero_d3), S);
+
+    {
+        let mut d_body = Block::new();
+        let d = f.load(d3_ptr);
+        let hd = f.load(head_dim_ptr);
+        let d_brk = f.binary(BinaryOperator::GreaterEqual, d, hd);
+
+        let acc_var = f.local_var("acc", b.ty_f32, None);
+        let acc_ptr = f.local_ptr(acc_var);
+        let zero_acc = f.literal_f32(0.0);
+        push_emit(&f.f.expressions, &mut d_body, d, zero_acc);
+        d_body.push(f.store(acc_ptr, zero_acc), S);
+
+        // Pre-compute output base index (pos_q + head_off) so we can use it after the inner loop
+        // without a wide emit range spanning inner-loop expressions
+        let pq = f.load(pos_q_ptr);
+        let ho = f.load(head_off_ptr);
+        let out_base = f.binary(BinaryOperator::Add, pq, ho);
+        // Store in local var to avoid cross-scope emit issues
+        let out_base_var = f.local_var("out_base", b.ty_u32, None);
+        let out_base_ptr = f.local_ptr(out_base_var);
+        push_emit(&f.f.expressions, &mut d_body, pq, out_base);
+        d_body.push(f.store(out_base_ptr, out_base), S);
+
+        let t3_var = f.local_var("t3", b.ty_u32, None);
+        let t3_iptr = f.local_ptr(t3_var);
+        let zero_t3 = f.literal_u32(0);
+        push_emit(&f.f.expressions, &mut d_body, zero_t3, zero_t3);
+        d_body.push(f.store(t3_iptr, zero_t3), S);
+
+        {
+            let mut t_body = Block::new();
+            let t = f.load(t3_iptr);
+            let cl = f.load(causal_ptr);
+            let t_brk = f.binary(BinaryOperator::GreaterEqual, t, cl);
+
+            // Recompute dot product for attention weight
+            let dot_var3 = f.local_var("dot3", b.ty_f32, None);
+            let dot_ptr3 = f.local_ptr(dot_var3);
+            let zero_dot = f.literal_f32(0.0);
+            push_emit(&f.f.expressions, &mut t_body, t, zero_dot);
+            t_body.push(f.store(dot_ptr3, zero_dot), S);
+
+            let k_base = compute_k_base(
+                &mut f, &mut t_body, t, kv_dim_ptr, kv_head_ptr, head_dim_ptr,
+            );
+
+            build_dot_loop(
+                &mut f, &mut t_body, gv_q, gv_k,
+                q_base_ptr, head_dim_ptr, k_base, dot_ptr3,
+                b.ty_u32, "d4",
+            );
+
+            // attn_weight = exp(score * scale - max) / sum_exp
+            let dot_val = f.load(dot_ptr3);
+            let sc = f.load(scale_ptr);
+            let score = f.binary(BinaryOperator::Multiply, dot_val, sc);
+            let mx = f.load(max_ptr);
+            let shifted = f.binary(BinaryOperator::Subtract, score, mx);
+            let e = f.math1(MathFunction::Exp, shifted);
+            let sum_val = f.load(sum_ptr_local);
+            let weight = f.binary(BinaryOperator::Divide, e, sum_val);
+
+            // v_val = v[k_base + d]
+            let v_idx = f.binary(BinaryOperator::Add, k_base, d);
+            let v_gp = f.global(gv_v);
+            let v_elem = f.index(v_gp, v_idx);
+            let v_val = f.load(v_elem);
+
+            let contrib = f.binary(BinaryOperator::Multiply, weight, v_val);
+            let old_acc = f.load(acc_ptr);
+            let new_acc = f.binary(BinaryOperator::Add, old_acc, contrib);
+            push_emit(&f.f.expressions, &mut t_body, dot_val, new_acc);
+            t_body.push(f.store(acc_ptr, new_acc), S);
+
+            let one_t = f.literal_u32(1);
+            let t4 = f.load(t3_iptr);
+            let tn = f.binary(BinaryOperator::Add, t4, one_t);
+            push_emit(&f.f.expressions, &mut t_body, one_t, tn);
+            t_body.push(f.store(t3_iptr, tn), S);
+
+            d_body.push(
+                Statement::Loop {
+                    body: t_body,
+                    continuing: Block::new(),
+                    break_if: Some(t_brk),
+                },
+                S,
+            );
+        }
+
+        // dst[out_base + d] = acc
+        let ob = f.load(out_base_ptr);
+        let out_idx = f.binary(BinaryOperator::Add, ob, d);
+        let dst_gp = f.global(gv_dst);
+        let dst_elem = f.index(dst_gp, out_idx);
+        let acc_val = f.load(acc_ptr);
+        // Single emit range covers ob through acc_val (dst_gp is pre-emit/skipped)
+        push_emit(&f.f.expressions, &mut d_body, ob, acc_val);
+        d_body.push(f.store(dst_elem, acc_val), S);
+
+        let one_d = f.literal_u32(1);
+        let d5 = f.load(d3_ptr);
+        let dn = f.binary(BinaryOperator::Add, d5, one_d);
+        push_emit(&f.f.expressions, &mut d_body, one_d, dn);
+        d_body.push(f.store(d3_ptr, dn), S);
+
+        f.f.body.push(
+            Statement::Loop {
+                body: d_body,
+                continuing: Block::new(),
+                break_if: Some(d_brk),
+            },
+            S,
+        );
+    }
+
+    b.entry_point("main", [1, 1, 1], f.finish());
+    b.finish()
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -1770,6 +2562,10 @@ mod tests {
             ShaderGroup::Reduce,
             ShaderGroup::Softmax,
             ShaderGroup::CrossEntropy,
+            ShaderGroup::RmsNorm,
+            ShaderGroup::Embedding,
+            ShaderGroup::RoPE,
+            ShaderGroup::CausalAttention,
         ];
 
         for group in &groups {
@@ -1787,6 +2583,7 @@ mod tests {
         assert!(names.contains(&"relu"), "missing relu");
         assert!(names.contains(&"sigmoid"), "missing sigmoid");
         assert!(names.contains(&"neg"), "missing neg");
+        assert!(names.contains(&"silu"), "missing silu");
 
         let m = generate_module(ShaderGroup::Binary);
         let names: Vec<&str> = m.entry_points.iter().map(|ep| ep.name.as_str()).collect();
@@ -1798,5 +2595,25 @@ mod tests {
         let names: Vec<&str> = m.entry_points.iter().map(|ep| ep.name.as_str()).collect();
         assert!(names.contains(&"sum_all"));
         assert!(names.contains(&"mean_all"));
+    }
+
+    #[test]
+    fn test_rms_norm_wgsl() {
+        let _ = generate_wgsl(ShaderGroup::RmsNorm);
+    }
+
+    #[test]
+    fn test_embedding_wgsl() {
+        let _ = generate_wgsl(ShaderGroup::Embedding);
+    }
+
+    #[test]
+    fn test_rope_wgsl() {
+        let _ = generate_wgsl(ShaderGroup::RoPE);
+    }
+
+    #[test]
+    fn test_causal_attention_wgsl() {
+        let _ = generate_wgsl(ShaderGroup::CausalAttention);
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -21,6 +21,11 @@ pub enum ShaderEntry {
     Softmax,
     CrossEntropyLoss,
     Transpose,
+    Silu,
+    RmsNorm,
+    Embedding,
+    RoPE,
+    CausalAttention,
 }
 
 impl ShaderEntry {
@@ -38,6 +43,11 @@ impl ShaderEntry {
             ShaderEntry::Softmax => ShaderGroup::Softmax,
             ShaderEntry::CrossEntropyLoss => ShaderGroup::CrossEntropy,
             ShaderEntry::Transpose => ShaderGroup::Transpose,
+            ShaderEntry::Silu => ShaderGroup::Unary,
+            ShaderEntry::RmsNorm => ShaderGroup::RmsNorm,
+            ShaderEntry::Embedding => ShaderGroup::Embedding,
+            ShaderEntry::RoPE => ShaderGroup::RoPE,
+            ShaderEntry::CausalAttention => ShaderGroup::CausalAttention,
         }
     }
 
@@ -59,6 +69,11 @@ impl ShaderEntry {
             ShaderEntry::Greater => "greater",
             ShaderEntry::SumAll => "sum_all",
             ShaderEntry::MeanAll => "mean_all",
+            ShaderEntry::Silu => "silu",
+            ShaderEntry::RmsNorm => "main",
+            ShaderEntry::Embedding => "main",
+            ShaderEntry::RoPE => "main",
+            ShaderEntry::CausalAttention => "main",
         }
     }
 }
@@ -357,6 +372,73 @@ impl<'a> Compiler<'a> {
                     input_buffers: vec![input],
                     output_buffer: out_buf,
                     params: vec![m, n, 0, 0],
+                });
+            }
+
+            Op::Silu => {
+                self.emit_unary(ShaderEntry::Silu, node, out_buf);
+            }
+
+            Op::RmsNorm { eps } => {
+                let x = self.get_buffer(node.inputs[0]);
+                let w = self.get_buffer(node.inputs[1]);
+                let shape = &self.graph.node(node.inputs[0]).ty.shape;
+                let rows = shape[0] as u32;
+                let cols = shape[1] as u32;
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::RmsNorm,
+                    workgroups: [ceil_div(rows, 256), 1, 1],
+                    input_buffers: vec![x, w],
+                    output_buffer: out_buf,
+                    params: vec![rows, cols, eps.to_bits(), 0],
+                });
+            }
+
+            Op::Embedding => {
+                let indices = self.get_buffer(node.inputs[0]);
+                let table = self.get_buffer(node.inputs[1]);
+                let idx_shape = &self.graph.node(node.inputs[0]).ty.shape;
+                let tbl_shape = &self.graph.node(node.inputs[1]).ty.shape;
+                let seq = idx_shape[0] as u32;
+                let hidden = tbl_shape[1] as u32;
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::Embedding,
+                    workgroups: [ceil_div(seq * hidden, 256), 1, 1],
+                    input_buffers: vec![indices, table],
+                    output_buffer: out_buf,
+                    params: vec![seq, hidden, 0, 0],
+                });
+            }
+
+            Op::RoPE { theta } => {
+                let input = self.get_buffer(node.inputs[0]);
+                let shape = &self.graph.node(node.inputs[0]).ty.shape;
+                let seq = shape[0] as u32;
+                let dim = shape[1] as u32;
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::RoPE,
+                    workgroups: [ceil_div(seq * dim / 2, 256), 1, 1],
+                    input_buffers: vec![input],
+                    output_buffer: out_buf,
+                    params: vec![seq, dim, theta.to_bits(), 0],
+                });
+            }
+
+            Op::CausalAttention {
+                num_heads,
+                num_kv_heads,
+                head_dim,
+            } => {
+                let q = self.get_buffer(node.inputs[0]);
+                let k = self.get_buffer(node.inputs[1]);
+                let v = self.get_buffer(node.inputs[2]);
+                let seq = self.graph.node(node.inputs[0]).ty.shape[0] as u32;
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::CausalAttention,
+                    workgroups: [ceil_div(seq, 1), num_heads, 1],
+                    input_buffers: vec![q, k, v],
+                    output_buffer: out_buf,
+                    params: vec![seq, num_heads, num_kv_heads, head_dim],
                 });
             }
         }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -3,7 +3,7 @@
 //! Provides a [`DataLoader`] that yields mini-batches from an in-memory
 //! dataset, and an [`MnistDataset`] that reads the standard IDX file format.
 
-pub mod huggingface;
+pub mod safetensors;
 pub mod mnist;
 
 pub use mnist::MnistDataset;

--- a/src/data/safetensors.rs
+++ b/src/data/safetensors.rs
@@ -1,14 +1,14 @@
-//! HuggingFace Hub integration for loading pre-trained models.
+//! Safetensors model weight loading.
 //!
-//! Downloads safetensors model weights from the HuggingFace Hub and
-//! provides them as named tensors that can be loaded into a [`Session`].
+//! Loads named tensors from `.safetensors` files (local or downloaded from
+//! the HuggingFace Hub) into f32 data that can be uploaded to a [`Session`].
 //!
 //! # Example
 //!
 //! ```no_run
-//! use meganeura::data::huggingface::HfModel;
+//! use meganeura::data::safetensors::SafeTensorsModel;
 //!
-//! let model = HfModel::download("dacorvo/mnist-mlp").unwrap();
+//! let model = SafeTensorsModel::download("dacorvo/mnist-mlp").unwrap();
 //! for (name, info) in model.tensor_info() {
 //!     println!("{}: shape={:?}", name, info.shape);
 //! }
@@ -26,15 +26,16 @@ pub struct TensorInfo {
     pub dtype: safetensors::Dtype,
 }
 
-/// A downloaded HuggingFace model with parsed safetensors weights.
-pub struct HfModel {
+/// Parsed safetensors weights, loaded from a local file or downloaded
+/// from the HuggingFace Hub.
+pub struct SafeTensorsModel {
     /// Raw bytes of the safetensors file (kept alive for zero-copy access).
     data: Vec<u8>,
     /// Cached tensor metadata.
     info: HashMap<String, TensorInfo>,
 }
 
-impl HfModel {
+impl SafeTensorsModel {
     /// Download a model from HuggingFace Hub by repository ID.
     ///
     /// Downloads `model.safetensors` from the given repo (e.g. `"dacorvo/mnist-mlp"`).
@@ -107,6 +108,75 @@ impl HfModel {
             .collect();
 
         Ok(floats)
+    }
+
+    /// Read a tensor as f32 data, auto-converting from BF16 if necessary.
+    ///
+    /// Supports F32 (direct) and BF16 (converted). Other dtypes return an error.
+    pub fn tensor_f32_auto(&self, name: &str) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+        let tensors = SafeTensors::deserialize(&self.data)?;
+        let view = tensors
+            .tensor(name)
+            .map_err(|e| format!("tensor '{}': {}", name, e))?;
+
+        match view.dtype() {
+            safetensors::Dtype::F32 => {
+                let bytes = view.data();
+                let floats: Vec<f32> = bytes
+                    .chunks_exact(4)
+                    .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                    .collect();
+                Ok(floats)
+            }
+            safetensors::Dtype::BF16 => {
+                let bytes = view.data();
+                let floats: Vec<f32> = bytes
+                    .chunks_exact(2)
+                    .map(|chunk| {
+                        let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
+                        // BF16 → F32: just shift left by 16 bits
+                        f32::from_bits((bits as u32) << 16)
+                    })
+                    .collect();
+                Ok(floats)
+            }
+            other => Err(format!(
+                "tensor '{}' has dtype {:?}, expected F32 or BF16",
+                name, other
+            )
+            .into()),
+        }
+    }
+
+    /// Read a tensor as f32 and transpose, auto-converting from BF16 if necessary.
+    pub fn tensor_f32_auto_transposed(
+        &self,
+        name: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+        let info = self
+            .info
+            .get(name)
+            .ok_or_else(|| format!("tensor '{}' not found", name))?;
+
+        if info.shape.len() != 2 {
+            return Err(format!(
+                "tensor '{}' has {} dims, expected 2 for transpose",
+                name,
+                info.shape.len()
+            )
+            .into());
+        }
+
+        let data = self.tensor_f32_auto(name)?;
+        let rows = info.shape[0];
+        let cols = info.shape[1];
+        let mut transposed = vec![0.0_f32; rows * cols];
+        for r in 0..rows {
+            for c in 0..cols {
+                transposed[c * rows + r] = data[r * cols + c];
+            }
+        }
+        Ok(transposed)
     }
 
     /// Read a tensor as f32 and transpose it from (rows, cols) to (cols, rows).

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5,12 +5,14 @@ pub type NodeId = u32;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum DType {
     F32,
+    U32,
 }
 
 impl DType {
     pub fn size_bytes(self) -> usize {
         match self {
             DType::F32 => 4,
+            DType::U32 => 4,
         }
     }
 }
@@ -92,6 +94,31 @@ pub enum Op {
 
     // Log-softmax (for numerical stability)
     LogSoftmax,
+
+    // --- Transformer ops ---
+
+    // SiLU activation: x * sigmoid(x)
+    Silu,
+
+    // RMSNorm: x / sqrt(mean(x²) + eps) * weight
+    // inputs: [x, weight], eps stored as f32 bits in params
+    RmsNorm { eps: f32 },
+
+    // Embedding lookup: indices → table rows
+    // inputs: [indices (U32), table (F32)]
+    Embedding,
+
+    // Rotary position embeddings
+    // inputs: [x], params encode theta
+    RoPE { theta: f32 },
+
+    // Fused causal multi-head attention with GQA
+    // inputs: [q, k, v] as 2D: q=[seq, num_heads*head_dim], k/v=[seq, num_kv_heads*head_dim]
+    CausalAttention {
+        num_heads: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -271,6 +298,87 @@ impl Graph {
     pub fn log_softmax(&mut self, x: NodeId) -> NodeId {
         let ty = self.node(x).ty.clone();
         self.add_node(Op::LogSoftmax, vec![x], ty)
+    }
+
+    // --- Transformer ops ---
+
+    pub fn silu(&mut self, x: NodeId) -> NodeId {
+        let ty = self.node(x).ty.clone();
+        self.add_node(Op::Silu, vec![x], ty)
+    }
+
+    pub fn rms_norm(&mut self, x: NodeId, weight: NodeId, eps: f32) -> NodeId {
+        let x_shape = &self.node(x).ty.shape;
+        let w_shape = &self.node(weight).ty.shape;
+        assert_eq!(x_shape.len(), 2, "rms_norm requires 2D input");
+        assert_eq!(w_shape.len(), 1, "rms_norm weight must be 1D");
+        assert_eq!(x_shape[1], w_shape[0], "rms_norm weight size must match last dim");
+        let ty = self.node(x).ty.clone();
+        self.add_node(Op::RmsNorm { eps }, vec![x, weight], ty)
+    }
+
+    pub fn input_u32(&mut self, name: &str, shape: &[usize]) -> NodeId {
+        let ty = TensorType::new(shape.to_vec(), DType::U32);
+        self.add_node(
+            Op::Input {
+                name: name.to_string(),
+            },
+            vec![],
+            ty,
+        )
+    }
+
+    pub fn embedding(&mut self, indices: NodeId, table: NodeId) -> NodeId {
+        let idx_shape = &self.node(indices).ty.shape;
+        let tbl_shape = &self.node(table).ty.shape;
+        assert_eq!(self.node(indices).ty.dtype, DType::U32, "embedding indices must be U32");
+        assert_eq!(idx_shape.len(), 1, "embedding indices must be 1D");
+        assert_eq!(tbl_shape.len(), 2, "embedding table must be 2D");
+        let seq_len = idx_shape[0];
+        let hidden = tbl_shape[1];
+        let ty = TensorType::f32(vec![seq_len, hidden]);
+        self.add_node(Op::Embedding, vec![indices, table], ty)
+    }
+
+    pub fn rope(&mut self, x: NodeId, theta: f32) -> NodeId {
+        let x_shape = &self.node(x).ty.shape;
+        assert_eq!(x_shape.len(), 2, "rope requires 2D input");
+        assert_eq!(x_shape[1] % 2, 0, "rope requires even last dim");
+        let ty = self.node(x).ty.clone();
+        self.add_node(Op::RoPE { theta }, vec![x], ty)
+    }
+
+    pub fn causal_attention(
+        &mut self,
+        q: NodeId,
+        k: NodeId,
+        v: NodeId,
+        num_heads: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
+    ) -> NodeId {
+        let q_shape = &self.node(q).ty.shape;
+        let k_shape = &self.node(k).ty.shape;
+        let v_shape = &self.node(v).ty.shape;
+        assert_eq!(q_shape.len(), 2, "q must be 2D");
+        assert_eq!(k_shape.len(), 2, "k must be 2D");
+        assert_eq!(v_shape.len(), 2, "v must be 2D");
+        let seq = q_shape[0];
+        assert_eq!(q_shape[1], (num_heads * head_dim) as usize, "q dim mismatch");
+        assert_eq!(k_shape[0], seq, "k seq must match q seq");
+        assert_eq!(k_shape[1], (num_kv_heads * head_dim) as usize, "k dim mismatch");
+        assert_eq!(v_shape[0], seq, "v seq must match q seq");
+        assert_eq!(v_shape[1], (num_kv_heads * head_dim) as usize, "v dim mismatch");
+        let ty = TensorType::f32(vec![seq, (num_heads * head_dim) as usize]);
+        self.add_node(
+            Op::CausalAttention {
+                num_heads,
+                num_kv_heads,
+                head_dim,
+            },
+            vec![q, k, v],
+            ty,
+        )
     }
 
     // --- Loss ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod codegen;
 pub mod compile;
 pub mod data;
 pub mod graph;
+pub mod models;
 pub mod optimize;
 pub mod runtime;
 pub mod train;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod smollm2;

--- a/src/models/smollm2.rs
+++ b/src/models/smollm2.rs
@@ -1,0 +1,179 @@
+//! SmolLM2 model definition for meganeura.
+//!
+//! Builds the computation graph for SmolLM2-135M inference.
+//! Architecture: decoder-only transformer with GQA, RoPE, RMSNorm, SwiGLU.
+
+use crate::graph::{Graph, NodeId};
+
+pub struct SmolLM2Config {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: u32,
+    pub num_key_value_heads: u32,
+    pub intermediate_size: usize,
+    pub rms_norm_eps: f32,
+    pub rope_theta: f32,
+}
+
+impl SmolLM2Config {
+    /// SmolLM2-135M configuration.
+    pub fn smollm2_135m() -> Self {
+        Self {
+            vocab_size: 49152,
+            hidden_size: 576,
+            num_hidden_layers: 30,
+            num_attention_heads: 9,
+            num_key_value_heads: 3,
+            intermediate_size: 1536,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+        }
+    }
+
+    pub fn head_dim(&self) -> u32 {
+        self.hidden_size as u32 / self.num_attention_heads
+    }
+
+    pub fn kv_dim(&self) -> usize {
+        self.num_key_value_heads as usize * self.head_dim() as usize
+    }
+}
+
+/// Build the SmolLM2 inference graph.
+///
+/// Returns the logits output node ID. The graph expects:
+/// - Input "token_ids": U32 tensor of shape `[seq_len]`
+/// - Parameters named following the safetensors convention:
+///   `model.embed_tokens.weight`, `model.layers.{i}.input_layernorm.weight`, etc.
+pub fn build_graph(g: &mut Graph, config: &SmolLM2Config, seq_len: usize) -> NodeId {
+    let hidden = config.hidden_size;
+    let kv_dim = config.kv_dim();
+    let ffn = config.intermediate_size;
+    let eps = config.rms_norm_eps;
+    let theta = config.rope_theta;
+
+    // Token embedding
+    let token_ids = g.input_u32("token_ids", &[seq_len]);
+    let embed_weight = g.parameter("model.embed_tokens.weight", &[config.vocab_size, hidden]);
+    let mut x = g.embedding(token_ids, embed_weight);
+
+    // Transformer layers
+    for i in 0..config.num_hidden_layers {
+        let prefix = format!("model.layers.{}", i);
+
+        // Pre-attention RMSNorm
+        let ln1_w = g.parameter(&format!("{}.input_layernorm.weight", prefix), &[hidden]);
+        let h = g.rms_norm(x, ln1_w, eps);
+
+        // QKV projections (weights are [out, in] in HF, we transpose during loading)
+        let wq = g.parameter(
+            &format!("{}.self_attn.q_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let wk = g.parameter(
+            &format!("{}.self_attn.k_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+        let wv = g.parameter(
+            &format!("{}.self_attn.v_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+
+        let q = g.matmul(h, wq); // [seq, hidden]
+        let k = g.matmul(h, wk); // [seq, kv_dim]
+        let v = g.matmul(h, wv); // [seq, kv_dim]
+
+        // RoPE
+        let q = g.rope(q, theta);
+        let k = g.rope(k, theta);
+
+        // Causal attention with GQA
+        let attn = g.causal_attention(
+            q,
+            k,
+            v,
+            config.num_attention_heads,
+            config.num_key_value_heads,
+            config.head_dim(),
+        );
+
+        // Output projection
+        let wo = g.parameter(
+            &format!("{}.self_attn.o_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let attn_out = g.matmul(attn, wo);
+
+        // Residual connection
+        x = g.add(x, attn_out);
+
+        // Post-attention RMSNorm
+        let ln2_w = g.parameter(
+            &format!("{}.post_attention_layernorm.weight", prefix),
+            &[hidden],
+        );
+        let h = g.rms_norm(x, ln2_w, eps);
+
+        // SwiGLU FFN
+        let w_gate = g.parameter(&format!("{}.mlp.gate_proj.weight", prefix), &[hidden, ffn]);
+        let w_up = g.parameter(&format!("{}.mlp.up_proj.weight", prefix), &[hidden, ffn]);
+        let w_down = g.parameter(&format!("{}.mlp.down_proj.weight", prefix), &[ffn, hidden]);
+
+        let gate = g.matmul(h, w_gate); // [seq, ffn]
+        let gate = g.silu(gate);
+        let up = g.matmul(h, w_up); // [seq, ffn]
+        let ffn_out = g.mul(gate, up);
+        let ffn_out = g.matmul(ffn_out, w_down); // [seq, hidden]
+
+        // Residual connection
+        x = g.add(x, ffn_out);
+    }
+
+    // Final RMSNorm
+    let final_ln_w = g.parameter("model.norm.weight", &[hidden]);
+    x = g.rms_norm(x, final_ln_w, eps);
+
+    // LM head (often tied to embed_tokens, loaded separately)
+    let lm_head = g.parameter("lm_head.weight", &[hidden, config.vocab_size]);
+    g.matmul(x, lm_head) // [seq, vocab]
+}
+
+/// Get all weight parameter names for SmolLM2.
+pub fn weight_names(config: &SmolLM2Config) -> Vec<String> {
+    let mut names = Vec::new();
+    names.push("model.embed_tokens.weight".to_string());
+
+    for i in 0..config.num_hidden_layers {
+        let p = format!("model.layers.{}", i);
+        names.push(format!("{}.input_layernorm.weight", p));
+        names.push(format!("{}.self_attn.q_proj.weight", p));
+        names.push(format!("{}.self_attn.k_proj.weight", p));
+        names.push(format!("{}.self_attn.v_proj.weight", p));
+        names.push(format!("{}.self_attn.o_proj.weight", p));
+        names.push(format!("{}.post_attention_layernorm.weight", p));
+        names.push(format!("{}.mlp.gate_proj.weight", p));
+        names.push(format!("{}.mlp.up_proj.weight", p));
+        names.push(format!("{}.mlp.down_proj.weight", p));
+    }
+
+    names.push("model.norm.weight".to_string());
+    names.push("lm_head.weight".to_string());
+    names
+}
+
+/// Names of weight tensors that need transposing (linear layer weights).
+pub fn transposed_weight_names(config: &SmolLM2Config) -> Vec<String> {
+    let mut names = Vec::new();
+    for i in 0..config.num_hidden_layers {
+        let p = format!("model.layers.{}", i);
+        names.push(format!("{}.self_attn.q_proj.weight", p));
+        names.push(format!("{}.self_attn.k_proj.weight", p));
+        names.push(format!("{}.self_attn.v_proj.weight", p));
+        names.push(format!("{}.self_attn.o_proj.weight", p));
+        names.push(format!("{}.mlp.gate_proj.weight", p));
+        names.push(format!("{}.mlp.up_proj.weight", p));
+        names.push(format!("{}.mlp.down_proj.weight", p));
+    }
+    names
+}

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -182,6 +182,12 @@ fn graph_to_egglog(graph: &Graph) -> String {
   ; Fused ops
   (FusedMatMulRelu Op Op)
   (FusedMatMulBiasRelu Op Op Op)
+  ; Transformer ops (passthrough, no fusion rules)
+  (Silu Op)
+  (RmsNorm Op Op)
+  (Embedding Op Op)
+  (RoPE Op)
+  (CausalAttention Op Op Op)
 )
 
 ",
@@ -245,6 +251,14 @@ fn node_to_egglog_expr(node: &Node) -> String {
         }
         Op::FusedMatMulBiasRelu => format!(
             "(FusedMatMulBiasRelu n{} n{} n{})",
+            node.inputs[0], node.inputs[1], node.inputs[2]
+        ),
+        Op::Silu => format!("(Silu n{})", node.inputs[0]),
+        Op::RmsNorm { .. } => format!("(RmsNorm n{} n{})", node.inputs[0], node.inputs[1]),
+        Op::Embedding => format!("(Embedding n{} n{})", node.inputs[0], node.inputs[1]),
+        Op::RoPE { .. } => format!("(RoPE n{})", node.inputs[0]),
+        Op::CausalAttention { .. } => format!(
+            "(CausalAttention n{} n{} n{})",
             node.inputs[0], node.inputs[1], node.inputs[2]
         ),
         Op::Nop => unreachable!("Nop nodes should be filtered before conversion"),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -97,6 +97,37 @@ struct SgdParams {
 
 // reduce: var src, dst, params (same layout as UnaryData)
 
+// rms_norm: var src, bias (weight), dst, params
+#[derive(blade_macros::ShaderData)]
+struct RmsNormData {
+    src: blade_graphics::BufferPiece,
+    bias: blade_graphics::BufferPiece, // weight, named "bias" to match binding
+    dst: blade_graphics::BufferPiece,
+    params: BiasAddParams, // reuse: rows=len, cols=bias_len, _pad x2
+}
+
+// embedding: var indices (u32), src (table), dst, params
+#[derive(blade_macros::ShaderData)]
+struct EmbeddingData {
+    indices: blade_graphics::BufferPiece,
+    src: blade_graphics::BufferPiece,
+    dst: blade_graphics::BufferPiece,
+    params: UnaryParams, // seq in len field
+}
+
+// rope: var src, dst, params
+// (same layout as UnaryData)
+
+// causal_attention: var src_a (q), src_b (k), bias (v), dst, params
+#[derive(blade_macros::ShaderData)]
+struct CausalAttentionData {
+    src_a: blade_graphics::BufferPiece,
+    src_b: blade_graphics::BufferPiece,
+    bias: blade_graphics::BufferPiece, // v, named "bias" to match binding
+    dst: blade_graphics::BufferPiece,
+    params: MatMulParams, // seq, num_heads, num_kv_heads, head_dim → reuse 4xu32
+}
+
 // softmax: var src, dst, params
 #[derive(blade_macros::ShaderData)]
 struct SoftmaxData {
@@ -200,7 +231,9 @@ fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
     match *entry {
         ShaderEntry::MatMul | ShaderEntry::MatMulRelu => MatMulData::layout(),
         ShaderEntry::MatMulBiasRelu => MatMulBiasReluData::layout(),
-        ShaderEntry::Relu | ShaderEntry::Sigmoid | ShaderEntry::Neg => UnaryData::layout(),
+        ShaderEntry::Relu | ShaderEntry::Sigmoid | ShaderEntry::Neg | ShaderEntry::Silu => {
+            UnaryData::layout()
+        }
         ShaderEntry::Add | ShaderEntry::Mul | ShaderEntry::Greater => BinaryData::layout(),
         ShaderEntry::BiasAdd => BiasAddData::layout(),
         ShaderEntry::SgdUpdate => SgdData::layout(),
@@ -208,6 +241,10 @@ fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
         ShaderEntry::Softmax => SoftmaxData::layout(),
         ShaderEntry::CrossEntropyLoss => CrossEntropyData::layout(),
         ShaderEntry::Transpose => TransposeData::layout(),
+        ShaderEntry::RmsNorm => RmsNormData::layout(),
+        ShaderEntry::Embedding => EmbeddingData::layout(),
+        ShaderEntry::RoPE => UnaryData::layout(), // same layout: src, dst, params
+        ShaderEntry::CausalAttention => CausalAttentionData::layout(),
     }
 }
 
@@ -285,6 +322,17 @@ impl Session {
 
     /// Upload input data.
     pub fn set_input(&mut self, name: &str, data: &[f32]) {
+        for &(ref input_name, buf_ref) in &self.plan.input_buffers {
+            if input_name == name {
+                self.upload_buffer(buf_ref, bytemuck::cast_slice(data));
+                return;
+            }
+        }
+        panic!("unknown input: {}", name);
+    }
+
+    /// Upload u32 input data (e.g. token IDs for embedding lookup).
+    pub fn set_input_u32(&mut self, name: &str, data: &[u32]) {
         for &(ref input_name, buf_ref) in &self.plan.input_buffers {
             if input_name == name {
                 self.upload_buffer(buf_ref, bytemuck::cast_slice(data));
@@ -402,7 +450,7 @@ impl Session {
                     },
                 );
             }
-            ShaderEntry::Relu | ShaderEntry::Sigmoid | ShaderEntry::Neg => {
+            ShaderEntry::Relu | ShaderEntry::Sigmoid | ShaderEntry::Neg | ShaderEntry::Silu => {
                 pc.bind(
                     0,
                     &UnaryData {
@@ -523,6 +571,70 @@ impl Session {
                             n: dispatch.params[1],
                             _pad0: 0,
                             _pad1: 0,
+                        },
+                    },
+                );
+            }
+            ShaderEntry::RmsNorm => {
+                pc.bind(
+                    0,
+                    &RmsNormData {
+                        src: buf(dispatch.input_buffers[0]),
+                        bias: buf(dispatch.input_buffers[1]),
+                        dst: buf(dispatch.output_buffer),
+                        params: BiasAddParams {
+                            len: dispatch.params[0],
+                            bias_len: dispatch.params[1],
+                            _pad0: dispatch.params[2], // eps_bits
+                            _pad1: 0,
+                        },
+                    },
+                );
+            }
+            ShaderEntry::Embedding => {
+                pc.bind(
+                    0,
+                    &EmbeddingData {
+                        indices: buf(dispatch.input_buffers[0]),
+                        src: buf(dispatch.input_buffers[1]),
+                        dst: buf(dispatch.output_buffer),
+                        params: UnaryParams {
+                            len: dispatch.params[0],
+                            _pad0: dispatch.params[1],
+                            _pad1: 0,
+                            _pad2: 0,
+                        },
+                    },
+                );
+            }
+            ShaderEntry::RoPE => {
+                pc.bind(
+                    0,
+                    &UnaryData {
+                        src: buf(dispatch.input_buffers[0]),
+                        dst: buf(dispatch.output_buffer),
+                        params: UnaryParams {
+                            len: dispatch.params[0],
+                            _pad0: dispatch.params[1],
+                            _pad1: dispatch.params[2],
+                            _pad2: 0,
+                        },
+                    },
+                );
+            }
+            ShaderEntry::CausalAttention => {
+                pc.bind(
+                    0,
+                    &CausalAttentionData {
+                        src_a: buf(dispatch.input_buffers[0]),
+                        src_b: buf(dispatch.input_buffers[1]),
+                        bias: buf(dispatch.input_buffers[2]),
+                        dst: buf(dispatch.output_buffer),
+                        params: MatMulParams {
+                            m: dispatch.params[0],
+                            k: dispatch.params[1],
+                            n: dispatch.params[2],
+                            _pad: dispatch.params[3],
                         },
                     },
                 );


### PR DESCRIPTION
Summary
	∙	Add five new GPU compute ops (SiLU, RMSNorm, Embedding, RoPE, fused CausalAttention with GQA) enabling decoder-only transformer inference while keeping all tensors 2D
	∙	Add DType::U32 and set_input_u32() for token ID buffers
	∙	Add BF16→F32 auto-conversion in safetensors loader (renamed data::huggingface → data::safetensors)
	∙	Add SmolLM2-135M model builder (30 layers, GQA 9/3 heads, SwiGLU FFN) and end-to-end inference example with tokenizer