### PR TITLE
Optimized MatMul exploration

### DIFF
--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -149,7 +149,7 @@ pub fn differentiate(forward: &Graph) -> Graph {
             // Leaf nodes, fused ops don't appear in forward pass before optimization
             Op::Input { .. } | Op::Parameter { .. } | Op::Constant { .. } | Op::Greater => {}
             Op::Nop => {}
-            Op::FusedMatMulRelu | Op::FusedMatMulBiasRelu => {
+            Op::FusedMatMulRelu | Op::FusedMatMulBiasRelu | Op::FusedMatMulSilu | Op::FusedMatMulGelu => {
                 log::warn!("autodiff should run before fusion optimization");
             }
             // Transformer / vision ops: inference-only, no autodiff support

--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -149,7 +149,8 @@ pub fn differentiate(forward: &Graph) -> Graph {
             // Leaf nodes, fused ops don't appear in forward pass before optimization
             Op::Input { .. } | Op::Parameter { .. } | Op::Constant { .. } | Op::Greater => {}
             Op::Nop => {}
-            Op::FusedMatMulRelu | Op::FusedMatMulBiasRelu | Op::FusedMatMulSilu | Op::FusedMatMulGelu => {
+            Op::FusedMatMulRelu | Op::FusedMatMulBiasRelu | Op::FusedMatMulSilu | Op::FusedMatMulGelu
+            | Op::MatMulSplitK { .. } => {
                 log::warn!("autodiff should run before fusion optimization");
             }
             // Transformer / vision ops: inference-only, no autodiff support

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -328,6 +328,14 @@ impl FnBuilder {
         })
     }
 
+    /// Extract .z from a vec3 value (produces a value, not a pointer).
+    fn vec_z(&mut self, vec: Handle<Expression>) -> Handle<Expression> {
+        self.expr(Expression::AccessIndex {
+            base: vec,
+            index: 2,
+        })
+    }
+
     /// AccessIndex on a struct or array
     fn field(&mut self, base: Handle<Expression>, index: u32) -> Handle<Expression> {
         self.expr(Expression::AccessIndex { base, index })
@@ -511,6 +519,8 @@ pub enum ShaderGroup {
     MatMulBiasRelu,
     MatMulSilu,
     MatMulGelu,
+    MatMulSplitK,
+    MatMulSplitKFinalize,
     Reduce,
     Softmax,
     CrossEntropy,
@@ -536,6 +546,8 @@ pub fn generate_module(group: ShaderGroup) -> Module {
         ShaderGroup::MatMulBiasRelu => gen_matmul(MatMulFusion::BiasRelu),
         ShaderGroup::MatMulSilu => gen_matmul(MatMulFusion::Silu),
         ShaderGroup::MatMulGelu => gen_matmul(MatMulFusion::Gelu),
+        ShaderGroup::MatMulSplitK => gen_matmul_split_k(),
+        ShaderGroup::MatMulSplitKFinalize => gen_matmul_split_k_finalize(),
         ShaderGroup::Reduce => gen_reduce(),
         ShaderGroup::Softmax => gen_softmax(),
         ShaderGroup::CrossEntropy => gen_cross_entropy(),
@@ -1345,6 +1357,355 @@ fn gen_matmul(fusion: MatMulFusion) -> Module {
     );
 
     b.entry_point("main", [16, 16, 1], f.finish());
+    b.finish()
+}
+
+// ---------------------------------------------------------------------------
+// matmul_split_k.wgsl: partial accumulation pass
+//
+// Each z-slice of workgroups handles a contiguous range of the K dimension.
+// Output is partial[z * m * n + row * n + col].
+// Params: m, k, n, num_splits (u32x4).
+// Workgroup: [16, 16, 1], dispatched as [ceil(N/16), ceil(M/16), num_splits].
+// ---------------------------------------------------------------------------
+
+fn gen_matmul_split_k() -> Module {
+    let mut b = Builder::new();
+    let ty_params = b.params_u32x4("Params", &["m", "k", "n", "num_splits"]);
+    let gv_a = b.storage_ro("a");
+    let gv_b = b.storage_ro("b");
+    let gv_partial = b.storage_rw("partial");
+    let gv_params = b.uniform("params", ty_params);
+    let gv_tile_a = b.workgroup_array("tile_a", 256);
+    let gv_tile_b = b.workgroup_array("tile_b", 256);
+
+    let mut f = FnBuilder::new(&b);
+    let gid = f.arg_gid();
+    let lid = f.arg_lid();
+
+    // Extract indices
+    let col = f.vec_x(gid);
+    f.label("col", col);
+    let row = f.vec_y(gid);
+    f.label("row", row);
+    let split_id = f.vec_z(gid);
+    f.label("split_id", split_id);
+    let local_col = f.vec_x(lid);
+    f.label("local_col", local_col);
+    let local_row = f.vec_y(lid);
+    f.label("local_row", local_row);
+
+    f.emit(col, local_row);
+
+    // Load params
+    let params_ptr = f.global(gv_params);
+    let m_ptr = f.field(params_ptr, 0);
+    let pm = f.load(m_ptr);
+    let k_ptr = f.field(params_ptr, 1);
+    let pk = f.load(k_ptr);
+    let n_ptr = f.field(params_ptr, 2);
+    let pn = f.load(n_ptr);
+    let splits_ptr = f.field(params_ptr, 3);
+    let pnum_splits = f.load(splits_ptr);
+    f.emit(params_ptr, pnum_splits);
+
+    // Compute K-range for this split:
+    //   k_per_split = (k + num_splits - 1) / num_splits
+    //   k_start = split_id * k_per_split
+    //   k_end = min(k_start + k_per_split, k)
+    let one_u = f.literal_u32(1);
+    let k_plus_s_m1 = f.binary(BinaryOperator::Add, pk, pnum_splits);
+    let k_adj = f.binary(BinaryOperator::Subtract, k_plus_s_m1, one_u);
+    let k_per_split = f.named("k_per_split", Expression::Binary {
+        op: BinaryOperator::Divide,
+        left: k_adj,
+        right: pnum_splits,
+    });
+    let k_start = f.named("k_start", Expression::Binary {
+        op: BinaryOperator::Multiply,
+        left: split_id,
+        right: k_per_split,
+    });
+    let k_end_raw = f.binary(BinaryOperator::Add, k_start, k_per_split);
+    let k_end_ge = f.binary(BinaryOperator::GreaterEqual, k_end_raw, pk);
+    let k_end = f.named("k_end", Expression::Select {
+        condition: k_end_ge,
+        accept: pk,
+        reject: k_end_raw,
+    });
+    f.emit(one_u, k_end);
+
+    // var sum = 0.0;
+    let zero_f = f.literal_f32(0.0);
+    f.emit(zero_f, zero_f);
+    let sum_var = f.local_var("sum", b.ty_f32, None);
+    let sum_ptr = f.local_ptr(sum_var);
+    f.f.body.push(f.store(sum_ptr, zero_f), S);
+
+    // Tiled loop over K-range: for t in (k_start/16)..(k_end+15)/16
+    {
+        let tile_const = f.literal_u32(16);
+        let tile_m1 = f.literal_u32(15);
+        let t_start = f.binary(BinaryOperator::Divide, k_start, tile_const);
+
+        let t_var = f.local_var("t", b.ty_u32, None);
+        let t_ptr = f.local_ptr(t_var);
+        f.emit(tile_const, t_start);
+        f.f.body.push(f.store(t_ptr, t_start), S);
+
+        let k_end_plus = f.binary(BinaryOperator::Add, k_end, tile_m1);
+        let tile_const2 = f.literal_u32(16);
+        let num_tiles_end = f.binary(BinaryOperator::Divide, k_end_plus, tile_const2);
+
+        let mut loop_body = Block::new();
+        {
+            let t_val = f.load(t_ptr);
+            let t_break = f.binary(BinaryOperator::GreaterEqual, t_val, num_tiles_end);
+
+            // a_col = t * 16 + local_col
+            let tile16 = f.literal_u32(16);
+            let t_16 = f.binary(BinaryOperator::Multiply, t_val, tile16);
+            let a_col = f.named("a_col", Expression::Binary {
+                op: BinaryOperator::Add,
+                left: t_16,
+                right: local_col,
+            });
+
+            // Load tile_a: a[row * k + a_col] if in bounds, else 0.0
+            let row_k = f.binary(BinaryOperator::Multiply, row, pk);
+            let a_idx = f.binary(BinaryOperator::Add, row_k, a_col);
+            let a_ptr = f.global(gv_a);
+            let a_elem = f.index(a_ptr, a_idx);
+            let a_val = f.load(a_elem);
+            let r_in = f.binary(BinaryOperator::Less, row, pm);
+            let c_in = f.binary(BinaryOperator::Less, a_col, pk);
+            let ab_in = f.binary(BinaryOperator::LogicalAnd, r_in, c_in);
+            let zero1 = f.literal_f32(0.0);
+            let safe_a = f.select(ab_in, a_val, zero1);
+            let tile16_2 = f.literal_u32(16);
+            let lr_t = f.binary(BinaryOperator::Multiply, local_row, tile16_2);
+            let ta_idx = f.binary(BinaryOperator::Add, lr_t, local_col);
+            let ta_ptr = f.global(gv_tile_a);
+            let ta_elem = f.index(ta_ptr, ta_idx);
+
+            // Load tile_b: b[a_col * n + col] if in bounds, else 0.0
+            let a_col_n = f.binary(BinaryOperator::Multiply, a_col, pn);
+            let b_idx = f.binary(BinaryOperator::Add, a_col_n, col);
+            let b_ptr = f.global(gv_b);
+            let b_elem = f.index(b_ptr, b_idx);
+            let b_val = f.load(b_elem);
+            let col_in = f.binary(BinaryOperator::Less, col, pn);
+            let bc_in = f.binary(BinaryOperator::LogicalAnd, c_in, col_in);
+            let zero2 = f.literal_f32(0.0);
+            let safe_b = f.select(bc_in, b_val, zero2);
+            let tile16_3 = f.literal_u32(16);
+            let i_t = f.binary(BinaryOperator::Multiply, local_row, tile16_3);
+            let tb_idx = f.binary(BinaryOperator::Add, i_t, local_col);
+            let tb_ptr = f.global(gv_tile_b);
+            let tb_elem = f.index(tb_ptr, tb_idx);
+
+            push_emit(&f.f.expressions, &mut loop_body, t_val, t_break);
+            loop_body.push(FnBuilder::if_break(t_break), S);
+            push_emit(&f.f.expressions, &mut loop_body, tile16, safe_a);
+            loop_body.push(f.store(ta_elem, safe_a), S);
+            push_emit(&f.f.expressions, &mut loop_body, a_col_n, safe_b);
+            loop_body.push(f.store(tb_elem, safe_b), S);
+
+            // workgroupBarrier()
+            loop_body.push(Statement::ControlBarrier(Barrier::WORK_GROUP), S);
+
+            // Inner accumulation loop
+            let i_var = f.local_var("i", b.ty_u32, None);
+            let i_ptr_l = f.local_ptr(i_var);
+            let zero_i = f.literal_u32(0);
+            push_emit(&f.f.expressions, &mut loop_body, zero_i, zero_i);
+            loop_body.push(f.store(i_ptr_l, zero_i), S);
+
+            let mut inner_body = Block::new();
+            {
+                let i_val = f.load(i_ptr_l);
+                let tile16_4 = f.literal_u32(16);
+                let i_break = f.binary(BinaryOperator::GreaterEqual, i_val, tile16_4);
+                let tile16_5 = f.literal_u32(16);
+                let lr_t2 = f.binary(BinaryOperator::Multiply, local_row, tile16_5);
+                let ta_i = f.binary(BinaryOperator::Add, lr_t2, i_val);
+                let ta_ptr2 = f.global(gv_tile_a);
+                let ta_e2 = f.index(ta_ptr2, ta_i);
+                let ta_v = f.load(ta_e2);
+
+                let i_t2 = f.binary(BinaryOperator::Multiply, i_val, tile16_5);
+                let tb_i = f.binary(BinaryOperator::Add, i_t2, local_col);
+                let tb_ptr2 = f.global(gv_tile_b);
+                let tb_e2 = f.index(tb_ptr2, tb_i);
+                let tb_v = f.load(tb_e2);
+
+                let prod = f.binary(BinaryOperator::Multiply, ta_v, tb_v);
+                let old_sum = f.load(sum_ptr);
+                let new_sum = f.binary(BinaryOperator::Add, old_sum, prod);
+
+                push_emit(&f.f.expressions, &mut inner_body, i_val, i_break);
+                inner_body.push(FnBuilder::if_break(i_break), S);
+                push_emit(&f.f.expressions, &mut inner_body, tile16_5, new_sum);
+                inner_body.push(f.store(sum_ptr, new_sum), S);
+
+                let one_inc = f.literal_u32(1);
+                let i_val2 = f.load(i_ptr_l);
+                let i_next = f.binary(BinaryOperator::Add, i_val2, one_inc);
+                push_emit(&f.f.expressions, &mut inner_body, one_inc, i_next);
+                inner_body.push(f.store(i_ptr_l, i_next), S);
+
+                loop_body.push(
+                    Statement::Loop {
+                        body: inner_body,
+                        continuing: Block::new(),
+                        break_if: None,
+                    },
+                    S,
+                );
+            }
+
+            // workgroupBarrier()
+            loop_body.push(Statement::ControlBarrier(Barrier::WORK_GROUP), S);
+
+            // t++
+            let one_t = f.literal_u32(1);
+            let t_val2 = f.load(t_ptr);
+            let t_next = f.binary(BinaryOperator::Add, t_val2, one_t);
+            push_emit(&f.f.expressions, &mut loop_body, one_t, t_next);
+            loop_body.push(f.store(t_ptr, t_next), S);
+        }
+
+        push_emit(&f.f.expressions, &mut f.f.body, k_end_plus, num_tiles_end);
+        f.f.body.push(
+            Statement::Loop {
+                body: loop_body,
+                continuing: Block::new(),
+                break_if: None,
+            },
+            S,
+        );
+    }
+
+    // Store result: partial[split_id * m * n + row * n + col] = sum
+    let r_lt_m = f.binary(BinaryOperator::Less, row, pm);
+    let c_lt_n = f.binary(BinaryOperator::Less, col, pn);
+    let store_cond = f.binary(BinaryOperator::LogicalAnd, r_lt_m, c_lt_n);
+    let mn = f.binary(BinaryOperator::Multiply, pm, pn);
+    let split_offset = f.binary(BinaryOperator::Multiply, split_id, mn);
+    let row_n = f.binary(BinaryOperator::Multiply, row, pn);
+    let rc = f.binary(BinaryOperator::Add, row_n, col);
+    let out_idx = f.binary(BinaryOperator::Add, split_offset, rc);
+    let p_ptr = f.global(gv_partial);
+    let p_elem = f.index(p_ptr, out_idx);
+    let final_val = f.load(sum_ptr);
+
+    f.emit(r_lt_m, final_val);
+
+    let store_block = Block::from_vec(vec![f.store(p_elem, final_val)]);
+    f.f.body.push(
+        Statement::If {
+            condition: store_cond,
+            accept: store_block,
+            reject: Block::new(),
+        },
+        S,
+    );
+
+    b.entry_point("main", [16, 16, 1], f.finish());
+    b.finish()
+}
+
+// ---------------------------------------------------------------------------
+// matmul_split_k_finalize.wgsl: reduce partial sums across K-splits
+//
+// Each thread handles one element of the M×N output.
+// Params: total_elements (M*N), num_splits, 0, 0.
+// Workgroup: [256, 1, 1], dispatched as [ceil(M*N/256), 1, 1].
+// ---------------------------------------------------------------------------
+
+fn gen_matmul_split_k_finalize() -> Module {
+    let mut b = Builder::new();
+    let ty_params = b.params_u32x4("Params", &["total", "num_splits", "_pad0", "_pad1"]);
+    let gv_partial = b.storage_ro("partial");
+    let gv_out = b.storage_rw("out");
+    let gv_params = b.uniform("params", ty_params);
+
+    let mut f = FnBuilder::new(&b);
+    let gid = f.arg_gid();
+    let idx = f.vec_x(gid);
+    f.label("idx", idx);
+
+    f.emit(idx, idx);
+
+    // Load params
+    let params_ptr = f.global(gv_params);
+    let total_ptr = f.field(params_ptr, 0);
+    let total = f.load(total_ptr);
+    let splits_ptr = f.field(params_ptr, 1);
+    let num_splits = f.load(splits_ptr);
+    f.emit(params_ptr, num_splits);
+
+    // Early exit: if (idx >= total) return
+    let oob = f.binary(BinaryOperator::GreaterEqual, idx, total);
+    f.emit(oob, oob);
+    f.f.body.push(f.if_return(oob), S);
+
+    // var sum = 0.0;
+    let zero_f = f.literal_f32(0.0);
+    f.emit(zero_f, zero_f);
+    let sum_var = f.local_var("sum", b.ty_f32, None);
+    let sum_ptr = f.local_ptr(sum_var);
+    f.f.body.push(f.store(sum_ptr, zero_f), S);
+
+    // for s in 0..num_splits: sum += partial[s * total + idx]
+    let s_var = f.local_var("s", b.ty_u32, None);
+    let s_ptr = f.local_ptr(s_var);
+    let zero_u = f.literal_u32(0);
+    f.emit(zero_u, zero_u);
+    f.f.body.push(f.store(s_ptr, zero_u), S);
+
+    let mut loop_body = Block::new();
+    {
+        let s_val = f.load(s_ptr);
+        let s_break = f.binary(BinaryOperator::GreaterEqual, s_val, num_splits);
+        let s_off = f.binary(BinaryOperator::Multiply, s_val, total);
+        let p_idx = f.binary(BinaryOperator::Add, s_off, idx);
+        let p_ptr = f.global(gv_partial);
+        let p_elem = f.index(p_ptr, p_idx);
+        let p_val = f.load(p_elem);
+        let old_sum = f.load(sum_ptr);
+        let new_sum = f.binary(BinaryOperator::Add, old_sum, p_val);
+
+        push_emit(&f.f.expressions, &mut loop_body, s_val, s_break);
+        loop_body.push(FnBuilder::if_break(s_break), S);
+        push_emit(&f.f.expressions, &mut loop_body, s_off, new_sum);
+        loop_body.push(f.store(sum_ptr, new_sum), S);
+
+        // s++
+        let one_s = f.literal_u32(1);
+        let s_val2 = f.load(s_ptr);
+        let s_next = f.binary(BinaryOperator::Add, s_val2, one_s);
+        push_emit(&f.f.expressions, &mut loop_body, one_s, s_next);
+        loop_body.push(f.store(s_ptr, s_next), S);
+    }
+
+    f.f.body.push(
+        Statement::Loop {
+            body: loop_body,
+            continuing: Block::new(),
+            break_if: None,
+        },
+        S,
+    );
+
+    // Store result
+    let out_ptr = f.global(gv_out);
+    let out_elem = f.index(out_ptr, idx);
+    let result = f.load(sum_ptr);
+    f.emit(out_ptr, result);
+    f.f.body.push(f.store(out_elem, result), S);
+
+    b.entry_point("main", [256, 1, 1], f.finish());
     b.finish()
 }
 
@@ -3368,6 +3729,8 @@ mod tests {
             ShaderGroup::MatMulBiasRelu,
             ShaderGroup::MatMulSilu,
             ShaderGroup::MatMulGelu,
+            ShaderGroup::MatMulSplitK,
+            ShaderGroup::MatMulSplitKFinalize,
             ShaderGroup::Reduce,
             ShaderGroup::Softmax,
             ShaderGroup::CrossEntropy,

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -509,6 +509,8 @@ pub enum ShaderGroup {
     MatMul,
     MatMulRelu,
     MatMulBiasRelu,
+    MatMulSilu,
+    MatMulGelu,
     Reduce,
     Softmax,
     CrossEntropy,
@@ -532,6 +534,8 @@ pub fn generate_module(group: ShaderGroup) -> Module {
         ShaderGroup::MatMul => gen_matmul(MatMulFusion::None),
         ShaderGroup::MatMulRelu => gen_matmul(MatMulFusion::Relu),
         ShaderGroup::MatMulBiasRelu => gen_matmul(MatMulFusion::BiasRelu),
+        ShaderGroup::MatMulSilu => gen_matmul(MatMulFusion::Silu),
+        ShaderGroup::MatMulGelu => gen_matmul(MatMulFusion::Gelu),
         ShaderGroup::Reduce => gen_reduce(),
         ShaderGroup::Softmax => gen_softmax(),
         ShaderGroup::CrossEntropy => gen_cross_entropy(),
@@ -1005,6 +1009,8 @@ enum MatMulFusion {
     None,
     Relu,
     BiasRelu,
+    Silu,
+    Gelu,
 }
 
 fn gen_matmul(fusion: MatMulFusion) -> Module {
@@ -1295,6 +1301,36 @@ fn gen_matmul(fusion: MatMulFusion) -> Module {
             let relu_val = f.math2(MathFunction::Max, biased, zero);
             f.emit(bias_ptr, relu_val);
             relu_val
+        }
+        // silu: x * sigmoid(x) = x / (1 + exp(-x))
+        MatMulFusion::Silu => {
+            let neg_val = f.unary(UnaryOperator::Negate, final_val);
+            let exp_neg = f.math1(MathFunction::Exp, neg_val);
+            let one = f.literal_f32(1.0);
+            let denom = f.binary(BinaryOperator::Add, one, exp_neg);
+            let one2 = f.literal_f32(1.0);
+            let sigmoid = f.binary(BinaryOperator::Divide, one2, denom);
+            let silu_val = f.binary(BinaryOperator::Multiply, final_val, sigmoid);
+            f.emit(neg_val, silu_val);
+            silu_val
+        }
+        // gelu: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+        MatMulFusion::Gelu => {
+            let sqrt_2_pi = f.literal_f32(0.797_884_6);
+            let coeff = f.literal_f32(0.044715);
+            let half = f.literal_f32(0.5);
+            let one = f.literal_f32(1.0);
+            let x2 = f.binary(BinaryOperator::Multiply, final_val, final_val);
+            let x3 = f.binary(BinaryOperator::Multiply, x2, final_val);
+            let cx3 = f.binary(BinaryOperator::Multiply, coeff, x3);
+            let inner = f.binary(BinaryOperator::Add, final_val, cx3);
+            let scaled = f.binary(BinaryOperator::Multiply, sqrt_2_pi, inner);
+            let tanh_val = f.math1(MathFunction::Tanh, scaled);
+            let one_plus_tanh = f.binary(BinaryOperator::Add, one, tanh_val);
+            let half_x = f.binary(BinaryOperator::Multiply, half, final_val);
+            let gelu_val = f.binary(BinaryOperator::Multiply, half_x, one_plus_tanh);
+            f.emit(sqrt_2_pi, gelu_val);
+            gelu_val
         }
     };
 
@@ -3330,6 +3366,8 @@ mod tests {
             ShaderGroup::MatMul,
             ShaderGroup::MatMulRelu,
             ShaderGroup::MatMulBiasRelu,
+            ShaderGroup::MatMulSilu,
+            ShaderGroup::MatMulGelu,
             ShaderGroup::Reduce,
             ShaderGroup::Softmax,
             ShaderGroup::CrossEntropy,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -8,6 +8,8 @@ pub enum ShaderEntry {
     MatMul,
     MatMulRelu,
     MatMulBiasRelu,
+    MatMulSilu,
+    MatMulGelu,
     Relu,
     Sigmoid,
     Neg,
@@ -39,6 +41,8 @@ impl ShaderEntry {
             ShaderEntry::MatMul => ShaderGroup::MatMul,
             ShaderEntry::MatMulRelu => ShaderGroup::MatMulRelu,
             ShaderEntry::MatMulBiasRelu => ShaderGroup::MatMulBiasRelu,
+            ShaderEntry::MatMulSilu => ShaderGroup::MatMulSilu,
+            ShaderEntry::MatMulGelu => ShaderGroup::MatMulGelu,
             ShaderEntry::Relu | ShaderEntry::Sigmoid | ShaderEntry::Neg => ShaderGroup::Unary,
             ShaderEntry::Add | ShaderEntry::Mul | ShaderEntry::Greater => ShaderGroup::Binary,
             ShaderEntry::BiasAdd => ShaderGroup::BiasAdd,
@@ -64,6 +68,8 @@ impl ShaderEntry {
             ShaderEntry::MatMul
             | ShaderEntry::MatMulRelu
             | ShaderEntry::MatMulBiasRelu
+            | ShaderEntry::MatMulSilu
+            | ShaderEntry::MatMulGelu
             | ShaderEntry::BiasAdd
             | ShaderEntry::SgdUpdate
             | ShaderEntry::Softmax
@@ -246,6 +252,40 @@ impl<'a> Compiler<'a> {
                 let n = b_shape[1] as u32;
                 self.plan.dispatches.push(Dispatch {
                     shader: ShaderEntry::MatMulRelu,
+                    workgroups: [ceil_div(n, 16), ceil_div(m, 16), 1],
+                    input_buffers: vec![a, b],
+                    output_buffer: out_buf,
+                    params: vec![m, k, n, 0],
+                });
+            }
+
+            Op::FusedMatMulSilu => {
+                let a = self.get_buffer(node.inputs[0]);
+                let b = self.get_buffer(node.inputs[1]);
+                let a_shape = &self.graph.node(node.inputs[0]).ty.shape;
+                let b_shape = &self.graph.node(node.inputs[1]).ty.shape;
+                let m = a_shape[0] as u32;
+                let k = a_shape[1] as u32;
+                let n = b_shape[1] as u32;
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::MatMulSilu,
+                    workgroups: [ceil_div(n, 16), ceil_div(m, 16), 1],
+                    input_buffers: vec![a, b],
+                    output_buffer: out_buf,
+                    params: vec![m, k, n, 0],
+                });
+            }
+
+            Op::FusedMatMulGelu => {
+                let a = self.get_buffer(node.inputs[0]);
+                let b = self.get_buffer(node.inputs[1]);
+                let a_shape = &self.graph.node(node.inputs[0]).ty.shape;
+                let b_shape = &self.graph.node(node.inputs[1]).ty.shape;
+                let m = a_shape[0] as u32;
+                let k = a_shape[1] as u32;
+                let n = b_shape[1] as u32;
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::MatMulGelu,
                     workgroups: [ceil_div(n, 16), ceil_div(m, 16), 1],
                     input_buffers: vec![a, b],
                     output_buffer: out_buf,
@@ -781,6 +821,8 @@ mod tests {
             ShaderEntry::MatMul,
             ShaderEntry::MatMulRelu,
             ShaderEntry::MatMulBiasRelu,
+            ShaderEntry::MatMulSilu,
+            ShaderEntry::MatMulGelu,
             ShaderEntry::Relu,
             ShaderEntry::Sigmoid,
             ShaderEntry::Neg,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -10,6 +10,8 @@ pub enum ShaderEntry {
     MatMulBiasRelu,
     MatMulSilu,
     MatMulGelu,
+    MatMulSplitK,
+    MatMulSplitKFinalize,
     Relu,
     Sigmoid,
     Neg,
@@ -43,6 +45,8 @@ impl ShaderEntry {
             ShaderEntry::MatMulBiasRelu => ShaderGroup::MatMulBiasRelu,
             ShaderEntry::MatMulSilu => ShaderGroup::MatMulSilu,
             ShaderEntry::MatMulGelu => ShaderGroup::MatMulGelu,
+            ShaderEntry::MatMulSplitK => ShaderGroup::MatMulSplitK,
+            ShaderEntry::MatMulSplitKFinalize => ShaderGroup::MatMulSplitKFinalize,
             ShaderEntry::Relu | ShaderEntry::Sigmoid | ShaderEntry::Neg => ShaderGroup::Unary,
             ShaderEntry::Add | ShaderEntry::Mul | ShaderEntry::Greater => ShaderGroup::Binary,
             ShaderEntry::BiasAdd => ShaderGroup::BiasAdd,
@@ -70,6 +74,8 @@ impl ShaderEntry {
             | ShaderEntry::MatMulBiasRelu
             | ShaderEntry::MatMulSilu
             | ShaderEntry::MatMulGelu
+            | ShaderEntry::MatMulSplitK
+            | ShaderEntry::MatMulSplitKFinalize
             | ShaderEntry::BiasAdd
             | ShaderEntry::SgdUpdate
             | ShaderEntry::Softmax
@@ -142,6 +148,8 @@ struct Compiler<'a> {
     plan: ExecutionPlan,
     /// Map from NodeId → BufferRef for each node's output.
     node_buffers: HashMap<NodeId, BufferRef>,
+    /// Intermediate buffers for multi-dispatch ops (e.g. split-K partial sums).
+    split_k_buffers: HashMap<NodeId, BufferRef>,
 }
 
 impl<'a> Compiler<'a> {
@@ -157,6 +165,7 @@ impl<'a> Compiler<'a> {
                 param_grad_pairs: Vec::new(),
             },
             node_buffers: HashMap::new(),
+            split_k_buffers: HashMap::new(),
         }
     }
 
@@ -185,6 +194,17 @@ impl<'a> Compiler<'a> {
                     self.plan.input_buffers.push((name.clone(), buf));
                 }
                 _ => {}
+            }
+        }
+
+        // Allocate intermediate buffers for split-K nodes (partial sums).
+        // Each split produces M*N f32 values, so the intermediate is num_splits * M * N * 4 bytes.
+        for node in self.graph.nodes() {
+            if let Op::MatMulSplitK { num_splits } = node.op {
+                let out_elements = node.ty.num_elements(); // M * N
+                let intermediate_size = (num_splits as usize) * out_elements * 4;
+                let buf = self.alloc_buffer(intermediate_size);
+                self.split_k_buffers.insert(node.id, buf);
             }
         }
 
@@ -239,6 +259,35 @@ impl<'a> Compiler<'a> {
                     input_buffers: vec![a, b],
                     output_buffer: out_buf,
                     params: vec![m, k, n, 0],
+                });
+            }
+
+            Op::MatMulSplitK { num_splits } => {
+                let a = self.get_buffer(node.inputs[0]);
+                let b = self.get_buffer(node.inputs[1]);
+                let a_shape = &self.graph.node(node.inputs[0]).ty.shape;
+                let b_shape = &self.graph.node(node.inputs[1]).ty.shape;
+                let m = a_shape[0] as u32;
+                let k = a_shape[1] as u32;
+                let n = b_shape[1] as u32;
+                let partial_buf = self.split_k_buffers[&node.id];
+
+                // Dispatch 1: each z-slice computes a partial sum over its K range
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::MatMulSplitK,
+                    workgroups: [ceil_div(n, 16), ceil_div(m, 16), num_splits],
+                    input_buffers: vec![a, b],
+                    output_buffer: partial_buf,
+                    params: vec![m, k, n, num_splits],
+                });
+
+                // Dispatch 2: reduce partial sums across splits → final output
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::MatMulSplitKFinalize,
+                    workgroups: [ceil_div(m * n, 256), 1, 1],
+                    input_buffers: vec![partial_buf],
+                    output_buffer: out_buf,
+                    params: vec![m * n, num_splits, 0, 0],
                 });
             }
 
@@ -823,6 +872,8 @@ mod tests {
             ShaderEntry::MatMulBiasRelu,
             ShaderEntry::MatMulSilu,
             ShaderEntry::MatMulGelu,
+            ShaderEntry::MatMulSplitK,
+            ShaderEntry::MatMulSplitKFinalize,
             ShaderEntry::Relu,
             ShaderEntry::Sigmoid,
             ShaderEntry::Neg,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -85,6 +85,11 @@ pub enum Op {
     FusedMatMulSilu,
     FusedMatMulGelu,
 
+    // Split-K MatMul: splits K-reduction across workgroups for better
+    // parallelism when M or N is small relative to K (e.g. inference).
+    // Compiles to two dispatches: partial accumulation + finalize reduction.
+    MatMulSplitK { num_splits: u32 },
+
     // Transpose (swap last two dims)
     Transpose,
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -82,6 +82,8 @@ pub enum Op {
     // Fused ops (created by optimizer)
     FusedMatMulRelu,
     FusedMatMulBiasRelu,
+    FusedMatMulSilu,
+    FusedMatMulGelu,
 
     // Transpose (swap last two dims)
     Transpose,

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -183,6 +183,8 @@ fn graph_to_egglog(graph: &Graph) -> String {
   (FusedMatMulBiasRelu Op Op Op)
   (FusedMatMulSilu Op Op)
   (FusedMatMulGelu Op Op)
+  ; Split-K: equivalent to MatMul but compiled with K-parallel strategy
+  (MatMulSplitK Op Op)
   ; Transformer ops (passthrough, no fusion rules)
   (Silu Op)
   (Gelu Op)
@@ -206,6 +208,9 @@ fn graph_to_egglog(graph: &Graph) -> String {
 (rewrite (Relu (BiasAdd (MatMul ?a ?b) ?c)) (FusedMatMulBiasRelu ?a ?b ?c))
 (rewrite (Silu (MatMul ?a ?b)) (FusedMatMulSilu ?a ?b))
 (rewrite (Gelu (MatMul ?a ?b)) (FusedMatMulGelu ?a ?b))
+
+; --- Split-K exploration: e-graph explores both strategies ---
+(rewrite (MatMul ?a ?b) (MatMulSplitK ?a ?b))
 
 ; --- Algebraic simplifications ---
 (rewrite (Neg (Neg ?x)) ?x)
@@ -253,6 +258,9 @@ fn node_to_egglog_expr(node: &Node) -> String {
             format!("(CrossEntropyLoss n{} n{})", node.inputs[0], node.inputs[1])
         }
         Op::Greater => format!("(Greater n{} n{})", node.inputs[0], node.inputs[1]),
+        Op::MatMulSplitK { .. } => {
+            format!("(MatMulSplitK n{} n{})", node.inputs[0], node.inputs[1])
+        }
         Op::FusedMatMulRelu => {
             format!("(FusedMatMulRelu n{} n{})", node.inputs[0], node.inputs[1])
         }
@@ -301,7 +309,8 @@ fn extract_graph_with_fusions(
     original: &Graph,
 ) -> (Graph, Vec<(String, u32)>) {
     let mut graph = clone_graph(original);
-    let fusions = apply_fusion_rewrites(&mut graph);
+    let mut fusions = apply_fusion_rewrites(&mut graph);
+    fusions.extend(apply_split_k_rewrites(&mut graph));
     (graph, fusions)
 }
 
@@ -412,6 +421,39 @@ fn apply_fusion_rewrites(graph: &mut Graph) -> Vec<(String, u32)> {
             nodes[d].op = Op::Nop;
             nodes[d].inputs.clear();
         }
+    }
+    applied
+}
+
+/// Convert standalone MatMul nodes to MatMulSplitK when K is large relative
+/// to M and N. This improves GPU occupancy on shapes like [1, 4096] × [4096, 1024]
+/// where the output tile grid is small but K provides ample parallelism.
+fn apply_split_k_rewrites(graph: &mut Graph) -> Vec<(String, u32)> {
+    let mut applied = Vec::new();
+    let nodes = graph.nodes_mut();
+    for i in 0..nodes.len() {
+        if !matches!(nodes[i].op, Op::MatMul) {
+            continue;
+        }
+        // Look up input shapes to decide split-K eligibility
+        let a_id = nodes[i].inputs[0] as usize;
+        let b_id = nodes[i].inputs[1] as usize;
+        let m = nodes[a_id].ty.shape[0] as u32;
+        let k = nodes[a_id].ty.shape[1] as u32;
+        let n = nodes[b_id].ty.shape[1] as u32;
+
+        // Heuristic: split-K when K is large and the output tile grid is small.
+        // The output grid is ceil(M/16)*ceil(N/16) tiles; if that's small (<= 32)
+        // but K is large (>= 256), splitting K across workgroups helps.
+        let output_tiles = m.div_ceil(16) * n.div_ceil(16);
+        if output_tiles > 32 || k < 256 {
+            continue;
+        }
+        // Choose num_splits: each split should handle >= 64 K-elements,
+        // cap at 16 splits to avoid excessive overhead.
+        let num_splits = (k / 64).clamp(2, 16);
+        nodes[i].op = Op::MatMulSplitK { num_splits };
+        applied.push(("MatMulSplitK".to_string(), i as u32));
     }
     applied
 }
@@ -669,6 +711,82 @@ mod tests {
             matches!(output_node.op, Op::FusedMatMulGelu),
             "expected FusedMatMulGelu, got {:?}",
             output_node.op
+        );
+    }
+
+    #[test]
+    fn test_split_k_matmul_triggered() {
+        // Small M, large K → split-K should activate
+        let mut g = Graph::new();
+        let x = g.input("x", &[2, 1024]);
+        let w = g.parameter("w", &[1024, 64]);
+        let y = g.matmul(x, w);
+        g.set_outputs(vec![y]);
+
+        let opt = optimize(&g);
+        let output_id = opt.outputs()[0];
+        let output_node = opt.node(output_id);
+        assert!(
+            matches!(output_node.op, Op::MatMulSplitK { .. }),
+            "expected MatMulSplitK, got {:?}",
+            output_node.op
+        );
+        if let Op::MatMulSplitK { num_splits } = output_node.op {
+            assert!(num_splits >= 2, "expected at least 2 splits, got {num_splits}");
+            assert!(num_splits <= 16, "expected at most 16 splits, got {num_splits}");
+        }
+    }
+
+    #[test]
+    fn test_split_k_not_triggered_large_output() {
+        // Large M and N → output tile grid is big, split-K should NOT activate
+        let mut g = Graph::new();
+        let x = g.input("x", &[128, 256]);
+        let w = g.parameter("w", &[256, 128]);
+        let y = g.matmul(x, w);
+        g.set_outputs(vec![y]);
+
+        let opt = optimize(&g);
+        let output_id = opt.outputs()[0];
+        let output_node = opt.node(output_id);
+        assert!(
+            matches!(output_node.op, Op::MatMul),
+            "expected MatMul (no split-K), got {:?}",
+            output_node.op
+        );
+    }
+
+    #[test]
+    fn test_split_k_compile_dual_dispatch() {
+        // Verify that split-K compiles to 2 dispatches
+        let mut g = Graph::new();
+        let x = g.input("x", &[2, 512]);
+        let w = g.parameter("w", &[512, 32]);
+        let y = g.matmul(x, w);
+        g.set_outputs(vec![y]);
+
+        let opt = optimize(&g);
+        let plan = crate::compile::compile(&opt);
+        // Should have 2 dispatches: split-K partial + finalize
+        assert_eq!(
+            plan.dispatches.len(),
+            2,
+            "expected 2 dispatches for split-K, got {}",
+            plan.dispatches.len()
+        );
+        assert_eq!(
+            plan.dispatches[0].shader,
+            crate::compile::ShaderEntry::MatMulSplitK
+        );
+        assert_eq!(
+            plan.dispatches[1].shader,
+            crate::compile::ShaderEntry::MatMulSplitKFinalize
+        );
+        // Z-dimension of first dispatch should be > 1
+        assert!(
+            plan.dispatches[0].workgroups[2] > 1,
+            "expected Z > 1 for split-K, got {:?}",
+            plan.dispatches[0].workgroups
         );
     }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -181,12 +181,18 @@ fn graph_to_egglog(graph: &Graph) -> String {
   ; Fused ops
   (FusedMatMulRelu Op Op)
   (FusedMatMulBiasRelu Op Op Op)
+  (FusedMatMulSilu Op Op)
+  (FusedMatMulGelu Op Op)
   ; Transformer ops (passthrough, no fusion rules)
   (Silu Op)
+  (Gelu Op)
   (RmsNorm Op Op)
   (Embedding Op Op)
   (RoPE Op)
   (CausalAttention Op Op Op)
+  (LayerNorm Op Op Op)
+  (FullAttention Op Op Op)
+  (CrossAttention Op Op Op)
 )
 
 ",
@@ -198,6 +204,8 @@ fn graph_to_egglog(graph: &Graph) -> String {
 ; --- Operator fusion ---
 (rewrite (Relu (MatMul ?a ?b)) (FusedMatMulRelu ?a ?b))
 (rewrite (Relu (BiasAdd (MatMul ?a ?b) ?c)) (FusedMatMulBiasRelu ?a ?b ?c))
+(rewrite (Silu (MatMul ?a ?b)) (FusedMatMulSilu ?a ?b))
+(rewrite (Gelu (MatMul ?a ?b)) (FusedMatMulGelu ?a ?b))
 
 ; --- Algebraic simplifications ---
 (rewrite (Neg (Neg ?x)) ?x)
@@ -252,6 +260,12 @@ fn node_to_egglog_expr(node: &Node) -> String {
             "(FusedMatMulBiasRelu n{} n{} n{})",
             node.inputs[0], node.inputs[1], node.inputs[2]
         ),
+        Op::FusedMatMulSilu => {
+            format!("(FusedMatMulSilu n{} n{})", node.inputs[0], node.inputs[1])
+        }
+        Op::FusedMatMulGelu => {
+            format!("(FusedMatMulGelu n{} n{})", node.inputs[0], node.inputs[1])
+        }
         Op::Silu => format!("(Silu n{})", node.inputs[0]),
         Op::RmsNorm { .. } => format!("(RmsNorm n{} n{})", node.inputs[0], node.inputs[1]),
         Op::Embedding => format!("(Embedding n{} n{})", node.inputs[0], node.inputs[1]),
@@ -344,6 +358,42 @@ fn apply_fusion_rewrites(graph: &mut Graph) -> Vec<(String, u32)> {
                         continue;
                     }
                     _ => {}
+                }
+            }
+            // Silu(MatMul(a,b)) → FusedMatMulSilu(a,b)
+            Op::Silu => {
+                let input_id = resolve(node.inputs[0], &replacements);
+                let input_node = &graph.nodes()[input_id as usize];
+                if let Op::MatMul = input_node.op {
+                    let a = resolve(input_node.inputs[0], &replacements);
+                    let b = resolve(input_node.inputs[1], &replacements);
+                    fusions.push((
+                        i,
+                        Op::FusedMatMulSilu,
+                        vec![a, b],
+                        node.ty.clone(),
+                        vec![input_id as usize],
+                        "FusedMatMulSilu",
+                    ));
+                    continue;
+                }
+            }
+            // Gelu(MatMul(a,b)) → FusedMatMulGelu(a,b)
+            Op::Gelu => {
+                let input_id = resolve(node.inputs[0], &replacements);
+                let input_node = &graph.nodes()[input_id as usize];
+                if let Op::MatMul = input_node.op {
+                    let a = resolve(input_node.inputs[0], &replacements);
+                    let b = resolve(input_node.inputs[1], &replacements);
+                    fusions.push((
+                        i,
+                        Op::FusedMatMulGelu,
+                        vec![a, b],
+                        node.ty.clone(),
+                        vec![input_id as usize],
+                        "FusedMatMulGelu",
+                    ));
+                    continue;
                 }
             }
             _ => {}
@@ -582,6 +632,44 @@ mod tests {
         let program = graph_to_egglog(&g);
         let mut egraph = egglog::EGraph::default();
         egraph.parse_and_run_program(None, &program).unwrap();
+    }
+
+    #[test]
+    fn test_fusion_matmul_silu() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 784]);
+        let w = g.parameter("w", &[784, 128]);
+        let mm = g.matmul(x, w);
+        let h = g.silu(mm);
+        g.set_outputs(vec![h]);
+
+        let opt = optimize(&g);
+        let output_id = opt.outputs()[0];
+        let output_node = opt.node(output_id);
+        assert!(
+            matches!(output_node.op, Op::FusedMatMulSilu),
+            "expected FusedMatMulSilu, got {:?}",
+            output_node.op
+        );
+    }
+
+    #[test]
+    fn test_fusion_matmul_gelu() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 784]);
+        let w = g.parameter("w", &[784, 128]);
+        let mm = g.matmul(x, w);
+        let h = g.gelu(mm);
+        g.set_outputs(vec![h]);
+
+        let opt = optimize(&g);
+        let output_id = opt.outputs()[0];
+        let output_node = opt.node(output_id);
+        assert!(
+            matches!(output_node.op, Op::FusedMatMulGelu),
+            "expected FusedMatMulGelu, got {:?}",
+            output_node.op
+        );
     }
 
     #[test]

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -240,8 +240,16 @@ fn write_pftrace(path: &Path, events: &[TraceEvent]) -> std::io::Result<()> {
     pkt.uint32(10, 1);
     trace.message(1, &pkt);
 
+    // Sort events by timestamp so Perfetto sees them in order within the
+    // shared packet sequence. GPU pass events are appended after CPU events
+    // but carry earlier timestamps (the submit offset), which causes
+    // "misplaced End" warnings if written in insertion order.
+    let mut sorted: Vec<usize> = (0..events.len()).collect();
+    sorted.sort_by_key(|&i| events[i].timestamp_ns);
+
     // Event packets.
-    for ev in events {
+    for &i in &sorted {
+        let ev = &events[i];
         let mut te = ProtoBuf::new();
         te.uint64(11, ev.track_uuid); // track_uuid
         te.int32(9, ev.kind as i32); // type enum

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -239,7 +239,7 @@ impl Pipelines {
 fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
     use blade_graphics::ShaderData;
     match *entry {
-        ShaderEntry::MatMul | ShaderEntry::MatMulRelu => MatMulData::layout(),
+        ShaderEntry::MatMul | ShaderEntry::MatMulRelu | ShaderEntry::MatMulSilu | ShaderEntry::MatMulGelu => MatMulData::layout(),
         ShaderEntry::MatMulBiasRelu => MatMulBiasReluData::layout(),
         ShaderEntry::Relu | ShaderEntry::Sigmoid | ShaderEntry::Neg | ShaderEntry::Silu => {
             UnaryData::layout()
@@ -441,7 +441,7 @@ impl Session {
     ) {
         let buf = |r: BufferRef| buffers[r.0 as usize].at(0);
         match dispatch.shader {
-            ShaderEntry::MatMul | ShaderEntry::MatMulRelu => {
+            ShaderEntry::MatMul | ShaderEntry::MatMulRelu | ShaderEntry::MatMulSilu | ShaderEntry::MatMulGelu => {
                 pc.bind(
                     0,
                     &MatMulData {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -239,7 +239,9 @@ impl Pipelines {
 fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
     use blade_graphics::ShaderData;
     match *entry {
-        ShaderEntry::MatMul | ShaderEntry::MatMulRelu | ShaderEntry::MatMulSilu | ShaderEntry::MatMulGelu => MatMulData::layout(),
+        ShaderEntry::MatMul | ShaderEntry::MatMulRelu | ShaderEntry::MatMulSilu | ShaderEntry::MatMulGelu
+        | ShaderEntry::MatMulSplitK => MatMulData::layout(),
+        ShaderEntry::MatMulSplitKFinalize => UnaryData::layout(),
         ShaderEntry::MatMulBiasRelu => MatMulBiasReluData::layout(),
         ShaderEntry::Relu | ShaderEntry::Sigmoid | ShaderEntry::Neg | ShaderEntry::Silu => {
             UnaryData::layout()
@@ -441,7 +443,8 @@ impl Session {
     ) {
         let buf = |r: BufferRef| buffers[r.0 as usize].at(0);
         match dispatch.shader {
-            ShaderEntry::MatMul | ShaderEntry::MatMulRelu | ShaderEntry::MatMulSilu | ShaderEntry::MatMulGelu => {
+            ShaderEntry::MatMul | ShaderEntry::MatMulRelu | ShaderEntry::MatMulSilu | ShaderEntry::MatMulGelu
+            | ShaderEntry::MatMulSplitK => {
                 pc.bind(
                     0,
                     &MatMulData {
@@ -452,7 +455,22 @@ impl Session {
                             m: dispatch.params[0],
                             k: dispatch.params[1],
                             n: dispatch.params[2],
-                            _pad: 0,
+                            _pad: dispatch.params[3],
+                        },
+                    },
+                );
+            }
+            ShaderEntry::MatMulSplitKFinalize => {
+                pc.bind(
+                    0,
+                    &UnaryData {
+                        src: buf(dispatch.input_buffers[0]),
+                        dst: buf(dispatch.output_buffer),
+                        params: UnaryParams {
+                            len: dispatch.params[0],
+                            _pad0: dispatch.params[1],
+                            _pad1: 0,
+                            _pad2: 0,
                         },
                     },
                 );


### PR DESCRIPTION
## Summary

- Add **FusedMatMulSilu** and **FusedMatMulGelu** e-graph fusion rules that eliminate a global memory round-trip by computing the activation inside the MatMul kernel's store path
- Add **MatMulSplitK** e-graph exploration that partitions the K-reduction across workgroup Z-slices for better AMD GPU occupancy when the output tile grid is small (M,N small) but K is large
- Split-K compiles to a dual-dispatch: tiled partial accumulation → flat finalize reduction, with automatic intermediate buffer allocation

## Test plan

- [x] All 85 tests pass (`cargo test --lib`)
- [x] `test_fusion_matmul_silu` — verifies `Silu(MatMul(a,b))` fuses to `FusedMatMulSilu`
- [x] `test_fusion_matmul_gelu` — verifies `Gelu(MatMul(a,b))` fuses to `FusedMatMulGelu`
- [x] `test_split_k_matmul_triggered` — verifies split-K activates for [2,1024]×[1024,64]
- [x] `test_split_k_not_triggered_large_output` — verifies split-K skips [128,256]×[256,128]
- [x] `test_split_k_compile_dual_dispatch` — verifies 2 dispatches emitted with Z > 1
- [x] All shader groups pass Naga WGSL validation roundtrip
- [ ] Run on AMD hardware to verify perf improvement on action expert MatMul
