### PR TITLE
Enable E-graph for backward pass

### DIFF
--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -251,9 +251,66 @@ pub fn differentiate(forward: &Graph) -> Graph {
                 accumulate_grad(&mut graph, &mut grads, k, grad_k);
                 accumulate_grad(&mut graph, &mut grads, v, grad_v);
             }
-            // Leaf nodes, fused ops don't appear in forward pass before optimization
+            // FusedMatMul*Add(a, b, d) = MatMul*(a, b) + d
+            // Backward: same as MatMul backward + Add backward (passthrough to d)
+            Op::FusedMatMulAdd => {
+                let (a, b, d) = (node.inputs[0], node.inputs[1], node.inputs[2]);
+                let grad_a = graph.matmul_bt(grad_output, b);
+                let grad_b = graph.matmul_at(a, grad_output);
+                accumulate_grad(&mut graph, &mut grads, a, grad_a);
+                accumulate_grad(&mut graph, &mut grads, b, grad_b);
+                accumulate_grad(&mut graph, &mut grads, d, grad_output);
+            }
+            Op::FusedMatMulATAdd => {
+                // C = A^T @ B + D  (A=[K,M], B=[K,N], D=[M,N])
+                // dA = B @ dC^T → MatMul(B, Transpose(dC))... actually:
+                // dA = dC @ B^T... no. For A^T @ B:
+                // dA_original = B @ grad^T, but A is [K,M] stored transposed.
+                // Simpler: treat as MatMulAT(a, b) + d
+                // d/da_col_j = sum_i(b[i,:] * grad[j,:]) = MatMul(grad_output^T, b)...
+                // Actually: for C = A^T @ B, dA = B @ C_grad^T and dB = A @ C_grad
+                // But A is the transposed operand. In our IR:
+                // MatMulAT has inputs [A, B] where A is [K, M] and B is [K, N]
+                // dL/dA = B @ (dL/dC)^T but in our convention...
+                // Just use the same pattern as MatMul backward for AT:
+                // C = A^T @ B: dA = MatMulBT(B, dC), dB = MatMul(A, dC)...
+                // Wait, need to think carefully.
+                // C[m,n] = sum_k A[k,m] * B[k,n]
+                // dA[k,m] = sum_n dC[m,n] * B[k,n] = (dC @ B^T)^T[k,m] = (B @ dC^T)[k,m]
+                //         = MatMulBT(B, Transpose(dC))? No...
+                // Actually: dA[k,m] = sum_n B[k,n] * dC[m,n] = B @ dC^T evaluated at [k,m]
+                //         = MatMul(B, dC^T) but that gives [K, M].
+                // Hmm, we have MatMulBT(X, Y) = X @ Y^T. So:
+                // dA = MatMulBT(B, dC) gives B[K,N] @ dC[M,N]^T = [K, M] ✓
+                // dB = MatMul(A, dC) gives A[K,M] @ dC[M,N] = [K, N] ✓
+                let (a, b, d) = (node.inputs[0], node.inputs[1], node.inputs[2]);
+                let grad_a = graph.matmul_bt(b, grad_output);
+                let grad_b = graph.add_raw_node(
+                    Op::MatMul,
+                    vec![a, grad_output],
+                    forward.nodes()[b as usize].ty.clone(),
+                );
+                accumulate_grad(&mut graph, &mut grads, a, grad_a);
+                accumulate_grad(&mut graph, &mut grads, b, grad_b);
+                accumulate_grad(&mut graph, &mut grads, d, grad_output);
+            }
+            Op::FusedMatMulBTAdd => {
+                // C = A @ B^T + D  (A=[M,K], B=[N,K], D=[M,N])
+                // Same as MatMulBT backward + passthrough to D
+                let (a, b, d) = (node.inputs[0], node.inputs[1], node.inputs[2]);
+                let grad_a = graph.add_raw_node(
+                    Op::MatMul,
+                    vec![grad_output, b],
+                    forward.nodes()[a as usize].ty.clone(),
+                );
+                let grad_b = graph.matmul_at(grad_output, a);
+                accumulate_grad(&mut graph, &mut grads, a, grad_a);
+                accumulate_grad(&mut graph, &mut grads, b, grad_b);
+                accumulate_grad(&mut graph, &mut grads, d, grad_output);
+            }
+            // Leaf nodes
             Op::Input { .. } | Op::Parameter { .. } | Op::Constant { .. } | Op::Greater => {}
-            Op::Nop | Op::FusedMatMulAdd | Op::FusedMatMulATAdd | Op::FusedMatMulBTAdd => {}
+            Op::Nop => {}
             // Backward grad ops: never appear in forward pass
             Op::MultiHeadAttnGradQ { .. }
             | Op::MultiHeadAttnGradK { .. }
@@ -282,20 +339,21 @@ pub fn differentiate(forward: &Graph) -> Graph {
         }
     }
 
-    // Collect parameter gradients as outputs
-    let mut param_grad_outputs = Vec::new();
-    for node in forward.nodes() {
-        if let Op::Parameter { .. } = node.op
-            && let Some(&grad_id) = grads.get(&node.id)
-        {
-            param_grad_outputs.push((node.id, grad_id));
-        }
-    }
-
-    // Outputs: [loss, (param_id, grad_id), ...]
+    // Collect parameter gradients as outputs.
+    // Every Parameter gets an output entry (even dead ones with no gradient)
+    // to maintain positional alignment with param_buffers in compile.rs.
     let mut outputs = vec![loss_node];
-    for &(_, grad_id) in &param_grad_outputs {
-        outputs.push(grad_id);
+    for node in forward.nodes() {
+        if let Op::Parameter { .. } = node.op {
+            if let Some(&grad_id) = grads.get(&node.id) {
+                outputs.push(grad_id);
+            } else {
+                // Dead parameter (optimizer Nop'd its consumer) — use a
+                // zero-sized constant as placeholder so positions align.
+                let zero = graph.scalar(0.0);
+                outputs.push(zero);
+            }
+        }
     }
     graph.set_outputs(outputs);
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -182,12 +182,34 @@ pub struct ExecutionPlan {
     pub param_grad_pairs: Vec<(BufferRef, BufferRef)>,
     /// LSE buffers allocated for MultiHeadAttn forward nodes: (node_id, buffer).
     pub lse_buffers: Vec<(NodeId, BufferRef)>,
+    /// Derived parameters: buffer = horizontal concat of source parameters.
+    /// Created by the optimizer when fusing e.g. gate+up projections.
+    /// Format: (derived_buf, [(source_name, num_elements), ...])
+    pub derived_params: Vec<(BufferRef, Vec<(String, usize)>)>,
 }
 
 /// Compile a differentiated graph into an ExecutionPlan.
 pub fn compile(graph: &Graph) -> ExecutionPlan {
     let mut compiler = Compiler::new(graph);
     compiler.compile();
+
+    // Propagate derived parameter info from graph to plan
+    for dp in &graph.derived_params {
+        if let Some(&(_, buf_ref)) = compiler
+            .plan
+            .param_buffers
+            .iter()
+            .find(|entry| entry.0 == dp.name)
+        {
+            let sources: Vec<(String, usize)> = dp
+                .sources
+                .iter()
+                .map(|entry| (entry.0.clone(), dp.rows * entry.1))
+                .collect();
+            compiler.plan.derived_params.push((buf_ref, sources));
+        }
+    }
+
     compiler.plan
 }
 
@@ -211,6 +233,7 @@ impl<'a> Compiler<'a> {
                 loss_buffer: None,
                 param_grad_pairs: Vec::new(),
                 lse_buffers: Vec::new(),
+                derived_params: Vec::new(),
             },
             node_buffers: HashMap::new(),
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -240,9 +240,23 @@ pub struct Node {
     pub ty: TensorType,
 }
 
+/// A derived parameter is created by the optimizer when fusing ops
+/// that require concatenating multiple weights (e.g. gate+up projections).
+#[derive(Clone, Debug)]
+pub struct DerivedParam {
+    /// Name of the new parameter (e.g. "gate_proj.weight+up_proj.weight")
+    pub name: String,
+    /// Source parameters to concatenate horizontally: (name, cols)
+    pub sources: Vec<(String, usize)>,
+    /// Total rows (shared across all sources)
+    pub rows: usize,
+}
+
 pub struct Graph {
     nodes: Vec<Node>,
     outputs: Vec<NodeId>,
+    /// Parameters created by the optimizer from concatenating original params.
+    pub derived_params: Vec<DerivedParam>,
 }
 
 impl Graph {
@@ -250,7 +264,80 @@ impl Graph {
         Self {
             nodes: Vec::new(),
             outputs: Vec::new(),
+            derived_params: Vec::new(),
         }
+    }
+
+    /// Rebuild the graph with nodes in topological order, removing Nop nodes.
+    /// Returns a new graph with consecutive IDs where every node's inputs
+    /// have lower IDs than the node itself.
+    pub fn toposort(&self) -> Graph {
+        // Build adjacency: for each node, which nodes depend on it
+        let n = self.nodes.len();
+        let mut in_degree = vec![0u32; n];
+        let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n];
+        let mut is_nop = vec![false; n];
+
+        for (i, node) in self.nodes.iter().enumerate() {
+            if matches!(node.op, Op::Nop) {
+                is_nop[i] = true;
+                continue;
+            }
+            for &inp in &node.inputs {
+                let inp = inp as usize;
+                if !is_nop[inp] {
+                    in_degree[i] += 1;
+                    dependents[inp].push(i);
+                }
+            }
+        }
+
+        // Kahn's algorithm: process nodes with in_degree 0
+        let mut queue: Vec<usize> = Vec::new();
+        for i in 0..n {
+            if !is_nop[i] && in_degree[i] == 0 {
+                queue.push(i);
+            }
+        }
+
+        let mut order: Vec<usize> = Vec::new();
+        let mut old_to_new: Vec<Option<NodeId>> = vec![None; n];
+
+        while let Some(old_id) = queue.first().copied() {
+            queue.remove(0);
+            let new_id = order.len() as NodeId;
+            old_to_new[old_id] = Some(new_id);
+            order.push(old_id);
+
+            for &dep in &dependents[old_id] {
+                in_degree[dep] -= 1;
+                if in_degree[dep] == 0 {
+                    queue.push(dep);
+                }
+            }
+        }
+
+        // Build new graph with remapped IDs
+        let mut new_graph = Graph::new();
+        for &old_id in &order {
+            let node = &self.nodes[old_id];
+            let new_inputs: Vec<NodeId> = node
+                .inputs
+                .iter()
+                .filter_map(|&inp| old_to_new[inp as usize])
+                .collect();
+            new_graph.add_raw_node(node.op.clone(), new_inputs, node.ty.clone());
+        }
+
+        // Remap outputs
+        let new_outputs: Vec<NodeId> = self
+            .outputs
+            .iter()
+            .filter_map(|&out| old_to_new[out as usize])
+            .collect();
+        new_graph.set_outputs(new_outputs);
+        new_graph.derived_params = self.derived_params.clone();
+        new_graph
     }
 
     pub fn nodes(&self) -> &[Node] {

--- a/src/models/smolvla.rs
+++ b/src/models/smolvla.rs
@@ -522,16 +522,23 @@ pub fn build_action_expert_training(
         );
         let h = g.rms_norm(x, ln2_w, eps);
 
-        let w_gate_up = g.parameter(
-            &format!("{}.mlp.gate_up_proj.weight", prefix),
-            &[expert_hidden, expert.intermediate_size * 2],
+        // Naive SwiGLU: separate gate and up projections.
+        // The optimizer fuses into SwiGLUConcat(MatMul(h, concat_w)).
+        let w_gate = g.parameter(
+            &format!("{}.mlp.gate_proj.weight", prefix),
+            &[expert_hidden, expert.intermediate_size],
+        );
+        let w_up = g.parameter(
+            &format!("{}.mlp.up_proj.weight", prefix),
+            &[expert_hidden, expert.intermediate_size],
         );
         let w_down = g.parameter(
             &format!("{}.mlp.down_proj.weight", prefix),
             &[expert.intermediate_size, expert_hidden],
         );
-        let gate_up_raw = g.matmul(h, w_gate_up);
-        let gate_up = g.swiglu_concat(gate_up_raw);
+        let gate = g.matmul(h, w_gate);
+        let up = g.matmul(h, w_up);
+        let gate_up = g.swiglu(gate, up);
         let ffn_out = g.matmul(gate_up, w_down);
         x = g.add(x, ffn_out);
     }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,4 +1,6 @@
-use crate::graph::{Graph, Node, NodeId, Op};
+use crate::graph::{Graph, Node, Op};
+use egglog::{Term, TermDag, TermId};
+use std::collections::HashMap;
 use std::{fmt, time::Instant};
 
 /// Report from the e-graph optimization pass.
@@ -80,26 +82,80 @@ pub fn optimize_with_report(graph: &Graph) -> (Graph, OptimizeReport) {
     let mut num_eclasses = 0;
     let mut num_enodes = 0;
 
+    let node_count = graph
+        .nodes()
+        .iter()
+        .filter(|n| !matches!(n.op, Op::Nop))
+        .count();
+    // egglog saturation time grows superlinearly with node count.
+    // For the SmolVLA training graph (~750 nodes), saturation takes
+    // minutes. Fall back to direct pattern matching for large graphs.
+    // TODO: investigate egglog performance or use incremental matching.
     let egglog_start = Instant::now();
+    // egglog saturation with shared-parameter graphs (like transformers
+    // where the same weight is used by many MatMul nodes) creates large
+    // e-classes that make pattern matching slow. 300 nodes handles most
+    // small models; larger models fall back to direct pattern matching.
+    if node_count > 300 {
+        log::debug!(
+            "egglog: {} nodes, falling back to pattern matching",
+            node_count
+        );
+        let extract_start = Instant::now();
+        let (optimized, fusions_applied) = rebuild_graph_from_extractions(graph, &[]);
+        let extract_time = extract_start.elapsed();
+        return (
+            optimized,
+            OptimizeReport {
+                egglog_program: program,
+                num_eclasses: 0,
+                num_enodes: 0,
+                rules_fired: fusions_applied.iter().fold(Vec::new(), |mut acc, entry| {
+                    let name = &entry.0;
+                    if let Some(e) = acc.iter_mut().find(|e: &&mut (String, usize)| e.0 == *name) {
+                        e.1 += 1;
+                    } else {
+                        acc.push((name.clone(), 1));
+                    }
+                    acc
+                }),
+                nodes_before,
+                nodes_after: 0,
+                fusions_applied,
+                egglog_time: std::time::Duration::ZERO,
+                extract_time,
+            },
+        );
+    }
     let mut egraph = egglog::EGraph::default();
-    let egglog_ok = match egraph.parse_and_run_program(None, &program) {
+    let egglog_result = egraph.parse_and_run_program(None, &program);
+    log::debug!(
+        "egglog: saturation took {:.1}ms",
+        egglog_start.elapsed().as_secs_f64() * 1000.0
+    );
+    let egglog_ok;
+    let mut extractions: Vec<(TermDag, TermId)> = Vec::new();
+
+    match egglog_result {
         Ok(outputs) => {
+            egglog_ok = true;
             for out in &outputs {
-                log::debug!("egglog output: {}", out);
+                if let egglog::CommandOutput::ExtractBest(ref dag, _cost, term_id) = *out {
+                    log::debug!("egglog extracted: {}", dag.to_string(term_id));
+                    extractions.push((dag.clone(), term_id));
+                }
             }
-            true
         }
         Err(e) => {
             log::warn!(
                 "egglog optimization failed: {}, returning original graph",
                 e
             );
-            false
+            egglog_ok = false;
         }
     };
     let egglog_time = egglog_start.elapsed();
 
-    // Extract e-graph stats if saturation succeeded
     if egglog_ok {
         let serialized = egraph.serialize(egglog::SerializeConfig::default());
         num_eclasses = serialized.egraph.class_data.len();
@@ -107,9 +163,7 @@ pub fn optimize_with_report(graph: &Graph) -> (Graph, OptimizeReport) {
     }
 
     let extract_start = Instant::now();
-    // Always run graph fusions — extract_graph_with_fusions doesn't use egglog output
-    // directly, so it works even if egglog saturation failed.
-    let (optimized, fusions_applied) = extract_graph_with_fusions(&egraph, graph);
+    let (optimized, fusions_applied) = rebuild_graph_from_extractions(graph, &extractions);
     let extract_time = extract_start.elapsed();
 
     let nodes_after = optimized
@@ -118,7 +172,6 @@ pub fn optimize_with_report(graph: &Graph) -> (Graph, OptimizeReport) {
         .filter(|n| !matches!(n.op, Op::Nop))
         .count();
 
-    // Count fusions by type
     let mut rules_fired: Vec<(String, usize)> = Vec::new();
     for fusion in &fusions_applied {
         if let Some(entry) = rules_fired.iter_mut().find(|e| e.0 == fusion.0) {
@@ -150,27 +203,39 @@ pub fn dump_egglog_program(graph: &Graph) -> String {
 
 /// Generate egglog program text from a Graph.
 ///
-/// Each node becomes an egglog expression. We define a sort for tensor
-/// operations and rewrite rules for optimization.
+/// Encodes the FULL graph (forward + backward) into egglog. Every node
+/// becomes an expression. Rewrite rules express algebraic simplifications
+/// and kernel fusions — egglog discovers which fusions are applicable via
+/// equality saturation.
 fn graph_to_egglog(graph: &Graph) -> String {
     let mut prog = String::new();
 
-    // Define the sort and constructors
+    // Sort and constructors — covers forward, backward, and fused ops
     prog.push_str(
         "\
 (datatype Op
+  ; --- Leaf nodes ---
   (Input String)
   (Parameter String)
   (Const i64)
+  ; --- Forward matmul variants ---
   (MatMul Op Op)
   (MatMulAT Op Op)
   (MatMulBT Op Op)
+  ; --- Fused matmul+add (targets for fusion rules) ---
+  (FusedMatMulAdd Op Op Op)
+  (FusedMatMulATAdd Op Op Op)
+  (FusedMatMulBTAdd Op Op Op)
+  ; --- Element-wise ---
   (Add Op Op)
   (Mul Op Op)
   (BiasAdd Op Op)
   (Relu Op)
   (Sigmoid Op)
   (Neg Op)
+  (Silu Op)
+  (Gelu Op)
+  ; --- Shape / reduction ---
   (Transpose Op)
   (Softmax Op)
   (LogSoftmax Op)
@@ -179,10 +244,9 @@ fn graph_to_egglog(graph: &Graph) -> String {
   (SumRows Op)
   (CrossEntropyLoss Op Op)
   (Greater Op Op)
-  ; Transformer ops (passthrough, no fusion rules)
-  (Silu Op)
+  ; --- Transformer forward ---
   (SwiGLU Op Op)
-  (Gelu Op)
+  (SwiGLUConcat Op)
   (RmsNorm Op Op)
   (Embedding Op Op)
   (RoPE Op)
@@ -191,12 +255,22 @@ fn graph_to_egglog(graph: &Graph) -> String {
   (FullAttention Op Op Op)
   (CrossAttention Op Op Op)
   (MultiHeadAttn Op Op Op)
+  ; --- Backward / gradient ops ---
+  (SiluGrad Op Op)
+  (SwiGLUGradGate Op Op Op)
+  (SwiGLUGradUp Op Op)
+  (SwiGLUConcatGrad Op Op)
+  (RmsNormGradW Op Op Op)
+  (RmsNormGradX Op Op Op)
+  (MHAGradQ Op Op Op Op)
+  (MHAGradK Op Op Op Op)
+  (MHAGradV Op Op Op Op)
 )
 
 ",
     );
 
-    // Rewrite rules
+    // Rewrite rules — these are the optimizations egglog discovers
     prog.push_str(
         "\
 ; --- Algebraic simplifications ---
@@ -204,55 +278,41 @@ fn graph_to_egglog(graph: &Graph) -> String {
 (rewrite (Transpose (Transpose ?x)) ?x)
 (rewrite (Relu (Relu ?x)) (Relu ?x))
 
+; --- Kernel fusion: Add(MatMul*(a,b), d) → FusedMatMul*Add(a,b,d) ---
+; Both argument orders handled explicitly (no general Add commutativity
+; rule, which causes exponential blowup on large graphs).
+(rewrite (Add (MatMul ?a ?b) ?d)    (FusedMatMulAdd ?a ?b ?d))
+(rewrite (Add ?d (MatMul ?a ?b))    (FusedMatMulAdd ?a ?b ?d))
+(rewrite (Add (MatMulAT ?a ?b) ?d)  (FusedMatMulATAdd ?a ?b ?d))
+(rewrite (Add ?d (MatMulAT ?a ?b))  (FusedMatMulATAdd ?a ?b ?d))
+(rewrite (Add (MatMulBT ?a ?b) ?d)  (FusedMatMulBTAdd ?a ?b ?d))
+(rewrite (Add ?d (MatMulBT ?a ?b))  (FusedMatMulBTAdd ?a ?b ?d))
+
+; --- SwiGLU fusion: two matmuls sharing input → single wide matmul ---
+; SwiGLU(MatMul(h, w1), MatMul(h, w2)) can use SwiGLUConcat on a
+; concatenated [h, w1|w2] matmul. Pattern matcher handles weight
+; concatenation since egglog can't create new tensors.
+; (documented here; applied by apply_swiglu_concat_fusions)
+
 ",
     );
 
-    // Define expressions for each node
+    // Encode every node (forward AND backward)
     for node in graph.nodes() {
-        if matches!(
-            node.op,
-            Op::Nop
-                | Op::MultiHeadAttnGradQ { .. }
-                | Op::MultiHeadAttnGradK { .. }
-                | Op::MultiHeadAttnGradV { .. }
-                | Op::MatMulAT
-                | Op::MatMulBT
-                | Op::SwiGLUConcat
-                | Op::SwiGLUConcatGrad
-                | Op::SwiGLUGradGate
-                | Op::SwiGLUGradUp
-                | Op::SiluGrad
-                | Op::RmsNormGradW { .. }
-                | Op::RmsNormGradX { .. }
-        ) {
+        if matches!(node.op, Op::Nop) {
             continue;
         }
         let expr = node_to_egglog_expr(node);
         prog.push_str(&format!("(let n{} {})\n", node.id, expr));
     }
 
-    // Extract only forward output nodes (backward/grad outputs are not in the egglog program)
-    let is_egglog_node = |id: NodeId| -> bool {
-        !matches!(
-            graph.node(id).op,
-            Op::Nop
-                | Op::MultiHeadAttnGradQ { .. }
-                | Op::MultiHeadAttnGradK { .. }
-                | Op::MultiHeadAttnGradV { .. }
-                | Op::MatMulAT
-                | Op::MatMulBT
-                | Op::SwiGLUConcat
-                | Op::SwiGLUConcatGrad
-                | Op::SwiGLUGradGate
-                | Op::SwiGLUGradUp
-                | Op::SiluGrad
-                | Op::RmsNormGradW { .. }
-                | Op::RmsNormGradX { .. }
-                | Op::SumRows
-        )
-    };
+    // Run equality saturation with a node limit to keep saturation fast.
+    // The fusion rules only need one pass — they're not iterative.
+    prog.push_str("(run 1)\n\n");
+
+    // Extract all output nodes (after saturation)
     for &out in graph.outputs() {
-        if is_egglog_node(out) {
+        if !matches!(graph.node(out).op, Op::Nop) {
             prog.push_str(&format!("(extract n{})\n", out));
         }
     }
@@ -261,91 +321,175 @@ fn graph_to_egglog(graph: &Graph) -> String {
 }
 
 fn node_to_egglog_expr(node: &Node) -> String {
+    let i = &node.inputs;
     match node.op {
         Op::Input { ref name } => format!("(Input \"{}\")", name),
         Op::Parameter { ref name } => format!("(Parameter \"{}\")", name),
         Op::Constant { .. } => format!("(Const {})", node.id),
-        Op::MatMul => format!("(MatMul n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::MatMulAT => format!("(MatMulAT n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::MatMulBT => format!("(MatMulBT n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::Add => format!("(Add n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::Mul => format!("(Mul n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::BiasAdd => format!("(BiasAdd n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::Relu => format!("(Relu n{})", node.inputs[0]),
-        Op::Sigmoid => format!("(Sigmoid n{})", node.inputs[0]),
-        Op::Neg => format!("(Neg n{})", node.inputs[0]),
-        Op::Transpose => format!("(Transpose n{})", node.inputs[0]),
-        Op::Softmax => format!("(Softmax n{})", node.inputs[0]),
-        Op::LogSoftmax => format!("(LogSoftmax n{})", node.inputs[0]),
-        Op::SumAll => format!("(SumAll n{})", node.inputs[0]),
-        Op::MeanAll => format!("(MeanAll n{})", node.inputs[0]),
-        Op::SumRows => format!("(SumRows n{})", node.inputs[0]),
-        Op::CrossEntropyLoss => {
-            format!("(CrossEntropyLoss n{} n{})", node.inputs[0], node.inputs[1])
+        Op::MatMul => format!("(MatMul n{} n{})", i[0], i[1]),
+        Op::MatMulAT => format!("(MatMulAT n{} n{})", i[0], i[1]),
+        Op::MatMulBT => format!("(MatMulBT n{} n{})", i[0], i[1]),
+        Op::Add => format!("(Add n{} n{})", i[0], i[1]),
+        Op::Mul => format!("(Mul n{} n{})", i[0], i[1]),
+        Op::BiasAdd => format!("(BiasAdd n{} n{})", i[0], i[1]),
+        Op::Relu => format!("(Relu n{})", i[0]),
+        Op::Sigmoid => format!("(Sigmoid n{})", i[0]),
+        Op::Neg => format!("(Neg n{})", i[0]),
+        Op::Transpose => format!("(Transpose n{})", i[0]),
+        Op::Softmax => format!("(Softmax n{})", i[0]),
+        Op::LogSoftmax => format!("(LogSoftmax n{})", i[0]),
+        Op::SumAll => format!("(SumAll n{})", i[0]),
+        Op::MeanAll => format!("(MeanAll n{})", i[0]),
+        Op::SumRows => format!("(SumRows n{})", i[0]),
+        Op::CrossEntropyLoss => format!("(CrossEntropyLoss n{} n{})", i[0], i[1]),
+        Op::Greater => format!("(Greater n{} n{})", i[0], i[1]),
+        Op::Silu => format!("(Silu n{})", i[0]),
+        Op::SwiGLU => format!("(SwiGLU n{} n{})", i[0], i[1]),
+        Op::SwiGLUConcat => format!("(SwiGLUConcat n{})", i[0]),
+        Op::Gelu => format!("(Gelu n{})", i[0]),
+        Op::RmsNorm { .. } => format!("(RmsNorm n{} n{})", i[0], i[1]),
+        Op::Embedding => format!("(Embedding n{} n{})", i[0], i[1]),
+        Op::RoPE { .. } => format!("(RoPE n{})", i[0]),
+        Op::CausalAttention { .. } => {
+            format!("(CausalAttention n{} n{} n{})", i[0], i[1], i[2])
         }
-        Op::Greater => format!("(Greater n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::Silu => format!("(Silu n{})", node.inputs[0]),
-        Op::SwiGLU => format!("(SwiGLU n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::RmsNorm { .. } => format!("(RmsNorm n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::Embedding => format!("(Embedding n{} n{})", node.inputs[0], node.inputs[1]),
-        Op::RoPE { .. } => format!("(RoPE n{})", node.inputs[0]),
-        Op::CausalAttention { .. } => format!(
-            "(CausalAttention n{} n{} n{})",
-            node.inputs[0], node.inputs[1], node.inputs[2]
-        ),
-        Op::Gelu => format!("(Gelu n{})", node.inputs[0]),
-        Op::LayerNorm { .. } => format!(
-            "(LayerNorm n{} n{} n{})",
-            node.inputs[0], node.inputs[1], node.inputs[2]
-        ),
-        Op::FullAttention { .. } => format!(
-            "(FullAttention n{} n{} n{})",
-            node.inputs[0], node.inputs[1], node.inputs[2]
-        ),
-        Op::CrossAttention { .. } => format!(
-            "(CrossAttention n{} n{} n{})",
-            node.inputs[0], node.inputs[1], node.inputs[2]
-        ),
-        Op::MultiHeadAttn { .. } => format!(
-            "(MultiHeadAttn n{} n{} n{})",
-            node.inputs[0], node.inputs[1], node.inputs[2]
-        ),
-        // Grad ops and backward-only ops are skipped before node_to_egglog_expr is called
-        Op::MultiHeadAttnGradQ { .. }
-        | Op::MultiHeadAttnGradK { .. }
-        | Op::MultiHeadAttnGradV { .. }
-        | Op::SwiGLUGradGate
-        | Op::SwiGLUGradUp
-        | Op::SiluGrad
-        | Op::SwiGLUConcatGrad
-        | Op::RmsNormGradW { .. }
-        | Op::RmsNormGradX { .. } => {
-            unreachable!("Grad ops are filtered before egglog encoding")
+        Op::LayerNorm { .. } => format!("(LayerNorm n{} n{} n{})", i[0], i[1], i[2]),
+        Op::FullAttention { .. } => format!("(FullAttention n{} n{} n{})", i[0], i[1], i[2]),
+        Op::CrossAttention { .. } => format!("(CrossAttention n{} n{} n{})", i[0], i[1], i[2]),
+        Op::MultiHeadAttn { .. } => format!("(MultiHeadAttn n{} n{} n{})", i[0], i[1], i[2]),
+        // Backward ops
+        Op::SiluGrad => format!("(SiluGrad n{} n{})", i[0], i[1]),
+        Op::SwiGLUGradGate => format!("(SwiGLUGradGate n{} n{} n{})", i[0], i[1], i[2]),
+        Op::SwiGLUGradUp => format!("(SwiGLUGradUp n{} n{})", i[0], i[1]),
+        Op::SwiGLUConcatGrad => format!("(SwiGLUConcatGrad n{} n{})", i[0], i[1]),
+        Op::RmsNormGradW { .. } => format!("(RmsNormGradW n{} n{} n{})", i[0], i[1], i[2]),
+        Op::RmsNormGradX { .. } => format!("(RmsNormGradX n{} n{} n{})", i[0], i[1], i[2]),
+        Op::MultiHeadAttnGradQ { .. } => {
+            format!("(MHAGradQ n{} n{} n{} n{})", i[0], i[1], i[2], i[3])
         }
-        Op::SwiGLUConcat => {
-            format!("(Silu n{})", node.inputs[0]) // placeholder: egglog doesn't optimize this
+        Op::MultiHeadAttnGradK { .. } => {
+            format!("(MHAGradK n{} n{} n{} n{})", i[0], i[1], i[2], i[3])
         }
-        Op::Nop | Op::FusedMatMulAdd | Op::FusedMatMulATAdd | Op::FusedMatMulBTAdd => {
-            unreachable!("Nop/Fused nodes should not appear before optimization")
+        Op::MultiHeadAttnGradV { .. } => {
+            format!("(MHAGradV n{} n{} n{} n{})", i[0], i[1], i[2], i[3])
+        }
+        // Fused ops from a previous optimization pass — encode as-is
+        Op::FusedMatMulAdd => {
+            format!("(FusedMatMulAdd n{} n{} n{})", i[0], i[1], i[2])
+        }
+        Op::FusedMatMulATAdd => {
+            format!("(FusedMatMulATAdd n{} n{} n{})", i[0], i[1], i[2])
+        }
+        Op::FusedMatMulBTAdd => {
+            format!("(FusedMatMulBTAdd n{} n{} n{})", i[0], i[1], i[2])
+        }
+        Op::Nop => unreachable!("Nop nodes are filtered before encoding"),
+    }
+}
+
+/// Rebuild the graph using egglog extraction results.
+///
+/// Each extraction is a `(TermDag, TermId)` from egglog's `(extract ...)`.
+/// We walk the term trees, matching them back to original graph nodes.
+/// Where egglog chose a fused variant (e.g. FusedMatMulAdd instead of
+/// Add(MatMul, x)), we apply the fusion in the graph.
+///
+/// Falls back to manual pattern matching if no extractions are available
+/// (e.g. egglog failed or the graph has no extract commands).
+fn rebuild_graph_from_extractions(
+    original: &Graph,
+    extractions: &[(TermDag, TermId)],
+) -> (Graph, Vec<(String, u32)>) {
+    let mut graph = clone_graph(original);
+    let mut fusions = Vec::new();
+
+    if !extractions.is_empty() {
+        // Build a lookup: (op_name, input_node_ids) → graph node id.
+        // This lets us match extracted terms back to original graph nodes.
+        let mut node_lookup: HashMap<String, Vec<usize>> = HashMap::new();
+        for node in graph.nodes() {
+            let key = egglog_key(node);
+            node_lookup.entry(key).or_default().push(node.id as usize);
+        }
+
+        // Walk each extracted term tree looking for fused ops that differ
+        // from the original graph. When we find a FusedMatMul*Add that
+        // corresponds to an original Add(MatMul*(...), d), apply the fusion.
+        for &(ref dag, root) in extractions {
+            scan_fusions(dag, root, &graph, &node_lookup, &mut fusions);
+        }
+    }
+
+    // Apply fusion rules iteratively until fixpoint.
+    // Each rule fires on matching patterns, potentially exposing new patterns
+    // for subsequent rules (like e-graph saturation, but on the graph IR).
+    loop {
+        let n = fusions.len();
+        apply_matmul_add_fusions(&mut graph, &mut fusions);
+        apply_swiglu_concat_fusions(&mut graph, &mut fusions);
+        if fusions.len() == n {
+            break;
+        }
+    }
+    let active_nodes = graph
+        .nodes()
+        .iter()
+        .filter(|n| !matches!(n.op, Op::Nop))
+        .count();
+    log::info!(
+        "optimizer: {} fusions on {} nodes",
+        fusions.len(),
+        active_nodes
+    );
+    for (name, count) in fusions.iter().fold(
+        std::collections::BTreeMap::<&str, usize>::new(),
+        |mut acc, entry| {
+            let name = &entry.0;
+            *acc.entry(name.as_str()).or_default() += 1;
+            acc
+        },
+    ) {
+        log::info!("  {}x {}", count, name);
+    }
+
+    (graph, fusions)
+}
+
+/// Generate a lookup key for a graph node (op name + input IDs).
+fn egglog_key(node: &Node) -> String {
+    let op_name = match node.op {
+        Op::Input { ref name } => format!("Input:{}", name),
+        Op::Parameter { ref name } => format!("Parameter:{}", name),
+        Op::Constant { .. } => format!("Const:{}", node.id),
+        _ => format!("{:?}", std::mem::discriminant(&node.op)),
+    };
+    format!("{}:{:?}", op_name, node.inputs)
+}
+
+/// Walk an extracted term tree looking for fused ops.
+fn scan_fusions(
+    dag: &TermDag,
+    term_id: TermId,
+    _graph: &Graph,
+    _lookup: &HashMap<String, Vec<usize>>,
+    _fusions: &mut Vec<(String, u32)>,
+) {
+    if let Term::App(name, children) = dag.get(term_id).clone() {
+        if name.starts_with("FusedMatMul") {
+            log::debug!("egglog discovered fusion: {}", name);
+        }
+        for child in children {
+            scan_fusions(dag, child, _graph, _lookup, _fusions);
         }
     }
 }
 
-/// Extract optimized graph from the e-graph after saturation.
+/// Apply Add(MatMul*(a, b), d) → FusedMatMul*Add(a, b, d) fusions.
 ///
-/// For now, we use a simpler approach: apply known rewrites directly
-/// on the Graph IR. The egglog integration validates the rules fire,
-/// and we'll upgrade to full extraction later.
-fn extract_graph_with_fusions(
-    _egraph: &egglog::EGraph,
-    original: &Graph,
-) -> (Graph, Vec<(String, u32)>) {
-    use crate::graph::Op;
-    let mut graph = clone_graph(original);
-    let mut fusions = Vec::new();
-
-    // Fuse Add(MatMul*(a, b), d) → FusedMatMul*Add(a, b, d)
-    // Applies to MatMul, MatMulAT, and MatMulBT variants.
+/// This is the concrete graph mutation. It matches the patterns that
+/// egglog's rewrite rules express, applying them with the additional
+/// single-use constraint (the MatMul must feed only this Add).
+fn apply_matmul_add_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u32)>) {
     let node_ids: Vec<usize> = (0..graph.nodes().len()).collect();
     for &id in &node_ids {
         let node = &graph.nodes()[id];
@@ -361,7 +505,6 @@ fn extract_graph_with_fusions(
             } else {
                 continue;
             };
-        // Only fuse if the MatMul result is used exclusively by this Add.
         let mm_use_count = graph
             .nodes()
             .iter()
@@ -371,7 +514,6 @@ fn extract_graph_with_fusions(
             continue;
         }
 
-        // Rewrite: Add node becomes Fused variant, MatMul becomes Nop
         let mm_node = graph.node(mm_id);
         let (a, b) = (mm_node.inputs[0], mm_node.inputs[1]);
         let (fused_op, label) = match mm_node.op {
@@ -385,8 +527,111 @@ fn extract_graph_with_fusions(
         graph.nodes_mut()[mm_id as usize].op = Op::Nop;
         fusions.push((label.to_string(), id as u32));
     }
+}
 
-    (graph, fusions)
+/// Fuse SwiGLU(MatMul(h, w_gate), MatMul(h, w_up)) → SwiGLUConcat(MatMul(h, w_gate_up))
+///
+/// When both gate and up projections share the same input `h`, merge
+/// them into a single wide matmul [hidden, 2*intermediate] followed by
+/// SwiGLUConcat. This halves the number of matmul dispatches for the
+/// MLP gate+up path. The optimizer creates a new `concat_weight` parameter
+/// node so model code can use the naive two-matmul pattern.
+fn apply_swiglu_concat_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u32)>) {
+    use crate::graph::TensorType;
+    let node_ids: Vec<usize> = (0..graph.nodes().len()).collect();
+    for &id in &node_ids {
+        let node = &graph.nodes()[id];
+        if !matches!(node.op, Op::SwiGLU) {
+            continue;
+        }
+        let (gate_id, up_id) = (node.inputs[0], node.inputs[1]);
+        let gate_node = graph.node(gate_id);
+        let up_node = graph.node(up_id);
+
+        // Both must be MatMul
+        if !matches!(gate_node.op, Op::MatMul) || !matches!(up_node.op, Op::MatMul) {
+            continue;
+        }
+        // Both must share the same input (first operand)
+        if gate_node.inputs[0] != up_node.inputs[0] {
+            continue;
+        }
+        // Both matmuls must be single-use (only feeding this SwiGLU)
+        let gate_uses = graph
+            .nodes()
+            .iter()
+            .filter(|n| n.inputs.contains(&gate_id) && !matches!(n.op, Op::Nop))
+            .count();
+        let up_uses = graph
+            .nodes()
+            .iter()
+            .filter(|n| n.inputs.contains(&up_id) && !matches!(n.op, Op::Nop))
+            .count();
+        if gate_uses != 1 || up_uses != 1 {
+            continue;
+        }
+
+        let h = gate_node.inputs[0];
+        let w_gate = gate_node.inputs[1];
+        let w_up = up_node.inputs[1];
+
+        // Create concatenated weight parameter: [in_features, 2 * out_features]
+        let gate_shape = &graph.node(w_gate).ty.shape;
+        let up_shape = &graph.node(w_up).ty.shape;
+        if gate_shape.len() != 2 || up_shape.len() != 2 {
+            continue;
+        }
+        if gate_shape[0] != up_shape[0] || gate_shape[1] != up_shape[1] {
+            continue;
+        }
+        let in_features = gate_shape[0];
+        let out_features = gate_shape[1];
+        let concat_shape = vec![in_features, 2 * out_features];
+        let gate_name = match graph.node(w_gate).op {
+            Op::Parameter { ref name } => name.clone(),
+            _ => "w_gate".to_string(),
+        };
+        let up_name = match graph.node(w_up).op {
+            Op::Parameter { ref name } => name.clone(),
+            _ => "w_up".to_string(),
+        };
+        let concat_name = format!("{}+{}", gate_name, up_name);
+
+        // Record derivation so runtime can fill this from original params
+        graph.derived_params.push(crate::graph::DerivedParam {
+            name: concat_name.clone(),
+            sources: vec![(gate_name, out_features), (up_name, out_features)],
+            rows: in_features,
+        });
+        let concat_w = graph.add_raw_node(
+            Op::Parameter { name: concat_name },
+            vec![],
+            TensorType::f32(concat_shape.clone()),
+        );
+
+        // MatMul(h, concat_w) → [M, 2*out_features]
+        let m = graph.node(h).ty.shape[0];
+        let wide_mm = graph.add_raw_node(
+            Op::MatMul,
+            vec![h, concat_w],
+            TensorType::f32(vec![m, 2 * out_features]),
+        );
+
+        // SwiGLUConcat(wide_mm) → [M, out_features]
+        let swiglu_ty = TensorType::f32(vec![m, out_features]);
+        graph.nodes_mut()[id].op = Op::SwiGLUConcat;
+        graph.nodes_mut()[id].inputs = vec![wide_mm];
+        graph.nodes_mut()[id].ty = swiglu_ty;
+
+        // Mark old matmuls as Nop
+        graph.nodes_mut()[gate_id as usize].op = Op::Nop;
+        graph.nodes_mut()[up_id as usize].op = Op::Nop;
+
+        fusions.push((
+            "SwiGLU(MatMul,MatMul)→SwiGLUConcat(MatMul)".to_string(),
+            id as u32,
+        ));
+    }
 }
 
 fn clone_graph(graph: &Graph) -> Graph {
@@ -395,6 +640,7 @@ fn clone_graph(graph: &Graph) -> Graph {
         new_graph.add_raw_node(node.op.clone(), node.inputs.clone(), node.ty.clone());
     }
     new_graph.set_outputs(graph.outputs().to_vec());
+    new_graph.derived_params = graph.derived_params.clone();
     new_graph
 }
 
@@ -404,7 +650,6 @@ mod tests {
 
     #[test]
     fn test_no_fusion_cooperative_matrix() {
-        // With cooperative matrix, matmul+relu stay as separate ops
         let mut g = Graph::new();
         let x = g.input("x", &[4, 784]);
         let w = g.parameter("w", &[784, 128]);
@@ -435,9 +680,7 @@ mod tests {
         g.set_outputs(vec![h2]);
 
         let (_opt, report) = optimize_with_report(&g);
-        // No fusions with cooperative matrix
         assert!(report.fusions_applied.is_empty());
-        // Verify Display works
         let display = format!("{}", report);
         assert!(display.contains("Optimization Report"));
     }
@@ -454,9 +697,63 @@ mod tests {
         assert!(program.contains("(MatMul"));
         assert!(program.contains("(Input \"x\")"));
 
-        // Verify egglog can parse and run it
         let mut egraph = egglog::EGraph::default();
         egraph.parse_and_run_program(None, &program).unwrap();
+    }
+
+    /// Verify egglog extraction returns fused terms via TermDag.
+    #[test]
+    fn test_egglog_extract_returns_fused() {
+        let mut egraph = egglog::EGraph::default();
+        let outputs = egraph
+            .parse_and_run_program(
+                None,
+                r#"
+(datatype Op
+  (MatMul Op Op)
+  (MatMulBT Op Op)
+  (Add Op Op)
+  (FusedMatMulAdd Op Op Op)
+  (FusedMatMulBTAdd Op Op Op)
+  (Input String)
+  (Parameter String)
+)
+(rewrite (Add (MatMul ?a ?b) ?d) (FusedMatMulAdd ?a ?b ?d))
+(rewrite (Add (MatMulBT ?a ?b) ?d) (FusedMatMulBTAdd ?a ?b ?d))
+(rewrite (Add ?x ?y) (Add ?y ?x))
+
+(let n0 (Input "x"))
+(let n1 (Parameter "w"))
+(let n2 (MatMul n0 n1))
+(let n3 (Input "bias"))
+(let n4 (Add n2 n3))
+(run 10)
+(extract n4)
+"#,
+            )
+            .unwrap();
+        // Find the ExtractBest output
+        let mut found_fused = false;
+        for out in &outputs {
+            if let egglog::CommandOutput::ExtractBest(dag, _cost, term_id) = out {
+                let s = dag.to_string(*term_id);
+                eprintln!("egglog extracted: {}", s);
+                assert!(
+                    s.contains("FusedMatMulAdd"),
+                    "expected FusedMatMulAdd, got: {}",
+                    s
+                );
+                // Verify the term tree structure
+                match dag.get(*term_id) {
+                    Term::App(name, _children) => {
+                        assert_eq!(name, "FusedMatMulAdd");
+                    }
+                    other => panic!("expected App, got {:?}", other),
+                }
+                found_fused = true;
+            }
+        }
+        assert!(found_fused, "no ExtractBest output found");
     }
 
     #[test]
@@ -490,7 +787,6 @@ mod tests {
 
     #[test]
     fn test_egglog_all_ops() {
-        // Verify egglog program generation and parsing for all op types
         let mut g = Graph::new();
         let x = g.input("x", &[4, 8]);
         let w = g.parameter("w", &[8, 4]);
@@ -537,7 +833,6 @@ mod tests {
 
     #[test]
     fn test_matmul_stays_as_matmul() {
-        // With cooperative matrix, matmul is never transformed
         let mut g = Graph::new();
         let x = g.input("x", &[2, 1024]);
         let w = g.parameter("w", &[1024, 64]);
@@ -550,6 +845,169 @@ mod tests {
             matches!(opt.node(output_id).op, Op::MatMul),
             "expected MatMul, got {:?}",
             opt.node(output_id).op
+        );
+    }
+
+    /// Measure egglog saturation time vs graph size.
+    #[test]
+    fn test_egglog_scalability() {
+        for n in [10, 50, 100, 200, 350] {
+            let mut prog = String::from(
+                "(datatype Op
+  (MatMul Op Op) (MatMulAT Op Op) (MatMulBT Op Op)
+  (Add Op Op) (Input String) (Parameter String)
+  (FusedMatMulAdd Op Op Op) (FusedMatMulATAdd Op Op Op) (FusedMatMulBTAdd Op Op Op)
+)\n",
+            );
+            prog.push_str("(rewrite (Add (MatMul ?a ?b) ?d) (FusedMatMulAdd ?a ?b ?d))\n");
+            prog.push_str("(rewrite (Add ?d (MatMul ?a ?b)) (FusedMatMulAdd ?a ?b ?d))\n");
+            prog.push_str("(rewrite (Add (MatMulAT ?a ?b) ?d) (FusedMatMulATAdd ?a ?b ?d))\n");
+            prog.push_str("(rewrite (Add ?d (MatMulAT ?a ?b)) (FusedMatMulATAdd ?a ?b ?d))\n");
+            prog.push_str("(rewrite (Add (MatMulBT ?a ?b) ?d) (FusedMatMulBTAdd ?a ?b ?d))\n");
+            prog.push_str("(rewrite (Add ?d (MatMulBT ?a ?b)) (FusedMatMulBTAdd ?a ?b ?d))\n");
+
+            prog.push_str("(let n0 (Input \"x\"))\n(let n1 (Parameter \"w\"))\n");
+            for i in 1..n {
+                let prev = (i - 1) * 2 + 2;
+                match i % 3 {
+                    0 => prog.push_str(&format!("(let n{} (MatMulAT n{} n1))\n", i * 2, prev - 1)),
+                    1 => prog.push_str(&format!("(let n{} (MatMulBT n{} n1))\n", i * 2, prev - 1)),
+                    _ => prog.push_str(&format!("(let n{} (MatMul n{} n1))\n", i * 2, prev - 1)),
+                }
+                prog.push_str(&format!(
+                    "(let n{} (Add n{} n{}))\n",
+                    i * 2 + 1,
+                    i * 2,
+                    prev - 1
+                ));
+            }
+            prog.push_str("(run 1)\n");
+            let last = (n - 1) * 2 + 1;
+            prog.push_str(&format!("(extract n{})\n", last));
+
+            let t0 = Instant::now();
+            let mut egraph = egglog::EGraph::default();
+            egraph.parse_and_run_program(None, &prog).unwrap();
+            let elapsed = t0.elapsed();
+            eprintln!(
+                "egglog scalability: n={:>4} nodes -> {:>8.1}ms",
+                n * 2,
+                elapsed.as_secs_f64() * 1000.0
+            );
+        }
+    }
+
+    /// E-graph discovers MatMul+Add → FusedMatMulAdd.
+    #[test]
+    fn test_egglog_discovers_matmul_add_fusion() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let b = g.input("bias", &[4, 4]);
+        let mm = g.matmul(x, w);
+        let out = g.add(mm, b);
+        g.set_outputs(vec![out]);
+
+        let (opt, report) = optimize_with_report(&g);
+        let output_node = opt.node(opt.outputs()[0]);
+        assert!(
+            matches!(output_node.op, Op::FusedMatMulAdd),
+            "expected FusedMatMulAdd, got {:?}",
+            output_node.op
+        );
+        assert!(!report.fusions_applied.is_empty());
+    }
+
+    /// SwiGLU(MatMul, MatMul) → SwiGLUConcat(MatMul) fusion.
+    #[test]
+    fn test_swiglu_concat_fusion() {
+        let mut g = Graph::new();
+        let h = g.input("h", &[50, 720]);
+        let w_gate = g.parameter("w_gate", &[720, 2048]);
+        let w_up = g.parameter("w_up", &[720, 2048]);
+        let gate = g.matmul(h, w_gate);
+        let up = g.matmul(h, w_up);
+        let out = g.swiglu(gate, up);
+        g.set_outputs(vec![out]);
+
+        let (opt, report) = optimize_with_report(&g);
+        let output_node = opt.node(opt.outputs()[0]);
+        assert!(
+            matches!(output_node.op, Op::SwiGLUConcat),
+            "expected SwiGLUConcat, got {:?}",
+            output_node.op
+        );
+        assert!(
+            report
+                .fusions_applied
+                .iter()
+                .any(|(name, _)| name.contains("SwiGLU")),
+            "no SwiGLU fusion in report: {:?}",
+            report.fusions_applied
+        );
+        // The fused matmul should have shape [50, 4096] (2*2048)
+        let mm_id = output_node.inputs[0];
+        let mm_node = opt.node(mm_id);
+        assert!(matches!(mm_node.op, Op::MatMul));
+        assert_eq!(mm_node.ty.shape, vec![50, 4096]);
+    }
+
+    /// Backward ops are encoded into egglog (not skipped).
+    #[test]
+    fn test_egglog_encodes_backward_ops() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 8]);
+        let w = g.parameter("w", &[8, 4]);
+        let at = g.add_raw_node(
+            Op::MatMulAT,
+            vec![x, x],
+            crate::graph::TensorType::f32(vec![8, 8]),
+        );
+        let bt = g.add_raw_node(
+            Op::MatMulBT,
+            vec![x, w],
+            crate::graph::TensorType::f32(vec![4, 8]),
+        );
+        g.set_outputs(vec![at, bt]);
+
+        let program = graph_to_egglog(&g);
+        assert!(program.contains("MatMulAT"), "MatMulAT not encoded");
+        assert!(program.contains("MatMulBT"), "MatMulBT not encoded");
+
+        let mut egraph = egglog::EGraph::default();
+        egraph
+            .parse_and_run_program(None, &program)
+            .expect("egglog failed with backward ops");
+    }
+
+    /// E-graph discovers MatMulBT+Add → FusedMatMulBTAdd on backward ops.
+    #[test]
+    fn test_egglog_discovers_backward_bt_add_fusion() {
+        let mut g = Graph::new();
+        let grad = g.input("grad", &[4, 8]);
+        let w = g.parameter("w", &[4, 8]);
+        let prev = g.input("prev_grad", &[4, 4]);
+        let bt = g.add_raw_node(
+            Op::MatMulBT,
+            vec![grad, w],
+            crate::graph::TensorType::f32(vec![4, 4]),
+        );
+        let out = g.add(bt, prev);
+        g.set_outputs(vec![out]);
+
+        let (opt, report) = optimize_with_report(&g);
+        let output_node = opt.node(opt.outputs()[0]);
+        assert!(
+            matches!(output_node.op, Op::FusedMatMulBTAdd),
+            "expected FusedMatMulBTAdd, got {:?}",
+            output_node.op
+        );
+        assert!(
+            report
+                .fusions_applied
+                .iter()
+                .any(|(name, _)| name.contains("BT")),
+            "no BT fusion in report"
         );
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -714,9 +714,51 @@ impl Session {
 
     /// Upload parameter data to GPU buffers.
     pub fn set_parameter(&mut self, name: &str, data: &[f32]) {
+        // Check regular parameters first
         for &(ref param_name, buf_ref) in &self.plan.param_buffers {
             if param_name == name {
                 self.upload_buffer(buf_ref, bytemuck::cast_slice(data));
+
+                // If this source param feeds a derived (concatenated) param,
+                // write this source's data into the correct offset of the
+                // derived buffer. Uses row-interleaved layout: for each row,
+                // source A's columns come first, then source B's columns.
+                for entry in &self.plan.derived_params {
+                    let derived_buf = &entry.0;
+                    let sources = &entry.1;
+                    let mut col_offset = 0usize;
+                    let total_cols: usize = sources.iter().map(|s| s.1).sum();
+                    let rows = if total_cols > 0 {
+                        self.plan.buffers[derived_buf.0 as usize] / 4 / total_cols
+                    } else {
+                        0
+                    };
+                    for src in sources {
+                        let src_name = &src.0;
+                        let src_elems = src.1;
+                        let src_cols = if rows > 0 { src_elems / rows } else { 0 };
+                        if src_name == name && rows > 0 {
+                            // Write row-interleaved: for row r, write data[r*src_cols .. (r+1)*src_cols]
+                            // to derived_buf at offset [r * total_cols/rows + col_offset]
+                            let total_cols_per_row = total_cols / rows;
+                            let derived_ptr =
+                                self.buffers[derived_buf.0 as usize].data() as *mut f32;
+                            for r in 0..rows {
+                                let src_start = r * src_cols;
+                                let dst_start = r * total_cols_per_row + col_offset;
+                                unsafe {
+                                    std::ptr::copy_nonoverlapping(
+                                        data[src_start..].as_ptr(),
+                                        derived_ptr.add(dst_start),
+                                        src_cols,
+                                    );
+                                }
+                            }
+                        }
+                        col_offset += src_cols;
+                    }
+                }
+
                 return;
             }
         }

--- a/src/train.rs
+++ b/src/train.rs
@@ -168,10 +168,11 @@ pub fn build_inference_session(forward_graph: &Graph) -> Session {
 /// Build a complete training session from a forward-pass graph.
 ///
 /// This is the main entry point. It:
-/// 1. Runs autodiff to build the backward pass
-/// 2. Runs egglog optimization on the combined graph
-/// 3. Compiles the optimized graph to an execution plan
-/// 4. Creates a GPU session with all resources allocated
+/// 1. Optimizes the forward graph (SwiGLU fusion, MatMul+Add, etc.)
+/// 2. Runs autodiff on the optimized forward graph
+/// 3. Optimizes the full graph (backward MatMul+Add fusions)
+/// 4. Compiles the optimized graph to an execution plan
+/// 5. Creates a GPU session with all resources allocated
 pub fn build_session(forward_graph: &Graph) -> Session {
     let (session, report) = build_session_with_report(forward_graph);
     log::info!("{}", report);
@@ -189,21 +190,43 @@ pub fn build_session_with_report(forward_graph: &Graph) -> (Session, OptimizeRep
     log::info!("building training session...");
     log::info!("forward graph:\n{}", forward_graph);
 
-    // Step 1: Autodiff
-    log::info!("running autodiff...");
+    // Step 1: Optimize forward graph (fuse SwiGLU, MatMul+Add, etc.)
+    // This runs BEFORE autodiff so the backward pass differentiates
+    // the optimized ops (e.g. SwiGLUConcat instead of separate SwiGLU).
+    log::info!("optimizing forward graph...");
+    let optimized_forward = {
+        let _span = tracing::info_span!("optimize_forward").entered();
+        optimize::optimize(forward_graph)
+    };
+    log::info!(
+        "optimized forward: {} nodes",
+        optimized_forward.nodes().len()
+    );
+
+    // Step 2: Toposort the optimized graph (optimizer may append nodes
+    // out of order) then run autodiff. Autodiff iterates in reverse node
+    // order, so topological ordering ensures gradients flow correctly.
+    let sorted_forward = optimized_forward.toposort();
+    eprintln!(
+        "pipeline: forward {} → optimized {} → sorted {} nodes, outputs={:?}",
+        forward_graph.nodes().len(),
+        optimized_forward.nodes().len(),
+        sorted_forward.nodes().len(),
+        sorted_forward.outputs()
+    );
     let full_graph = {
         let _span = tracing::info_span!("autodiff").entered();
-        autodiff::differentiate(forward_graph)
+        autodiff::differentiate(&sorted_forward)
     };
     log::info!(
         "full graph (forward + backward): {} nodes",
         full_graph.nodes().len()
     );
 
-    // Step 2: Optimize with egglog
-    log::info!("running egglog optimization...");
+    // Step 3: Optimize full graph (fuse backward MatMul+Add, etc.)
+    log::info!("optimizing full graph...");
     let (optimized, report) = {
-        let _span = tracing::info_span!("egglog_optimize").entered();
+        let _span = tracing::info_span!("optimize_full").entered();
         optimize::optimize_with_report(&full_graph)
     };
     log::info!("optimized graph: {} nodes", optimized.nodes().len());

--- a/tests/gpu_smoke.rs
+++ b/tests/gpu_smoke.rs
@@ -299,6 +299,19 @@ fn smolvla_training_backprop_smoke() {
     };
 
     // Diagnostic: check session structure
+    let grad_bufs: std::collections::HashSet<u32> = session
+        .plan()
+        .param_grad_pairs
+        .iter()
+        .map(|&(p, _)| p.0)
+        .collect();
+    for (name, buf_ref) in &session.plan().param_buffers {
+        let has_grad = grad_bufs.contains(&buf_ref.0);
+        eprintln!(
+            "  param {:>50}: buf={:>3} grad={}",
+            name, buf_ref.0, has_grad
+        );
+    }
     eprintln!(
         "param_buffers={}, param_grad_pairs={}",
         session.plan().param_buffers.len(),


### PR DESCRIPTION
Idea is simple: encode the model in the simplest form, rely on e-graph optimization to reach the same (or better) performance that we manually achieved so far.