### PR TITLE
Add KV cache infrastructure for autoregressive decode

### DIFF
--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -435,7 +435,9 @@ pub fn differentiate(forward: &Graph) -> Graph {
             | Op::CausalAttention { .. }
             | Op::LayerNorm { .. }
             | Op::FullAttention { .. }
-            | Op::CrossAttention { .. } => {
+            | Op::CrossAttention { .. }
+            | Op::CacheWrite
+            | Op::CachedAttention { .. } => {
                 log::warn!(
                     "autodiff not supported for {:?}, inference-only op",
                     node.op

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -103,6 +103,9 @@ pub enum ShaderGroup {
     ScatterAdd,
     BceLoss,
     FusedRmsNormMatMul,
+    CacheWrite,
+    CachedAttention,
+    RoPEDynamic,
 }
 
 /// Generate a `naga::Module` for a shader group.
@@ -149,6 +152,9 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::FusedRmsNormMatMul => gen_fused_rms_norm_matmul(),
         ShaderGroup::ScatterAdd => gen_scatter_add(),
         ShaderGroup::BceLoss => gen_bce_loss(),
+        ShaderGroup::CacheWrite => gen_cache_write(),
+        ShaderGroup::CachedAttention => gen_cached_attention(),
+        ShaderGroup::RoPEDynamic => gen_rope_dynamic(),
     }
 }
 
@@ -856,6 +862,26 @@ fn gen_cross_attention() -> ShaderModule {
 }
 
 // ---------------------------------------------------------------------------
+// cache_write.wgsl: write [1, dim] into row kv_pos of [max_seq, dim]
+// ---------------------------------------------------------------------------
+
+fn gen_rope_dynamic() -> ShaderModule {
+    parse_wgsl(include_str!("shaders/rope_dynamic.wgsl"))
+}
+
+fn gen_cache_write() -> ShaderModule {
+    parse_wgsl(include_str!("shaders/cache_write.wgsl"))
+}
+
+// ---------------------------------------------------------------------------
+// cached_attention.wgsl: single-token attention with KV cache
+// ---------------------------------------------------------------------------
+
+fn gen_cached_attention() -> ShaderModule {
+    parse_wgsl(include_str!("shaders/cached_attention.wgsl"))
+}
+
+// ---------------------------------------------------------------------------
 // multi_head_attn (forward, saves LSE for backward)
 // Same as gen_attention_parallel(false, true) but with an extra `lse` binding.
 // After normalization, thread 0 writes lse[pos * num_heads + head] = max + log(sum_exp).
@@ -1239,6 +1265,11 @@ mod tests {
                 ShaderEntry::FusedRmsNormMatMul => {
                     vec!["src_a", "src_b", "bias", "dst", "params"]
                 }
+                ShaderEntry::CacheWrite => vec!["src", "dst", "kv_pos_buf", "params"],
+                ShaderEntry::CachedAttention => {
+                    vec!["src_a", "src_b", "bias", "kv_pos_buf", "dst", "params"]
+                }
+                ShaderEntry::RoPEDynamic => vec!["src", "dst", "pos_offset_buf", "params"],
             }
         }
 
@@ -1289,6 +1320,9 @@ mod tests {
             ShaderEntry::AdamUpdate,
             ShaderEntry::ScatterAdd,
             ShaderEntry::BceLoss,
+            ShaderEntry::CacheWrite,
+            ShaderEntry::CachedAttention,
+            ShaderEntry::RoPEDynamic,
         ];
 
         for entry in &entries {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -54,6 +54,9 @@ pub enum ShaderEntry {
     RmsNormGradW,
     RmsNormGradX,
     FusedRmsNormMatMul,
+    CacheWrite,
+    CachedAttention,
+    RoPEDynamic,
 }
 
 impl ShaderEntry {
@@ -103,6 +106,9 @@ impl ShaderEntry {
             ShaderEntry::SumRows => ShaderGroup::SumRows,
             ShaderEntry::RmsNormGradW | ShaderEntry::RmsNormGradX => ShaderGroup::RmsNormGrad,
             ShaderEntry::FusedRmsNormMatMul => ShaderGroup::FusedRmsNormMatMul,
+            ShaderEntry::CacheWrite => ShaderGroup::CacheWrite,
+            ShaderEntry::CachedAttention => ShaderGroup::CachedAttention,
+            ShaderEntry::RoPEDynamic => ShaderGroup::RoPEDynamic,
         }
     }
 
@@ -156,6 +162,9 @@ impl ShaderEntry {
             ShaderEntry::RmsNormGradW => "rms_norm_grad_w",
             ShaderEntry::RmsNormGradX => "rms_norm_grad_x",
             ShaderEntry::FusedRmsNormMatMul => "main",
+            ShaderEntry::CacheWrite => "main",
+            ShaderEntry::CachedAttention => "main",
+            ShaderEntry::RoPEDynamic => "main",
         }
     }
 }
@@ -202,8 +211,10 @@ pub struct ExecutionPlan {
     /// The dispatch sequence. For a training graph, this includes
     /// forward, backward, and parameter update dispatches.
     pub dispatches: Vec<Dispatch>,
-    /// Index of the loss buffer (for reading back).
+    /// Index of the loss buffer (first graph output, for reading back).
     pub loss_buffer: Option<BufferRef>,
+    /// All graph output buffers (for reading back multiple outputs).
+    pub output_buffers: Vec<BufferRef>,
     /// Parameter buffer → gradient buffer mapping (for SGD).
     pub param_grad_pairs: Vec<(BufferRef, BufferRef)>,
     /// LSE buffers allocated for MultiHeadAttn forward nodes: (node_id, buffer).
@@ -257,6 +268,7 @@ impl<'a> Compiler<'a> {
                 constant_buffers: Vec::new(),
                 dispatches: Vec::new(),
                 loss_buffer: None,
+                output_buffers: Vec::new(),
                 param_grad_pairs: Vec::new(),
                 lse_buffers: Vec::new(),
                 derived_params: Vec::new(),
@@ -355,7 +367,10 @@ impl<'a> Compiler<'a> {
             };
         }
 
-        // Set loss buffer (first output)
+        // Set loss buffer (first output) and collect all output buffers
+        for &out_id in self.graph.outputs() {
+            self.plan.output_buffers.push(self.get_buffer(out_id));
+        }
         if let Some(&loss_id) = self.graph.outputs().first() {
             self.plan.loss_buffer = Some(self.get_buffer(loss_id));
         }
@@ -814,22 +829,38 @@ impl<'a> Compiler<'a> {
                 });
             }
 
-            Op::RoPE { theta } => {
+            Op::RoPE { theta, pos_offset } => {
                 let input = self.get_buffer(node.inputs[0]);
                 let shape = &self.graph.node(node.inputs[0]).ty.shape;
                 let seq = shape[0] as u32;
                 let dim = shape[1] as u32;
-                self.plan.dispatches.push(Dispatch {
-                    shader: ShaderEntry::RoPE,
-                    workgroups: [ceil_div(seq * dim / 2, 256), 1, 1],
-                    input_buffers: vec![input],
-                    output_buffer: out_buf,
-                    extra_output: None,
-                    params: vec![seq, dim, theta.to_bits(), 0],
-                    use_coop: false,
-                    use_small_tiles: false,
-                    label: String::new(),
-                });
+                if node.inputs.len() == 2 {
+                    // Dynamic offset: read pos_offset from input buffer
+                    let offset_buf = self.get_buffer(node.inputs[1]);
+                    self.plan.dispatches.push(Dispatch {
+                        shader: ShaderEntry::RoPEDynamic,
+                        workgroups: [ceil_div(seq * dim / 2, 256), 1, 1],
+                        input_buffers: vec![input, offset_buf],
+                        output_buffer: out_buf,
+                        extra_output: None,
+                        params: vec![seq, dim, theta.to_bits(), 0],
+                        use_coop: false,
+                        use_small_tiles: false,
+                        label: String::new(),
+                    });
+                } else {
+                    self.plan.dispatches.push(Dispatch {
+                        shader: ShaderEntry::RoPE,
+                        workgroups: [ceil_div(seq * dim / 2, 256), 1, 1],
+                        input_buffers: vec![input],
+                        output_buffer: out_buf,
+                        extra_output: None,
+                        params: vec![seq, dim, theta.to_bits(), pos_offset],
+                        use_coop: false,
+                        use_small_tiles: false,
+                        label: String::new(),
+                    });
+                }
             }
 
             Op::CausalAttention {
@@ -848,6 +879,48 @@ impl<'a> Compiler<'a> {
                     output_buffer: out_buf,
                     extra_output: None,
                     params: vec![seq, num_heads, num_kv_heads, head_dim],
+                    use_coop: false,
+                    use_small_tiles: false,
+                    label: String::new(),
+                });
+            }
+
+            Op::CacheWrite => {
+                let new_kv = self.get_buffer(node.inputs[0]);
+                let cache = self.get_buffer(node.inputs[1]);
+                let kv_pos_input = self.get_buffer(node.inputs[2]);
+                let dim = self.graph.node(node.inputs[0]).ty.shape[1] as u32;
+                // Output aliases the cache buffer (in-place write)
+                self.node_buffers.insert(node.id, cache);
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::CacheWrite,
+                    workgroups: [ceil_div(dim, 256), 1, 1],
+                    input_buffers: vec![new_kv, cache, kv_pos_input],
+                    output_buffer: cache,
+                    extra_output: None,
+                    params: vec![dim, 0, 0, 0], // kv_pos read from input buffer at runtime
+                    use_coop: false,
+                    use_small_tiles: false,
+                    label: String::new(),
+                });
+            }
+
+            Op::CachedAttention {
+                num_heads,
+                num_kv_heads,
+                head_dim,
+            } => {
+                let q = self.get_buffer(node.inputs[0]);
+                let k_cache = self.get_buffer(node.inputs[1]);
+                let v_cache = self.get_buffer(node.inputs[2]);
+                let kv_pos_input = self.get_buffer(node.inputs[3]);
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::CachedAttention,
+                    workgroups: [1, num_heads, 1],
+                    input_buffers: vec![q, k_cache, v_cache, kv_pos_input],
+                    output_buffer: out_buf,
+                    extra_output: None,
+                    params: vec![0, num_heads, num_kv_heads, head_dim], // kv_len read from input buffer
                     use_coop: false,
                     use_small_tiles: false,
                     label: String::new(),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -152,9 +152,13 @@ pub enum Op {
     Embedding,
 
     // Rotary position embeddings
-    // inputs: [x], params encode theta
+    // inputs: [x] or [x, pos_offset_input]
+    // pos_offset: static offset added to each row's position (0 for prefill)
+    // When inputs has 2 elements, the second is a u32 buffer whose value is
+    // added to position (for decode, this is kv_pos).
     RoPE {
         theta: f32,
+        pos_offset: u32,
     },
 
     // Fused causal multi-head attention with GQA
@@ -244,6 +248,23 @@ pub enum Op {
     // inputs: [dy, x, w] → [rows, cols]
     RmsNormGradX {
         eps: f32,
+    },
+
+    // --- KV cache ops ---
+
+    // Write [1, dim] into row kv_pos of [max_seq, dim] cache buffer.
+    // inputs: [new_kv, cache_buf], kv_pos read from a u32 input.
+    // output: cache_buf (in-place write at row kv_pos)
+    CacheWrite,
+
+    // Attention with Q from current token and K/V from pre-allocated cache.
+    // inputs: [q, k_cache, v_cache, kv_pos_input]
+    // q: [1, num_heads*head_dim], k_cache/v_cache: [max_seq, kv_dim]
+    // kv_pos_input: u32 scalar (number of valid cached positions)
+    CachedAttention {
+        num_heads: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
     },
 }
 
@@ -695,11 +716,32 @@ impl Graph {
     }
 
     pub fn rope(&mut self, x: NodeId, theta: f32) -> NodeId {
+        self.rope_with_offset(x, theta, 0)
+    }
+
+    pub fn rope_with_offset(&mut self, x: NodeId, theta: f32, pos_offset: u32) -> NodeId {
         let x_shape = &self.node(x).ty.shape;
         assert_eq!(x_shape.len(), 2, "rope requires 2D input");
         assert_eq!(x_shape[1] % 2, 0, "rope requires even last dim");
         let ty = self.node(x).ty.clone();
-        self.add_node(Op::RoPE { theta }, vec![x], ty)
+        self.add_node(Op::RoPE { theta, pos_offset }, vec![x], ty)
+    }
+
+    /// RoPE with a dynamic position offset read from an input buffer.
+    /// The position for each row is `row_index + offset_buf[0]`.
+    pub fn rope_dynamic_offset(&mut self, x: NodeId, theta: f32, offset_input: NodeId) -> NodeId {
+        let x_shape = &self.node(x).ty.shape;
+        assert_eq!(x_shape.len(), 2, "rope requires 2D input");
+        assert_eq!(x_shape[1] % 2, 0, "rope requires even last dim");
+        let ty = self.node(x).ty.clone();
+        self.add_node(
+            Op::RoPE {
+                theta,
+                pos_offset: 0,
+            },
+            vec![x, offset_input],
+            ty,
+        )
     }
 
     pub fn causal_attention(
@@ -743,6 +785,54 @@ impl Graph {
                 head_dim,
             },
             vec![q, k, v],
+            ty,
+        )
+    }
+
+    // --- KV cache ops ---
+
+    /// Write `new_kv` [1, dim] into row `kv_pos` of `cache` [max_seq, dim].
+    /// Returns a node representing the updated cache buffer.
+    pub fn cache_write(&mut self, new_kv: NodeId, cache: NodeId, kv_pos: NodeId) -> NodeId {
+        let nk_shape = &self.node(new_kv).ty.shape;
+        let c_shape = &self.node(cache).ty.shape;
+        assert_eq!(nk_shape.len(), 2, "new_kv must be 2D");
+        assert_eq!(nk_shape[0], 1, "new_kv must have seq_len=1");
+        assert_eq!(c_shape.len(), 2, "cache must be 2D");
+        assert_eq!(nk_shape[1], c_shape[1], "dim must match");
+        let ty = self.node(cache).ty.clone();
+        self.add_node(Op::CacheWrite, vec![new_kv, cache, kv_pos], ty)
+    }
+
+    /// Cached attention: Q attends to K/V cache.
+    /// q: [1, num_heads*head_dim], k_cache/v_cache: [max_seq, kv_dim],
+    /// kv_pos: u32 scalar (number of valid positions in cache).
+    pub fn cached_attention(
+        &mut self,
+        q: NodeId,
+        k_cache: NodeId,
+        v_cache: NodeId,
+        kv_pos: NodeId,
+        num_heads: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
+    ) -> NodeId {
+        let q_shape = &self.node(q).ty.shape;
+        assert_eq!(q_shape.len(), 2, "q must be 2D");
+        assert_eq!(q_shape[0], 1, "q must have seq_len=1 for cached attention");
+        assert_eq!(
+            q_shape[1],
+            (num_heads * head_dim) as usize,
+            "q dim mismatch"
+        );
+        let ty = TensorType::f32(vec![1, (num_heads * head_dim) as usize]);
+        self.add_node(
+            Op::CachedAttention {
+                num_heads,
+                num_kv_heads,
+                head_dim,
+            },
+            vec![q, k_cache, v_cache, kv_pos],
             ty,
         )
     }

--- a/src/models/smollm2.rs
+++ b/src/models/smollm2.rs
@@ -150,6 +150,214 @@ pub fn build_graph(g: &mut Graph, config: &SmolLM2Config, seq_len: usize) -> Nod
     g.matmul(x, lm_head) // [seq, vocab]
 }
 
+/// Build the SmolLM2 prefill graph.
+///
+/// Processes the full prompt and outputs logits plus K/V tensors per layer
+/// as graph outputs for initializing the decode cache.
+///
+/// Returns (logits, k_outputs, v_outputs) where k/v_outputs are per-layer.
+pub fn build_prefill_graph(
+    g: &mut Graph,
+    config: &SmolLM2Config,
+    seq_len: usize,
+) -> (NodeId, Vec<NodeId>, Vec<NodeId>) {
+    let hidden = config.hidden_size;
+    let kv_dim = config.kv_dim();
+    let ffn = config.intermediate_size;
+    let eps = config.rms_norm_eps;
+    let theta = config.rope_theta;
+
+    let token_ids = g.input_u32("token_ids", &[seq_len]);
+    let embed_weight = g.parameter("model.embed_tokens.weight", &[config.vocab_size, hidden]);
+    let mut x = g.embedding(token_ids, embed_weight);
+
+    let mut k_outputs = Vec::new();
+    let mut v_outputs = Vec::new();
+
+    for i in 0..config.num_hidden_layers {
+        let prefix = format!("model.layers.{}", i);
+
+        let ln1_w = g.parameter(&format!("{}.input_layernorm.weight", prefix), &[hidden]);
+        let h = g.rms_norm(x, ln1_w, eps);
+
+        let wq = g.parameter(
+            &format!("{}.self_attn.q_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let wk = g.parameter(
+            &format!("{}.self_attn.k_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+        let wv = g.parameter(
+            &format!("{}.self_attn.v_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+
+        let q = g.matmul(h, wq);
+        let k = g.matmul(h, wk);
+        let v = g.matmul(h, wv);
+
+        let q = g.rope(q, theta);
+        let k = g.rope(k, theta);
+
+        // Save K/V for cache initialization
+        k_outputs.push(k);
+        v_outputs.push(v);
+
+        let attn = g.causal_attention(
+            q,
+            k,
+            v,
+            config.num_attention_heads,
+            config.num_key_value_heads,
+            config.head_dim(),
+        );
+
+        let wo = g.parameter(
+            &format!("{}.self_attn.o_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let attn_out = g.matmul(attn, wo);
+        x = g.add(x, attn_out);
+
+        let ln2_w = g.parameter(
+            &format!("{}.post_attention_layernorm.weight", prefix),
+            &[hidden],
+        );
+        let h = g.rms_norm(x, ln2_w, eps);
+
+        let w_gate = g.parameter(&format!("{}.mlp.gate_proj.weight", prefix), &[hidden, ffn]);
+        let w_up = g.parameter(&format!("{}.mlp.up_proj.weight", prefix), &[hidden, ffn]);
+        let w_down = g.parameter(&format!("{}.mlp.down_proj.weight", prefix), &[ffn, hidden]);
+
+        let gate = g.matmul(h, w_gate);
+        let up = g.matmul(h, w_up);
+        let ffn_out = g.swiglu(gate, up);
+        let ffn_out = g.matmul(ffn_out, w_down);
+
+        x = g.add(x, ffn_out);
+    }
+
+    let final_ln_w = g.parameter("model.norm.weight", &[hidden]);
+    x = g.rms_norm(x, final_ln_w, eps);
+
+    let lm_head = g.parameter("lm_head.weight", &[hidden, config.vocab_size]);
+    let logits = g.matmul(x, lm_head);
+
+    (logits, k_outputs, v_outputs)
+}
+
+/// Build the SmolLM2 decode graph (single-token with KV cache).
+///
+/// Processes 1 token, reads/writes KV cache, returns logits for 1 position.
+/// `max_seq_len` is the pre-allocated cache size.
+///
+/// Returns (logits, k_cache_params, v_cache_params) where cache params are
+/// the parameter NodeIds for pre-allocated cache buffers.
+pub fn build_decode_graph(
+    g: &mut Graph,
+    config: &SmolLM2Config,
+    max_seq_len: usize,
+) -> (NodeId, Vec<NodeId>, Vec<NodeId>) {
+    let hidden = config.hidden_size;
+    let kv_dim = config.kv_dim();
+    let ffn = config.intermediate_size;
+    let eps = config.rms_norm_eps;
+    let theta = config.rope_theta;
+
+    // Single token input
+    let token_ids = g.input_u32("token_ids", &[1]);
+    // Dynamic position for cache write (u32 scalar)
+    let kv_pos = g.input_u32("kv_pos", &[1]);
+
+    let embed_weight = g.parameter("model.embed_tokens.weight", &[config.vocab_size, hidden]);
+    let mut x = g.embedding(token_ids, embed_weight);
+
+    let mut k_cache_params = Vec::new();
+    let mut v_cache_params = Vec::new();
+
+    for i in 0..config.num_hidden_layers {
+        let prefix = format!("model.layers.{}", i);
+
+        let ln1_w = g.parameter(&format!("{}.input_layernorm.weight", prefix), &[hidden]);
+        let h = g.rms_norm(x, ln1_w, eps);
+
+        let wq = g.parameter(
+            &format!("{}.self_attn.q_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let wk = g.parameter(
+            &format!("{}.self_attn.k_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+        let wv = g.parameter(
+            &format!("{}.self_attn.v_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+
+        let q = g.matmul(h, wq); // [1, hidden]
+        let k = g.matmul(h, wk); // [1, kv_dim]
+        let v = g.matmul(h, wv); // [1, kv_dim]
+
+        // RoPE with dynamic position offset from kv_pos input
+        let q = g.rope_dynamic_offset(q, theta, kv_pos);
+        let k = g.rope_dynamic_offset(k, theta, kv_pos);
+
+        // Pre-allocated KV cache buffers (treated as mutable parameters)
+        let k_cache = g.parameter(&format!("kv_cache.layer.{}.k", i), &[max_seq_len, kv_dim]);
+        let v_cache = g.parameter(&format!("kv_cache.layer.{}.v", i), &[max_seq_len, kv_dim]);
+        k_cache_params.push(k_cache);
+        v_cache_params.push(v_cache);
+
+        // Write new K/V into cache at kv_pos
+        let _k_updated = g.cache_write(k, k_cache, kv_pos);
+        let _v_updated = g.cache_write(v, v_cache, kv_pos);
+
+        // Cached attention: Q attends to full cache
+        let attn = g.cached_attention(
+            q,
+            k_cache,
+            v_cache,
+            kv_pos,
+            config.num_attention_heads,
+            config.num_key_value_heads,
+            config.head_dim(),
+        );
+
+        let wo = g.parameter(
+            &format!("{}.self_attn.o_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let attn_out = g.matmul(attn, wo);
+        x = g.add(x, attn_out);
+
+        let ln2_w = g.parameter(
+            &format!("{}.post_attention_layernorm.weight", prefix),
+            &[hidden],
+        );
+        let h = g.rms_norm(x, ln2_w, eps);
+
+        let w_gate = g.parameter(&format!("{}.mlp.gate_proj.weight", prefix), &[hidden, ffn]);
+        let w_up = g.parameter(&format!("{}.mlp.up_proj.weight", prefix), &[hidden, ffn]);
+        let w_down = g.parameter(&format!("{}.mlp.down_proj.weight", prefix), &[ffn, hidden]);
+
+        let gate = g.matmul(h, w_gate);
+        let up = g.matmul(h, w_up);
+        let ffn_out = g.swiglu(gate, up);
+        let ffn_out = g.matmul(ffn_out, w_down);
+
+        x = g.add(x, ffn_out);
+    }
+
+    let final_ln_w = g.parameter("model.norm.weight", &[hidden]);
+    x = g.rms_norm(x, final_ln_w, eps);
+
+    let lm_head = g.parameter("lm_head.weight", &[hidden, config.vocab_size]);
+    let logits = g.matmul(x, lm_head); // [1, vocab]
+
+    (logits, k_cache_params, v_cache_params)
+}
+
 /// Get all weight parameter names for SmolLM2.
 pub fn weight_names(config: &SmolLM2Config) -> Vec<String> {
     let mut names = Vec::new();

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -261,6 +261,9 @@ fn graph_to_egglog(graph: &Graph) -> String {
   (FullAttention Op Op Op)
   (CrossAttention Op Op Op)
   (MultiHeadAttn Op Op Op)
+  ; --- KV cache ops ---
+  (CacheWrite Op Op Op)
+  (CachedAttention Op Op Op Op)
   ; --- Backward / gradient ops ---
   (SiluGrad Op Op)
   (SwiGLUGradGate Op Op Op)
@@ -401,6 +404,10 @@ fn node_to_egglog_expr(node: &Node) -> String {
         }
         Op::FusedRmsNormMatMul { .. } => {
             format!("(FusedRmsNormMatMul n{} n{} n{})", i[0], i[1], i[2])
+        }
+        Op::CacheWrite => format!("(CacheWrite n{} n{} n{})", i[0], i[1], i[2]),
+        Op::CachedAttention { .. } => {
+            format!("(CachedAttention n{} n{} n{} n{})", i[0], i[1], i[2], i[3])
         }
         Op::Nop => unreachable!("Nop nodes are filtered before encoding"),
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -223,6 +223,35 @@ struct CausalAttentionData {
     params: MatMulParams, // seq, num_heads, num_kv_heads, head_dim → reuse 4xu32
 }
 
+// rope_dynamic: var src, dst, pos_offset_buf, params
+#[derive(blade_macros::ShaderData)]
+struct RoPEDynamicData {
+    src: blade_graphics::BufferPiece,
+    dst: blade_graphics::BufferPiece,
+    pos_offset_buf: blade_graphics::BufferPiece,
+    params: UnaryParams, // seq, dim, theta_bits, _pad
+}
+
+// cache_write: var src, dst (read_write), kv_pos_buf, params
+#[derive(blade_macros::ShaderData)]
+struct CacheWriteData {
+    src: blade_graphics::BufferPiece,
+    dst: blade_graphics::BufferPiece,
+    kv_pos_buf: blade_graphics::BufferPiece,
+    params: UnaryParams, // dim, _pad x3
+}
+
+// cached_attention: var src_a (q), src_b (k_cache), bias (v_cache), kv_pos_buf, dst, params
+#[derive(blade_macros::ShaderData)]
+struct CachedAttentionData {
+    src_a: blade_graphics::BufferPiece,
+    src_b: blade_graphics::BufferPiece,
+    bias: blade_graphics::BufferPiece,
+    kv_pos_buf: blade_graphics::BufferPiece,
+    dst: blade_graphics::BufferPiece,
+    params: MatMulParams, // _reserved, num_heads, num_kv_heads, head_dim
+}
+
 // layer_norm: var src, src_b (weight), bias, dst, params
 #[derive(blade_macros::ShaderData)]
 struct LayerNormData {
@@ -518,6 +547,9 @@ fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
         ShaderEntry::SwiGLUGradUp | ShaderEntry::SiluGrad => BinaryData::layout(),
         ShaderEntry::RmsNormGradW | ShaderEntry::RmsNormGradX => CausalAttentionData::layout(),
         ShaderEntry::FusedRmsNormMatMul => CausalAttentionData::layout(),
+        ShaderEntry::RoPEDynamic => RoPEDynamicData::layout(),
+        ShaderEntry::CacheWrite => CacheWriteData::layout(),
+        ShaderEntry::CachedAttention => CachedAttentionData::layout(),
     }
 }
 
@@ -1043,6 +1075,45 @@ impl Session {
         }
     }
 
+    /// Read back a graph output by index.
+    ///
+    /// Index 0 is the primary output (logits/loss). Higher indices are
+    /// additional outputs (e.g. KV tensors from prefill).
+    pub fn read_output_by_index(&self, index: usize, out: &mut [f32]) {
+        let buf_ref = self.plan.output_buffers[index];
+        self.read_buffer(buf_ref, out);
+    }
+
+    /// Number of graph outputs.
+    pub fn num_outputs(&self) -> usize {
+        self.plan.output_buffers.len()
+    }
+
+    /// Look up a parameter's buffer reference by name.
+    pub fn param_buffer(&self, name: &str) -> Option<BufferRef> {
+        self.plan
+            .param_buffers
+            .iter()
+            .find(|entry| entry.0 == name)
+            .map(|entry| entry.1)
+    }
+
+    /// Read a parameter buffer's contents by name.
+    pub fn read_param(&self, name: &str, out: &mut [f32]) {
+        let buf_ref = self
+            .param_buffer(name)
+            .unwrap_or_else(|| panic!("unknown param: {}", name));
+        self.read_buffer(buf_ref, out);
+    }
+
+    /// Upload data into a parameter buffer by name (for initializing KV caches etc.).
+    pub fn upload_param(&self, name: &str, data: &[f32]) {
+        let buf_ref = self
+            .param_buffer(name)
+            .unwrap_or_else(|| panic!("unknown param: {}", name));
+        self.upload_buffer(buf_ref, bytemuck::cast_slice(data));
+    }
+
     /// Print GPU pass timings from the last completed step.
     ///
     /// Must be called after `step()` + `wait()`, then another `step()`
@@ -1502,7 +1573,7 @@ impl Session {
                             len: dispatch.params[0],
                             _pad0: dispatch.params[1],
                             _pad1: dispatch.params[2],
-                            _pad2: 0,
+                            _pad2: dispatch.params[3], // pos_offset
                         },
                     },
                 );
@@ -1703,6 +1774,56 @@ impl Session {
                             seq_len: dispatch.params[1],
                             embed_dim: dispatch.params[2],
                             _pad: 0,
+                        },
+                    },
+                );
+            }
+            ShaderEntry::RoPEDynamic => {
+                pc.bind(
+                    0,
+                    &RoPEDynamicData {
+                        src: buf(dispatch.input_buffers[0]),
+                        dst: buf(dispatch.output_buffer),
+                        pos_offset_buf: buf(dispatch.input_buffers[1]),
+                        params: UnaryParams {
+                            len: dispatch.params[0],
+                            _pad0: dispatch.params[1],
+                            _pad1: dispatch.params[2],
+                            _pad2: 0,
+                        },
+                    },
+                );
+            }
+            ShaderEntry::CacheWrite => {
+                pc.bind(
+                    0,
+                    &CacheWriteData {
+                        src: buf(dispatch.input_buffers[0]),
+                        dst: buf(dispatch.output_buffer),
+                        kv_pos_buf: buf(dispatch.input_buffers[2]),
+                        params: UnaryParams {
+                            len: dispatch.params[0], // dim
+                            _pad0: 0,
+                            _pad1: 0,
+                            _pad2: 0,
+                        },
+                    },
+                );
+            }
+            ShaderEntry::CachedAttention => {
+                pc.bind(
+                    0,
+                    &CachedAttentionData {
+                        src_a: buf(dispatch.input_buffers[0]),      // Q
+                        src_b: buf(dispatch.input_buffers[1]),      // K cache
+                        bias: buf(dispatch.input_buffers[2]),       // V cache
+                        kv_pos_buf: buf(dispatch.input_buffers[3]), // kv_pos
+                        dst: buf(dispatch.output_buffer),
+                        params: MatMulParams {
+                            m: dispatch.params[0],
+                            n: dispatch.params[1],
+                            k: dispatch.params[2],
+                            _pad: dispatch.params[3],
                         },
                     },
                 );

--- a/src/shaders/cache_write.wgsl
+++ b/src/shaders/cache_write.wgsl
@@ -1,0 +1,22 @@
+// cache_write: write [1, dim] into row kv_pos of [max_seq, dim] cache buffer.
+// Dispatch: [ceil(dim/256), 1, 1]
+
+struct Params {
+    dim: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+}
+
+var<storage> src: array<f32>;             // new K or V: [1, dim]
+var<storage, read_write> dst: array<f32>; // cache: [max_seq, dim]
+var<storage> kv_pos_buf: array<u32>;      // [1] — current write position
+var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let j = gid.x;
+    if j >= params.dim { return; }
+    let kv_pos = kv_pos_buf[0];
+    dst[kv_pos * params.dim + j] = src[j];
+}

--- a/src/shaders/cached_attention.wgsl
+++ b/src/shaders/cached_attention.wgsl
@@ -1,0 +1,77 @@
+// Cached single-token attention: Q=[1, num_heads*head_dim], K/V from cache.
+// Dispatch: [1, num_heads, 1]
+// Each workgroup handles one head: loops over 0..kv_len cached positions.
+// kv_len = kv_pos + 1 (read from kv_pos_buf storage buffer).
+// Uses online softmax (same algorithm as attention.wgsl).
+
+struct Params {
+    _reserved: u32,
+    num_heads: u32,
+    num_kv_heads: u32,
+    head_dim: u32,
+}
+
+var<storage> src_a: array<f32>;      // Q: [1, num_heads * head_dim]
+var<storage> src_b: array<f32>;      // K cache: [max_seq, num_kv_heads * head_dim]
+var<storage> bias: array<f32>;       // V cache: [max_seq, num_kv_heads * head_dim]
+var<storage> kv_pos_buf: array<u32>; // [1] — current kv position
+var<storage, read_write> dst: array<f32>;
+var<uniform> params: Params;
+var<workgroup> wg_dot: array<f32, 64>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
+    let head = wgid.y;
+    let tid = lid.x;
+
+    let num_heads = params.num_heads;
+    let num_kv_heads = params.num_kv_heads;
+    let head_dim = params.head_dim;
+    let kv_len = kv_pos_buf[0] + 1u; // attend to positions 0..kv_pos inclusive
+
+    if head >= num_heads { return; }
+
+    let kv_head = head / (num_heads / num_kv_heads);
+    let kv_head_off = kv_head * head_dim;
+    let scale = inverseSqrt(f32(head_dim));
+    let q_base = head * head_dim;
+    let q_val = src_a[q_base + tid];
+
+    var my_out = 0.0;
+    var max_score = -1e30;
+    var sum_exp = 0.0;
+
+    for (var t = 0u; t < kv_len; t++) {
+        let k_base = t * (num_kv_heads * head_dim) + kv_head_off;
+
+        // Parallel dot product Q.K
+        wg_dot[tid] = q_val * src_b[k_base + tid];
+        workgroupBarrier();
+
+        // Tree reduction
+        if tid < 32u { wg_dot[tid] += wg_dot[tid + 32u]; }
+        workgroupBarrier();
+        if tid < 16u { wg_dot[tid] += wg_dot[tid + 16u]; }
+        workgroupBarrier();
+        if tid < 8u { wg_dot[tid] += wg_dot[tid + 8u]; }
+        workgroupBarrier();
+        if tid < 4u { wg_dot[tid] += wg_dot[tid + 4u]; }
+        workgroupBarrier();
+        if tid < 2u { wg_dot[tid] += wg_dot[tid + 2u]; }
+        workgroupBarrier();
+        if tid < 1u { wg_dot[tid] += wg_dot[tid + 1u]; }
+        workgroupBarrier();
+
+        let score = wg_dot[0] * scale;
+
+        // Online softmax update
+        let new_max = max(max_score, score);
+        let correction = exp(max_score - new_max);
+        let weight = exp(score - new_max);
+        sum_exp = sum_exp * correction + weight;
+        my_out = my_out * correction + weight * bias[k_base + tid];
+        max_score = new_max;
+    }
+
+    dst[q_base + tid] = my_out / sum_exp;
+}

--- a/src/shaders/rope_dynamic.wgsl
+++ b/src/shaders/rope_dynamic.wgsl
@@ -1,12 +1,16 @@
+// RoPE with dynamic position offset read from a storage buffer.
+// Same as rope.wgsl but pos_offset comes from a u32 buffer instead of params.
+
 struct Params {
     seq: u32,
     dim: u32,
     theta_bits: u32,
-    pos_offset: u32,
+    _pad: u32,
 }
 
 var<storage> src: array<f32>;
 var<storage, read_write> dst: array<f32>;
+var<storage> pos_offset_buf: array<u32>;
 var<uniform> params: Params;
 
 @compute @workgroup_size(256)
@@ -17,11 +21,10 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     if i >= total { return; }
 
     let row = i / half_dim;
-    let pos = row + params.pos_offset;
+    let pos = row + pos_offset_buf[0];
     let pair_idx = i % half_dim;
     let theta = bitcast<f32>(params.theta_bits);
 
-    // inv_freq = theta ^ (-2 * pair_idx / dim)
     let exponent = -2.0 * f32(pair_idx) / f32(params.dim);
     let inv_freq = pow(theta, exponent);
     let angle = f32(pos) * inv_freq;

--- a/tests/gpu_smoke.rs
+++ b/tests/gpu_smoke.rs
@@ -841,3 +841,83 @@ fn checkpoint_round_trip() {
 
     std::fs::remove_file(&tmp).ok();
 }
+
+/// Smoke test: KV cache ops (cache_write, cached_attention, rope_dynamic) compile and run.
+#[test]
+fn kv_cache_ops_smoke() {
+    let num_heads: u32 = 2;
+    let num_kv_heads: u32 = 2;
+    let head_dim: u32 = 64;
+    let kv_dim = (num_kv_heads * head_dim) as usize;
+    let q_dim = (num_heads * head_dim) as usize;
+    let max_seq: usize = 16;
+
+    let mut g = Graph::new();
+    let q_input = g.input("q", &[1, q_dim]);
+    let k_input = g.input("k", &[1, kv_dim]);
+    let v_input = g.input("v", &[1, kv_dim]);
+    let kv_pos = g.input_u32("kv_pos", &[1]);
+
+    // Pre-allocated cache buffers
+    let k_cache = g.parameter("k_cache", &[max_seq, kv_dim]);
+    let v_cache = g.parameter("v_cache", &[max_seq, kv_dim]);
+
+    // Write new K/V into cache
+    let _k_updated = g.cache_write(k_input, k_cache, kv_pos);
+    let _v_updated = g.cache_write(v_input, v_cache, kv_pos);
+
+    // RoPE with dynamic offset
+    let q_rope = g.rope_dynamic_offset(q_input, 10000.0, kv_pos);
+
+    // Cached attention
+    let attn = g.cached_attention(
+        q_rope,
+        k_cache,
+        v_cache,
+        kv_pos,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+    );
+
+    g.set_outputs(vec![attn]);
+
+    let mut session = build_inference_session(&g);
+
+    // Initialize caches to zero
+    session.set_parameter("k_cache", &vec![0.0f32; max_seq * kv_dim]);
+    session.set_parameter("v_cache", &vec![0.0f32; max_seq * kv_dim]);
+
+    // Step 0: write first K/V
+    let q_data: Vec<f32> = (0..q_dim).map(|i| (i as f32 * 0.01).sin()).collect();
+    let k_data: Vec<f32> = (0..kv_dim).map(|i| (i as f32 * 0.02).sin()).collect();
+    let v_data: Vec<f32> = (0..kv_dim).map(|i| (i as f32 * 0.03).sin()).collect();
+
+    session.set_input("q", &q_data);
+    session.set_input("k", &k_data);
+    session.set_input("v", &v_data);
+    session.set_input_u32("kv_pos", &[0]);
+
+    session.step();
+    session.wait();
+
+    let out = session.read_output(q_dim);
+    assert_eq!(out.len(), q_dim);
+    // With only 1 cached position, attention output should be non-zero
+    let sum: f32 = out.iter().map(|x| x.abs()).sum();
+    assert!(
+        sum > 0.0,
+        "attention output should be non-zero, got sum={}",
+        sum
+    );
+
+    // Step 1: add another K/V entry
+    session.set_input_u32("kv_pos", &[1]);
+    session.step();
+    session.wait();
+
+    let out2 = session.read_output(q_dim);
+    assert_eq!(out2.len(), q_dim);
+    let sum2: f32 = out2.iter().map(|x| x.abs()).sum();
+    assert!(sum2 > 0.0, "second step output should be non-zero");
+}


### PR DESCRIPTION
Implement the Phase 1 foundation from docs/kv-cache-plan.md:
- New ops: CacheWrite, CachedAttention, RoPE with pos_offset
- New shaders: cache_write.wgsl, cached_attention.wgsl, rope_dynamic.wgsl
- Prefill/decode graph builders for SmolLM2
- Runtime API for reading multiple outputs and managing cache buffers
- GPU smoke test validating cache write + cached attention over 2 steps