### PR TITLE
Conv2dGradWeight via implicit GEMM, coop matrix fixes, RoPE per-head …

### DIFF
--- a/bench/bench_sd_unet_train.rs
+++ b/bench/bench_sd_unet_train.rs
@@ -17,6 +17,7 @@ fn main() {
     }
 
     let use_small = std::env::args().any(|a| a == "--small");
+    let profile = std::env::var("MEGANEURA_PROFILE").is_ok();
     let warmup: usize = parse_arg("--warmup").unwrap_or(2);
     let runs: usize = parse_arg("--runs").unwrap_or(5);
     let steps_per_run: usize = parse_arg("--steps").unwrap_or(20);
@@ -96,6 +97,41 @@ fn main() {
         session.set_input("noise_target", &noise);
         session.step();
         session.wait();
+    }
+
+    // --- GPU profiling (MEGANEURA_PROFILE=1) ---
+    if profile {
+        session.set_profiling(true);
+        eprintln!(
+            "\n=== GPU timings ({} dispatches) ===",
+            session.plan().dispatches.len()
+        );
+        // 3-step dance for blade's 2-buffer ring:
+        // step A (profiled) → step B (advance ring) → step C reads A's timestamps
+        let noisy: Vec<f32> = (0..in_size).map(|_| next_f32()).collect();
+        let noise: Vec<f32> = (0..in_size).map(|_| next_f32() * 0.5).collect();
+        session.set_input("noisy_latent", &noisy);
+        session.set_input("noise_target", &noise);
+        session.step();
+        session.wait();
+
+        let noisy: Vec<f32> = (0..in_size).map(|_| next_f32()).collect();
+        let noise: Vec<f32> = (0..in_size).map(|_| next_f32() * 0.5).collect();
+        session.set_input("noisy_latent", &noisy);
+        session.set_input("noise_target", &noise);
+        session.step();
+        session.wait();
+
+        let noisy: Vec<f32> = (0..in_size).map(|_| next_f32()).collect();
+        let noise: Vec<f32> = (0..in_size).map(|_| next_f32() * 0.5).collect();
+        session.set_input("noisy_latent", &noisy);
+        session.set_input("noise_target", &noise);
+        session.step();
+        session.dump_gpu_timings();
+        session.wait();
+
+        session.set_profiling(false);
+        return;
     }
 
     // --- Timed runs ---

--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -553,7 +553,8 @@ pub fn differentiate(forward: &Graph) -> Graph {
             | Op::FullAttention { .. }
             | Op::CrossAttention { .. }
             | Op::CacheWrite
-            | Op::CachedAttention { .. } => {
+            | Op::CachedAttention { .. }
+            | Op::GroupNormSilu { .. } => {
                 log::warn!(
                     "autodiff not supported for {:?}, inference-only op",
                     node.op

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -116,6 +116,7 @@ pub enum ShaderGroup {
     Conv2dGradInputGemm,
     Conv2dGradInputGemmSmall,
     Conv2dGradInputGemmCoop,
+    GroupNormSilu,
     Conv2dGradWeight,
     Conv2dGradWeightGemm,
     Conv2dGradWeightGemmSmall,
@@ -181,6 +182,7 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::Conv2dGradInputGemm => gen_conv2d_grad_input_gemm(),
         ShaderGroup::Conv2dGradInputGemmSmall => gen_conv2d_grad_input_gemm_small(),
         ShaderGroup::Conv2dGradInputGemmCoop => gen_conv2d_grad_input_gemm_coop(),
+        ShaderGroup::GroupNormSilu => gen_group_norm_silu(),
         ShaderGroup::Conv2dGradWeight => gen_conv2d_grad_weight(),
         ShaderGroup::Conv2dGradWeightGemm => gen_conv2d_grad_weight_gemm(),
         ShaderGroup::Conv2dGradWeightGemmSmall => gen_conv2d_grad_weight_gemm_small(),
@@ -919,6 +921,10 @@ fn gen_group_norm_grad() -> ShaderModule {
     parse_wgsl(include_str!("shaders/group_norm_grad.wgsl"))
 }
 
+fn gen_group_norm_silu() -> ShaderModule {
+    parse_wgsl(include_str!("shaders/group_norm_silu.wgsl"))
+}
+
 // ---------------------------------------------------------------------------
 // concat.wgsl — Channel concatenation
 // ---------------------------------------------------------------------------
@@ -1480,7 +1486,9 @@ mod tests {
                 ShaderEntry::CachedAttention => {
                     vec!["src_a", "src_b", "bias", "kv_pos_buf", "dst", "params"]
                 }
-                ShaderEntry::GroupNorm => vec!["src", "src_b", "bias", "dst", "params"],
+                ShaderEntry::GroupNorm | ShaderEntry::GroupNormSilu => {
+                    vec!["src", "src_b", "bias", "dst", "params"]
+                }
                 ShaderEntry::GroupNormGradInput => vec!["src_a", "src_b", "bias", "dst", "params"],
                 ShaderEntry::GroupNormGradWeightBias => {
                     vec!["src_a", "src_b", "bias", "dst", "params"]

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -115,7 +115,9 @@ pub enum ShaderGroup {
     Conv2dGradInput,
     Conv2dGradInputGemm,
     Conv2dGradInputGemmSmall,
+    Conv2dGradInputGemmCoop,
     Conv2dGradWeight,
+    Conv2dGradWeightGemm,
     CacheWrite,
     CachedAttention,
     RoPEDynamic,
@@ -177,7 +179,9 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::Conv2dGradInput => gen_conv2d_grad_input(),
         ShaderGroup::Conv2dGradInputGemm => gen_conv2d_grad_input_gemm(),
         ShaderGroup::Conv2dGradInputGemmSmall => gen_conv2d_grad_input_gemm_small(),
+        ShaderGroup::Conv2dGradInputGemmCoop => gen_conv2d_grad_input_gemm_coop(),
         ShaderGroup::Conv2dGradWeight => gen_conv2d_grad_weight(),
+        ShaderGroup::Conv2dGradWeightGemm => gen_conv2d_grad_weight_gemm(),
         ShaderGroup::CacheWrite => gen_cache_write(),
         ShaderGroup::CachedAttention => gen_cached_attention(),
         ShaderGroup::RoPEDynamic => gen_rope_dynamic(),
@@ -191,6 +195,7 @@ pub fn generate_coop_module(group: ShaderGroup, config: &CoopConfig) -> ShaderMo
         ShaderGroup::MatMulCoopAdd => gen_matmul_coop_wgsl(true, MatMulCoopVariant::Normal, config),
         ShaderGroup::MatMulCoopBT => gen_matmul_coop_wgsl(false, MatMulCoopVariant::BT, config),
         ShaderGroup::MatMulCoopAT => gen_matmul_coop_wgsl(false, MatMulCoopVariant::AT, config),
+        ShaderGroup::Conv2dGradInputGemmCoop => gen_conv2d_grad_input_gemm_coop_wgsl(config),
         _ => panic!("not a coop shader group: {:?}", group),
     }
 }
@@ -202,6 +207,7 @@ pub fn generate_wgsl(group: ShaderGroup) -> String {
         ShaderGroup::MatMulCoop
         | ShaderGroup::MatMulCoopAdd
         | ShaderGroup::MatMulCoopAT
+        | ShaderGroup::Conv2dGradInputGemmCoop
         | ShaderGroup::MatMulCoopBT => {
             naga::valid::Capabilities::COOPERATIVE_MATRIX
                 | naga::valid::Capabilities::SHADER_FLOAT16
@@ -625,10 +631,10 @@ fn gen_matmul_coop_wgsl(
         (
             "var<storage> src: array<f32>;".to_string(),
             format!(
-                "var acc00 = coopLoad<{coop_c}>(&src[c00], n);\n\
-                 \x20   var acc01 = coopLoad<{coop_c}>(&src[c01], n);\n\
-                 \x20   var acc10 = coopLoad<{coop_c}>(&src[c10], n);\n\
-                 \x20   var acc11 = coopLoad<{coop_c}>(&src[c11], n);"
+                "var acc00 = coopLoadT<{coop_c}>(&src[c00], n);\n\
+                 \x20   var acc01 = coopLoadT<{coop_c}>(&src[c01], n);\n\
+                 \x20   var acc10 = coopLoadT<{coop_c}>(&src[c10], n);\n\
+                 \x20   var acc11 = coopLoadT<{coop_c}>(&src[c11], n);"
             ),
         )
     } else {
@@ -983,12 +989,83 @@ fn gen_conv2d_grad_input_gemm_small() -> ShaderModule {
     parse_wgsl(include_str!("shaders/conv2d_grad_input_gemm_small.wgsl"))
 }
 
+fn gen_conv2d_grad_input_gemm_coop() -> ShaderModule {
+    let default_config = CoopConfig {
+        tile_size: 16,
+        use_f16_input: true,
+    };
+    gen_conv2d_grad_input_gemm_coop_wgsl(&default_config)
+}
+
+fn gen_conv2d_grad_input_gemm_coop_wgsl(config: &CoopConfig) -> ShaderModule {
+    let tile = config.tile_size;
+    let output_tile = config.output_tile();
+    let shared_size = tile * tile;
+    let wg_size: u32 = 64;
+    let staging_iters = shared_size / wg_size;
+    let row_stride = wg_size / tile;
+    let tile_mask = tile - 1;
+    let tile_shift = tile.trailing_zeros();
+
+    let (elem_type, enable_f16, elem_zero, cast_open, cast_close) = if config.use_f16_input {
+        ("f16", "enable f16;", "f16(0.0)", "f16(", ")")
+    } else {
+        ("f32", "", "0.0", "", "")
+    };
+    let ab_type = if config.use_f16_input { "f16" } else { "f32" };
+    let coop_ab = format!("coop_mat{}x{}<{},A>", tile, tile, ab_type);
+    let coop_ba = format!("coop_mat{}x{}<{},B>", tile, tile, ab_type);
+    let coop_c = format!("coop_mat{}x{}<f32,C>", tile, tile);
+
+    let acc_init = format!(
+        "var acc00 = {coop_c}();\n\
+         \x20   var acc01 = {coop_c}();\n\
+         \x20   var acc10 = {coop_c}();\n\
+         \x20   var acc11 = {coop_c}();"
+    );
+
+    let output_tile_u = format!("{}u", output_tile);
+    let tile_size_u = format!("{}u", tile);
+    let tile_mask_u = format!("{}u", tile_mask);
+    let tile_shift_u = format!("{}u", tile_shift);
+    let staging_iters_u = format!("{}u", staging_iters);
+    let row_stride_u = format!("{}u", row_stride);
+    let shared_size_s = format!("{}", shared_size);
+
+    let src = include_str!("shaders/conv2d_grad_input_gemm_coop.wgsl");
+    let src = preprocess(
+        src,
+        &[
+            ("$ENABLE_F16", enable_f16),
+            ("$ELEM_TYPE", elem_type),
+            ("$ELEM_ZERO", elem_zero),
+            ("$SHARED_SIZE", &shared_size_s),
+            ("$OUTPUT_TILE_U", &output_tile_u),
+            ("$TILE_SIZE_U", &tile_size_u),
+            ("$TILE_MASK_U", &tile_mask_u),
+            ("$TILE_SHIFT_U", &tile_shift_u),
+            ("$STAGING_ITERS_U", &staging_iters_u),
+            ("$ROW_STRIDE_U", &row_stride_u),
+            ("$CAST_OPEN", cast_open),
+            ("$CAST_CLOSE", cast_close),
+            ("$COOP_AB", &coop_ab),
+            ("$COOP_BA", &coop_ba),
+            ("$ACC_INIT", &acc_init),
+        ],
+    );
+    parse_wgsl(&src)
+}
+
 // ---------------------------------------------------------------------------
 // conv2d_grad_weight.wgsl — Conv2d backward w.r.t. kernel weights
 // ---------------------------------------------------------------------------
 
 fn gen_conv2d_grad_weight() -> ShaderModule {
     parse_wgsl(include_str!("shaders/conv2d_grad_weight.wgsl"))
+}
+
+fn gen_conv2d_grad_weight_gemm() -> ShaderModule {
+    parse_wgsl(include_str!("shaders/conv2d_grad_weight_gemm.wgsl"))
 }
 
 fn gen_cache_write() -> ShaderModule {
@@ -1082,6 +1159,11 @@ mod tests {
             ),
             (
                 ShaderGroup::MatMulCoopBT,
+                naga::valid::Capabilities::COOPERATIVE_MATRIX
+                    | naga::valid::Capabilities::SHADER_FLOAT16,
+            ),
+            (
+                ShaderGroup::Conv2dGradInputGemmCoop,
                 naga::valid::Capabilities::COOPERATIVE_MATRIX
                     | naga::valid::Capabilities::SHADER_FLOAT16,
             ),
@@ -1270,6 +1352,7 @@ mod tests {
                     | ShaderGroup::MatMulCoopAdd
                     | ShaderGroup::MatMulCoopAT
                     | ShaderGroup::MatMulCoopBT
+                    | ShaderGroup::Conv2dGradInputGemmCoop
             ) {
                 continue;
             }
@@ -1409,7 +1492,12 @@ mod tests {
                 ShaderEntry::Conv2dGradInputGemm | ShaderEntry::Conv2dGradInputGemmSmall => {
                     vec!["grad_out", "weight", "dst", "params"]
                 }
-                ShaderEntry::Conv2dGradWeight => vec!["grad_out", "src", "dst", "params"],
+                ShaderEntry::Conv2dGradInputGemmCoop => {
+                    vec!["grad_out", "weight", "dst", "params"]
+                }
+                ShaderEntry::Conv2dGradWeight | ShaderEntry::Conv2dGradWeightGemm => {
+                    vec!["grad_out", "src", "dst", "params"]
+                }
                 ShaderEntry::RoPEDynamic => vec!["src", "dst", "pos_offset_buf", "params"],
             }
         }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -118,6 +118,7 @@ pub enum ShaderGroup {
     Conv2dGradInputGemmCoop,
     Conv2dGradWeight,
     Conv2dGradWeightGemm,
+    Conv2dGradWeightGemmSmall,
     CacheWrite,
     CachedAttention,
     RoPEDynamic,
@@ -182,6 +183,7 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::Conv2dGradInputGemmCoop => gen_conv2d_grad_input_gemm_coop(),
         ShaderGroup::Conv2dGradWeight => gen_conv2d_grad_weight(),
         ShaderGroup::Conv2dGradWeightGemm => gen_conv2d_grad_weight_gemm(),
+        ShaderGroup::Conv2dGradWeightGemmSmall => gen_conv2d_grad_weight_gemm_small(),
         ShaderGroup::CacheWrite => gen_cache_write(),
         ShaderGroup::CachedAttention => gen_cached_attention(),
         ShaderGroup::RoPEDynamic => gen_rope_dynamic(),
@@ -1068,6 +1070,10 @@ fn gen_conv2d_grad_weight_gemm() -> ShaderModule {
     parse_wgsl(include_str!("shaders/conv2d_grad_weight_gemm.wgsl"))
 }
 
+fn gen_conv2d_grad_weight_gemm_small() -> ShaderModule {
+    parse_wgsl(include_str!("shaders/conv2d_grad_weight_gemm_small.wgsl"))
+}
+
 fn gen_cache_write() -> ShaderModule {
     parse_wgsl(include_str!("shaders/cache_write.wgsl"))
 }
@@ -1495,7 +1501,9 @@ mod tests {
                 ShaderEntry::Conv2dGradInputGemmCoop => {
                     vec!["grad_out", "weight", "dst", "params"]
                 }
-                ShaderEntry::Conv2dGradWeight | ShaderEntry::Conv2dGradWeightGemm => {
+                ShaderEntry::Conv2dGradWeight
+                | ShaderEntry::Conv2dGradWeightGemm
+                | ShaderEntry::Conv2dGradWeightGemmSmall => {
                     vec!["grad_out", "src", "dst", "params"]
                 }
                 ShaderEntry::RoPEDynamic => vec!["src", "dst", "pos_offset_buf", "params"],

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -68,7 +68,9 @@ pub enum ShaderEntry {
     Conv2dGradInput,
     Conv2dGradInputGemm,
     Conv2dGradInputGemmSmall,
+    Conv2dGradInputGemmCoop,
     Conv2dGradWeight,
+    Conv2dGradWeightGemm,
     CacheWrite,
     CachedAttention,
     RoPEDynamic,
@@ -134,7 +136,9 @@ impl ShaderEntry {
             ShaderEntry::Conv2dGradInput => ShaderGroup::Conv2dGradInput,
             ShaderEntry::Conv2dGradInputGemm => ShaderGroup::Conv2dGradInputGemm,
             ShaderEntry::Conv2dGradInputGemmSmall => ShaderGroup::Conv2dGradInputGemmSmall,
+            ShaderEntry::Conv2dGradInputGemmCoop => ShaderGroup::Conv2dGradInputGemmCoop,
             ShaderEntry::Conv2dGradWeight => ShaderGroup::Conv2dGradWeight,
+            ShaderEntry::Conv2dGradWeightGemm => ShaderGroup::Conv2dGradWeightGemm,
             ShaderEntry::CacheWrite => ShaderGroup::CacheWrite,
             ShaderEntry::CachedAttention => ShaderGroup::CachedAttention,
             ShaderEntry::RoPEDynamic => ShaderGroup::RoPEDynamic,
@@ -202,8 +206,10 @@ impl ShaderEntry {
             ShaderEntry::Conv2d => "main",
             ShaderEntry::Conv2dGemm | ShaderEntry::Conv2dGemmSmall => "main",
             ShaderEntry::Conv2dGradInput => "main",
-            ShaderEntry::Conv2dGradInputGemm | ShaderEntry::Conv2dGradInputGemmSmall => "main",
-            ShaderEntry::Conv2dGradWeight => "main",
+            ShaderEntry::Conv2dGradInputGemm
+            | ShaderEntry::Conv2dGradInputGemmSmall
+            | ShaderEntry::Conv2dGradInputGemmCoop => "main",
+            ShaderEntry::Conv2dGradWeight | ShaderEntry::Conv2dGradWeightGemm => "main",
             ShaderEntry::CacheWrite => "main",
             ShaderEntry::CachedAttention => "main",
             ShaderEntry::RoPEDynamic => "main",
@@ -1282,9 +1288,12 @@ impl<'a> Compiler<'a> {
                 let out_w = (in_w + 2 * padding - kernel_w) / stride + 1;
                 let out_size = self.graph.node(node.inputs[0]).ty.shape[0] as u32;
                 let batch = out_size / (out_channels * out_h * out_w);
+                // Use GEMM formulation: grad_weight[Co, Ci*kH*kW] = grad_out_flat[Co, N*oH*oW] @ im2col(input)[N*oH*oW, Ci*kH*kW]
+                let n_total = in_channels * kernel_h * kernel_w; // Ci*kH*kW
+                let m_total = out_channels; // Co
                 self.plan.dispatches.push(Dispatch {
-                    shader: ShaderEntry::Conv2dGradWeight,
-                    workgroups: [in_channels * kernel_w, kernel_h, out_channels],
+                    shader: ShaderEntry::Conv2dGradWeightGemm,
+                    workgroups: [ceil_div(n_total, 64), ceil_div(m_total, 64), 1],
                     input_buffers: vec![grad_out, input],
                     output_buffer: out_buf,
                     extra_output: None,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -55,6 +55,7 @@ pub enum ShaderEntry {
     RmsNormGradX,
     FusedRmsNormMatMul,
     GroupNorm,
+    GroupNormSilu,
     GroupNormGradInput,
     GroupNormGradWeightBias,
     Concat,
@@ -125,6 +126,7 @@ impl ShaderEntry {
             ShaderEntry::RmsNormGradW | ShaderEntry::RmsNormGradX => ShaderGroup::RmsNormGrad,
             ShaderEntry::FusedRmsNormMatMul => ShaderGroup::FusedRmsNormMatMul,
             ShaderEntry::GroupNorm => ShaderGroup::GroupNorm,
+            ShaderEntry::GroupNormSilu => ShaderGroup::GroupNormSilu,
             ShaderEntry::GroupNormGradInput => ShaderGroup::GroupNormGrad,
             ShaderEntry::GroupNormGradWeightBias => ShaderGroup::GroupNormGrad,
             ShaderEntry::Concat => ShaderGroup::Concat,
@@ -197,7 +199,7 @@ impl ShaderEntry {
             ShaderEntry::RmsNormGradW => "rms_norm_grad_w",
             ShaderEntry::RmsNormGradX => "rms_norm_grad_x",
             ShaderEntry::FusedRmsNormMatMul => "main",
-            ShaderEntry::GroupNorm => "main",
+            ShaderEntry::GroupNorm | ShaderEntry::GroupNormSilu => "main",
             ShaderEntry::GroupNormGradInput => "grad_input",
             ShaderEntry::GroupNormGradWeightBias => "grad_weight_bias",
             ShaderEntry::Concat => "main",
@@ -1001,6 +1003,30 @@ impl<'a> Compiler<'a> {
                 let batch = total / (channels * spatial);
                 self.plan.dispatches.push(Dispatch {
                     shader: ShaderEntry::GroupNorm,
+                    workgroups: [batch * num_groups, 1, 1],
+                    input_buffers: vec![x, weight, bias],
+                    output_buffer: out_buf,
+                    extra_output: None,
+                    params: vec![batch, channels, spatial, num_groups, eps.to_bits(), 0, 0, 0],
+                    use_coop: false,
+                    use_small_tiles: false,
+                    label: String::new(),
+                });
+            }
+
+            Op::GroupNormSilu {
+                num_groups,
+                eps,
+                channels,
+                spatial,
+            } => {
+                let x = self.get_buffer(node.inputs[0]);
+                let weight = self.get_buffer(node.inputs[1]);
+                let bias = self.get_buffer(node.inputs[2]);
+                let total = node.ty.shape[0] as u32;
+                let batch = total / (channels * spatial);
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::GroupNormSilu,
                     workgroups: [batch * num_groups, 1, 1],
                     input_buffers: vec![x, weight, bias],
                     output_buffer: out_buf,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -71,6 +71,7 @@ pub enum ShaderEntry {
     Conv2dGradInputGemmCoop,
     Conv2dGradWeight,
     Conv2dGradWeightGemm,
+    Conv2dGradWeightGemmSmall,
     CacheWrite,
     CachedAttention,
     RoPEDynamic,
@@ -139,6 +140,7 @@ impl ShaderEntry {
             ShaderEntry::Conv2dGradInputGemmCoop => ShaderGroup::Conv2dGradInputGemmCoop,
             ShaderEntry::Conv2dGradWeight => ShaderGroup::Conv2dGradWeight,
             ShaderEntry::Conv2dGradWeightGemm => ShaderGroup::Conv2dGradWeightGemm,
+            ShaderEntry::Conv2dGradWeightGemmSmall => ShaderGroup::Conv2dGradWeightGemmSmall,
             ShaderEntry::CacheWrite => ShaderGroup::CacheWrite,
             ShaderEntry::CachedAttention => ShaderGroup::CachedAttention,
             ShaderEntry::RoPEDynamic => ShaderGroup::RoPEDynamic,
@@ -209,7 +211,9 @@ impl ShaderEntry {
             ShaderEntry::Conv2dGradInputGemm
             | ShaderEntry::Conv2dGradInputGemmSmall
             | ShaderEntry::Conv2dGradInputGemmCoop => "main",
-            ShaderEntry::Conv2dGradWeight | ShaderEntry::Conv2dGradWeightGemm => "main",
+            ShaderEntry::Conv2dGradWeight
+            | ShaderEntry::Conv2dGradWeightGemm
+            | ShaderEntry::Conv2dGradWeightGemmSmall => "main",
             ShaderEntry::CacheWrite => "main",
             ShaderEntry::CachedAttention => "main",
             ShaderEntry::RoPEDynamic => "main",
@@ -1291,9 +1295,16 @@ impl<'a> Compiler<'a> {
                 // Use GEMM formulation: grad_weight[Co, Ci*kH*kW] = grad_out_flat[Co, N*oH*oW] @ im2col(input)[N*oH*oW, Ci*kH*kW]
                 let n_total = in_channels * kernel_h * kernel_w; // Ci*kH*kW
                 let m_total = out_channels; // Co
+                let wgs_64 = ceil_div(n_total, 64) * ceil_div(m_total, 64);
+                let use_small = wgs_64 < 16;
+                let tile = if use_small { 32 } else { 64 };
                 self.plan.dispatches.push(Dispatch {
-                    shader: ShaderEntry::Conv2dGradWeightGemm,
-                    workgroups: [ceil_div(n_total, 64), ceil_div(m_total, 64), 1],
+                    shader: if use_small {
+                        ShaderEntry::Conv2dGradWeightGemmSmall
+                    } else {
+                        ShaderEntry::Conv2dGradWeightGemm
+                    },
+                    workgroups: [ceil_div(n_total, tile), ceil_div(m_total, tile), 1],
                     input_buffers: vec![grad_out, input],
                     output_buffer: out_buf,
                     extra_output: None,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -311,6 +311,15 @@ pub enum Op {
         spatial: u32, // H * W
     },
 
+    /// Fused GroupNorm + SiLU: normalize then apply SiLU activation.
+    /// inputs: [x, weight, bias], same shape as GroupNorm.
+    GroupNormSilu {
+        num_groups: u32,
+        eps: f32,
+        channels: u32,
+        spatial: u32,
+    },
+
     // GroupNorm backward w.r.t. input
     // inputs: [grad_output, input, weight]
     GroupNormGradInput {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -263,6 +263,7 @@ fn graph_to_egglog(graph: &Graph) -> String {
   (MultiHeadAttn Op Op Op)
   ; --- GroupNorm, Concat, Upsample, Conv2d ops ---
   (GroupNorm Op Op Op)
+  (GroupNormSilu Op Op Op)
   (GroupNormGradInput Op Op Op)
   (GroupNormGradWeightBias Op Op)
   (Concat Op Op)
@@ -418,6 +419,7 @@ fn node_to_egglog_expr(node: &Node) -> String {
             format!("(FusedRmsNormMatMul n{} n{} n{})", i[0], i[1], i[2])
         }
         Op::GroupNorm { .. } => format!("(GroupNorm n{} n{} n{})", i[0], i[1], i[2]),
+        Op::GroupNormSilu { .. } => format!("(GroupNormSilu n{} n{} n{})", i[0], i[1], i[2]),
         Op::GroupNormGradInput { .. } => {
             format!("(GroupNormGradInput n{} n{} n{})", i[0], i[1], i[2])
         }
@@ -689,6 +691,52 @@ fn apply_swiglu_concat_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u32
             "SwiGLU(MatMul,MatMul)→SwiGLUConcat(MatMul)".to_string(),
             id as u32,
         ));
+    }
+}
+
+/// Fuse Silu(GroupNorm(x, w, b)) → GroupNormSilu(x, w, b)
+///
+/// Only fuses if the GroupNorm result is used exclusively by this Silu.
+/// This is inference-only (backward pass can't differentiate through the fused op).
+pub fn apply_group_norm_silu_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u32)>) {
+    let node_ids: Vec<usize> = (0..graph.nodes().len()).collect();
+    for &id in &node_ids {
+        let node = &graph.nodes()[id];
+        if !matches!(node.op, Op::Silu) {
+            continue;
+        }
+        let gn_id = node.inputs[0];
+        let gn_node = graph.node(gn_id);
+        let (num_groups, eps, channels, spatial) = match gn_node.op {
+            Op::GroupNorm {
+                num_groups,
+                eps,
+                channels,
+                spatial,
+            } => (num_groups, eps, channels, spatial),
+            _ => continue,
+        };
+        // Only fuse if GroupNorm has a single consumer
+        let gn_use_count = graph
+            .nodes()
+            .iter()
+            .filter(|n| n.inputs.contains(&gn_id) && !matches!(n.op, Op::Nop))
+            .count();
+        if gn_use_count != 1 {
+            continue;
+        }
+        let (x, w, b) = (gn_node.inputs[0], gn_node.inputs[1], gn_node.inputs[2]);
+        // Rewrite Silu node to GroupNormSilu
+        graph.nodes_mut()[id].op = Op::GroupNormSilu {
+            num_groups,
+            eps,
+            channels,
+            spatial,
+        };
+        graph.nodes_mut()[id].inputs = vec![x, w, b];
+        // Mark old GroupNorm as Nop
+        graph.nodes_mut()[gn_id as usize].op = Op::Nop;
+        fusions.push(("GroupNorm+Silu→GroupNormSilu".to_string(), id as u32));
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -507,6 +507,7 @@ impl Pipelines {
                     ShaderGroup::MatMulAdd => ShaderGroup::MatMulCoopAdd,
                     ShaderGroup::MatMulAT => ShaderGroup::MatMulCoopAT,
                     ShaderGroup::MatMulBT => ShaderGroup::MatMulCoopBT,
+                    ShaderGroup::Conv2dGradInputGemm => ShaderGroup::Conv2dGradInputGemmCoop,
                     _ => continue,
                 };
                 needed_coop.insert(coop_group);
@@ -670,10 +671,12 @@ fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
         ShaderEntry::Conv2d => Conv2dData::layout(),
         ShaderEntry::Conv2dGemm | ShaderEntry::Conv2dGemmSmall => Conv2dData::layout(),
         ShaderEntry::Conv2dGradInput => Conv2dGradInputData::layout(),
-        ShaderEntry::Conv2dGradInputGemm | ShaderEntry::Conv2dGradInputGemmSmall => {
-            Conv2dGradInputData::layout()
+        ShaderEntry::Conv2dGradInputGemm
+        | ShaderEntry::Conv2dGradInputGemmSmall
+        | ShaderEntry::Conv2dGradInputGemmCoop => Conv2dGradInputData::layout(),
+        ShaderEntry::Conv2dGradWeight | ShaderEntry::Conv2dGradWeightGemm => {
+            Conv2dGradWeightData::layout()
         }
-        ShaderEntry::Conv2dGradWeight => Conv2dGradWeightData::layout(),
         ShaderEntry::RoPEDynamic => RoPEDynamicData::layout(),
         ShaderEntry::CacheWrite => CacheWriteData::layout(),
         ShaderEntry::CachedAttention => CachedAttentionData::layout(),
@@ -994,17 +997,37 @@ impl Session {
             let half_tile = config.tile_size;
             for dispatch in &mut plan.dispatches {
                 let group = dispatch.shader.shader_group();
-                let (m, n, k) = match group {
-                    ShaderGroup::MatMul | ShaderGroup::MatMulAdd => {
-                        (dispatch.params[0], dispatch.params[2], dispatch.params[1])
+                // Extract (m, n, k, batch) from dispatch params based on shader group.
+                let (m, n, k, batch) = match group {
+                    ShaderGroup::MatMul | ShaderGroup::MatMulAdd => (
+                        dispatch.params[0],
+                        dispatch.params[2],
+                        dispatch.params[1],
+                        1u32,
+                    ),
+                    ShaderGroup::Conv2dGradInputGemm => {
+                        // params: [batch, in_channels, in_h, in_w, out_channels, kernel_h, kernel_w, stride, padding, out_h, out_w, ...]
+                        let in_ch = dispatch.params[1];
+                        let in_h = dispatch.params[2];
+                        let in_w = dispatch.params[3];
+                        let out_ch = dispatch.params[4];
+                        let kh = dispatch.params[5];
+                        let kw = dispatch.params[6];
+                        (in_ch, in_h * in_w, out_ch * kh * kw, dispatch.params[0])
                     }
                     // Coop AT/BT disabled for now.
                     // TODO: safe to enable for f32 path (no f16 precision loss).
                     ShaderGroup::MatMulAT | ShaderGroup::MatMulBT => continue,
                     _ => continue,
                 };
-                let coop_wgs = ceil_div(m, output_tile) * ceil_div(n, output_tile);
-                let min_wgs = if k >= 1024 {
+                let coop_wgs = ceil_div(m, output_tile) * ceil_div(n, output_tile) * batch;
+                // Conv2d GEMM has heavier staging (im2col indexing with integer
+                // division per element), so require more workgroups to amortize
+                // the cooperative matrix overhead.
+                let is_conv = matches!(group, ShaderGroup::Conv2dGradInputGemm);
+                let min_wgs = if is_conv {
+                    512
+                } else if k >= 1024 {
                     MIN_COOP_WORKGROUPS_HIGH_K
                 } else {
                     MIN_COOP_WORKGROUPS
@@ -1013,13 +1036,14 @@ impl Session {
                 let n_edge_safe = n % output_tile <= half_tile;
                 if coop_wgs >= min_wgs && m_edge_safe && n_edge_safe {
                     dispatch.use_coop = true;
-                    dispatch.workgroups = [ceil_div(m, output_tile), ceil_div(n, output_tile), 1];
+                    dispatch.workgroups =
+                        [ceil_div(m, output_tile), ceil_div(n, output_tile), batch];
                     // coopStore/coopLoad operate on full tiles without per-element
                     // bounds checking. Pad output and addend buffers so edge
                     // tiles don't read/write past the end.
                     let padded_m = ceil_div(m, output_tile) * output_tile;
                     let padded_n = ceil_div(n, output_tile) * output_tile;
-                    let padded_bytes = (padded_m * padded_n * 4) as usize;
+                    let padded_bytes = (padded_m * padded_n * batch * 4) as usize;
                     let buf_idx = dispatch.output_buffer.0 as usize;
                     if plan.buffers[buf_idx] < padded_bytes {
                         plan.buffers[buf_idx] = padded_bytes;
@@ -2111,7 +2135,8 @@ impl Session {
             }
             ShaderEntry::Conv2dGradInput
             | ShaderEntry::Conv2dGradInputGemm
-            | ShaderEntry::Conv2dGradInputGemmSmall => {
+            | ShaderEntry::Conv2dGradInputGemmSmall
+            | ShaderEntry::Conv2dGradInputGemmCoop => {
                 let p = &dispatch.params;
                 pc.bind(
                     0,
@@ -2136,7 +2161,7 @@ impl Session {
                     },
                 );
             }
-            ShaderEntry::Conv2dGradWeight => {
+            ShaderEntry::Conv2dGradWeight | ShaderEntry::Conv2dGradWeightGemm => {
                 let p = &dispatch.params;
                 pc.bind(
                     0,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -662,7 +662,7 @@ fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
         ShaderEntry::SwiGLUGradUp | ShaderEntry::SiluGrad => BinaryData::layout(),
         ShaderEntry::RmsNormGradW | ShaderEntry::RmsNormGradX => CausalAttentionData::layout(),
         ShaderEntry::FusedRmsNormMatMul => CausalAttentionData::layout(),
-        ShaderEntry::GroupNorm => GroupNormData::layout(),
+        ShaderEntry::GroupNorm | ShaderEntry::GroupNormSilu => GroupNormData::layout(),
         ShaderEntry::GroupNormGradInput => GroupNormGradInputData::layout(),
         ShaderEntry::GroupNormGradWeightBias => GroupNormGradWeightBiasData::layout(),
         ShaderEntry::Concat => BinaryData::layout(),
@@ -1993,7 +1993,7 @@ impl Session {
                     },
                 );
             }
-            ShaderEntry::GroupNorm => {
+            ShaderEntry::GroupNorm | ShaderEntry::GroupNormSilu => {
                 let p = &dispatch.params;
                 pc.bind(
                     0,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -674,9 +674,9 @@ fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
         ShaderEntry::Conv2dGradInputGemm
         | ShaderEntry::Conv2dGradInputGemmSmall
         | ShaderEntry::Conv2dGradInputGemmCoop => Conv2dGradInputData::layout(),
-        ShaderEntry::Conv2dGradWeight | ShaderEntry::Conv2dGradWeightGemm => {
-            Conv2dGradWeightData::layout()
-        }
+        ShaderEntry::Conv2dGradWeight
+        | ShaderEntry::Conv2dGradWeightGemm
+        | ShaderEntry::Conv2dGradWeightGemmSmall => Conv2dGradWeightData::layout(),
         ShaderEntry::RoPEDynamic => RoPEDynamicData::layout(),
         ShaderEntry::CacheWrite => CacheWriteData::layout(),
         ShaderEntry::CachedAttention => CachedAttentionData::layout(),
@@ -2161,7 +2161,9 @@ impl Session {
                     },
                 );
             }
-            ShaderEntry::Conv2dGradWeight | ShaderEntry::Conv2dGradWeightGemm => {
+            ShaderEntry::Conv2dGradWeight
+            | ShaderEntry::Conv2dGradWeightGemm
+            | ShaderEntry::Conv2dGradWeightGemmSmall => {
                 let p = &dispatch.params;
                 pc.bind(
                     0,

--- a/src/shaders/conv2d_grad_input_gemm_coop.wgsl
+++ b/src/shaders/conv2d_grad_input_gemm_coop.wgsl
@@ -1,0 +1,205 @@
+// Conv2d backward w.r.t. input via implicit GEMM — cooperative matrix variant.
+//
+// grad_input[n] = weight_T @ im2col(grad_out[n])^T
+// C[Ci, H*W] = A[Ci, K] × B[K, H*W], K = Co*kH*kW, per batch item.
+//
+// Uses 2×2 cooperative matrix tile grid ($OUTPUT_TILE×$OUTPUT_TILE per WG).
+// Dispatch: [ceil(Ci / $OUTPUT_TILE), ceil(H*W / $OUTPUT_TILE), batch]
+
+$ENABLE_F16
+enable wgpu_cooperative_matrix;
+
+struct Params {
+    batch: u32,
+    in_channels: u32,
+    in_h: u32,
+    in_w: u32,
+    out_channels: u32,
+    kernel_h: u32,
+    kernel_w: u32,
+    stride: u32,
+    padding: u32,
+    out_h: u32,
+    out_w: u32,
+    _pad: u32,
+}
+
+var<storage> grad_out: array<f32>;
+var<storage> weight: array<f32>;
+var<storage, read_write> dst: array<f32>;
+var<uniform> params: Params;
+var<workgroup> shared_a0: array<$ELEM_TYPE, $SHARED_SIZE>;
+var<workgroup> shared_a1: array<$ELEM_TYPE, $SHARED_SIZE>;
+var<workgroup> shared_b0: array<$ELEM_TYPE, $SHARED_SIZE>;
+var<workgroup> shared_b1: array<$ELEM_TYPE, $SHARED_SIZE>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
+    let tile_row = wgid.x * $OUTPUT_TILE_U;  // M (Ci)
+    let tile_col = wgid.y * $OUTPUT_TILE_U;  // N (H*W)
+    let n = wgid.z;                           // batch
+
+    let m_total = params.in_channels;
+    let n_total = params.in_h * params.in_w;
+    let kernel_hw = params.kernel_h * params.kernel_w;
+    let k_total = params.out_channels * kernel_hw;
+    let go_spatial = params.out_h * params.out_w;
+
+    let pad_h = i32(params.kernel_h) - 1 - i32(params.padding);
+    let pad_w = i32(params.kernel_w) - 1 - i32(params.padding);
+
+    // C offsets for the 4 output tiles (row-major in [Ci, H*W])
+    let c00 = n * m_total * n_total + tile_row * n_total + tile_col;
+    let c01 = n * m_total * n_total + tile_row * n_total + (tile_col + $TILE_SIZE_U);
+    let c10 = n * m_total * n_total + (tile_row + $TILE_SIZE_U) * n_total + tile_col;
+    let c11 = n * m_total * n_total + (tile_row + $TILE_SIZE_U) * n_total + (tile_col + $TILE_SIZE_U);
+
+    let n1_valid = (tile_col + $TILE_SIZE_U) < n_total;
+    let m1_valid = (tile_row + $TILE_SIZE_U) < m_total;
+
+    $ACC_INIT
+
+    // Hoisted staging index components
+    let src_col = lid.x & $TILE_MASK_U;
+    let base_row = lid.x >> $TILE_SHIFT_U;
+
+    var t = 0u;
+    loop {
+        if t >= k_total { break; }
+
+        let zero_val = $ELEM_ZERO;
+
+        // Stage sa0: B-tile [K, H*W] → im2col(grad_out)^T
+        // sa0[flat] = im2col[t+row_local, tile_col+col_local]
+        let cc0 = tile_col + src_col;
+        let in_n0 = cc0 < n_total;
+        for (var e = 0u; e < $STAGING_ITERS_U; e++) {
+            let flat = lid.x + e * 64u;
+            let tr = t + base_row + e * $ROW_STRIDE_U;
+            var val = zero_val;
+            if tr < k_total && in_n0 {
+                let co = tr / kernel_hw;
+                let k_rem = tr - co * kernel_hw;
+                let kh = k_rem / params.kernel_w;
+                let kw = k_rem - kh * params.kernel_w;
+                let ih = cc0 / params.in_w;
+                let iw = cc0 - ih * params.in_w;
+                if params.stride == 1u {
+                    let oh = i32(ih) + pad_h - i32(kh);
+                    let ow = i32(iw) + pad_w - i32(kw);
+                    if oh >= 0 && u32(oh) < params.out_h && ow >= 0 && u32(ow) < params.out_w {
+                        val = $CAST_OPEN grad_out[n * params.out_channels * go_spatial + co * go_spatial + u32(oh) * params.out_w + u32(ow)] $CAST_CLOSE;
+                    }
+                } else {
+                    let h_off = i32(ih) + i32(params.padding) - i32(kh);
+                    let w_off = i32(iw) + i32(params.padding) - i32(kw);
+                    let i_stride = i32(params.stride);
+                    if h_off >= 0 && w_off >= 0 && (h_off % i_stride) == 0 && (w_off % i_stride) == 0 {
+                        let oh = u32(h_off) / params.stride;
+                        let ow = u32(w_off) / params.stride;
+                        if oh < params.out_h && ow < params.out_w {
+                            val = $CAST_OPEN grad_out[n * params.out_channels * go_spatial + co * go_spatial + oh * params.out_w + ow] $CAST_CLOSE;
+                        }
+                    }
+                }
+            }
+            shared_a0[flat] = val;
+        }
+
+        // Stage sa1: B-tile second column block [K, tile_col+TILE..tile_col+2*TILE]
+        let cc1 = tile_col + $TILE_SIZE_U + src_col;
+        let in_n1 = cc1 < n_total;
+        for (var e = 0u; e < $STAGING_ITERS_U; e++) {
+            let flat = lid.x + e * 64u;
+            let tr = t + base_row + e * $ROW_STRIDE_U;
+            var val = zero_val;
+            if tr < k_total && in_n1 {
+                let co = tr / kernel_hw;
+                let k_rem = tr - co * kernel_hw;
+                let kh = k_rem / params.kernel_w;
+                let kw = k_rem - kh * params.kernel_w;
+                let ih = cc1 / params.in_w;
+                let iw = cc1 - ih * params.in_w;
+                if params.stride == 1u {
+                    let oh = i32(ih) + pad_h - i32(kh);
+                    let ow = i32(iw) + pad_w - i32(kw);
+                    if oh >= 0 && u32(oh) < params.out_h && ow >= 0 && u32(ow) < params.out_w {
+                        val = $CAST_OPEN grad_out[n * params.out_channels * go_spatial + co * go_spatial + u32(oh) * params.out_w + u32(ow)] $CAST_CLOSE;
+                    }
+                } else {
+                    let h_off = i32(ih) + i32(params.padding) - i32(kh);
+                    let w_off = i32(iw) + i32(params.padding) - i32(kw);
+                    let i_stride = i32(params.stride);
+                    if h_off >= 0 && w_off >= 0 && (h_off % i_stride) == 0 && (w_off % i_stride) == 0 {
+                        let oh = u32(h_off) / params.stride;
+                        let ow = u32(w_off) / params.stride;
+                        if oh < params.out_h && ow < params.out_w {
+                            val = $CAST_OPEN grad_out[n * params.out_channels * go_spatial + co * go_spatial + oh * params.out_w + ow] $CAST_CLOSE;
+                        }
+                    }
+                }
+            }
+            shared_a1[flat] = val;
+        }
+
+        // Stage sb0: A-tile [Ci, K] → weight_T
+        // sb0[flat] = weight_T[tile_row+row_local, t+col_local]
+        let tc = t + src_col;
+        let in_k = tc < k_total;
+        for (var e = 0u; e < $STAGING_ITERS_U; e++) {
+            let flat = lid.x + e * 64u;
+            let gr = tile_row + base_row + e * $ROW_STRIDE_U;
+            var val = zero_val;
+            if gr < m_total && in_k {
+                let co = tc / kernel_hw;
+                let k_rem = tc - co * kernel_hw;
+                let kh = k_rem / params.kernel_w;
+                let kw = k_rem - kh * params.kernel_w;
+                val = $CAST_OPEN weight[(co * m_total + gr) * kernel_hw + kh * params.kernel_w + kw] $CAST_CLOSE;
+            }
+            shared_b0[flat] = val;
+        }
+
+        // Stage sb1: A-tile second row block [Ci+TILE..Ci+2*TILE, K]
+        for (var e = 0u; e < $STAGING_ITERS_U; e++) {
+            let flat = lid.x + e * 64u;
+            let gr = tile_row + $TILE_SIZE_U + base_row + e * $ROW_STRIDE_U;
+            var val = zero_val;
+            if gr < m_total && in_k {
+                let co = tc / kernel_hw;
+                let k_rem = tc - co * kernel_hw;
+                let kh = k_rem / params.kernel_w;
+                let kw = k_rem - kh * params.kernel_w;
+                val = $CAST_OPEN weight[(co * m_total + gr) * kernel_hw + kh * params.kernel_w + kw] $CAST_CLOSE;
+            }
+            shared_b1[flat] = val;
+        }
+
+        workgroupBarrier();
+
+        // Cooperative matrix multiply-add: C += A × B
+        let a0 = coopLoadT<$COOP_AB>(&shared_b0[0], $TILE_SIZE_U);
+        let a1 = coopLoadT<$COOP_AB>(&shared_b1[0], $TILE_SIZE_U);
+        let b0 = coopLoadT<$COOP_BA>(&shared_a0[0], $TILE_SIZE_U);
+        let b1 = coopLoadT<$COOP_BA>(&shared_a1[0], $TILE_SIZE_U);
+        acc00 = coopMultiplyAdd(a0, b0, acc00);
+        acc01 = coopMultiplyAdd(a0, b1, acc01);
+        acc10 = coopMultiplyAdd(a1, b0, acc10);
+        acc11 = coopMultiplyAdd(a1, b1, acc11);
+
+        workgroupBarrier();
+        t += $TILE_SIZE_U;
+    }
+
+    // Store results to grad_input [N, Ci, H, W] in NCHW layout
+    coopStoreT(acc00, &dst[c00], n_total);
+    if n1_valid {
+        coopStoreT(acc01, &dst[c01], n_total);
+    }
+    if m1_valid {
+        coopStoreT(acc10, &dst[c10], n_total);
+    }
+    if n1_valid && m1_valid {
+        coopStoreT(acc11, &dst[c11], n_total);
+    }
+}

--- a/src/shaders/conv2d_grad_weight_gemm.wgsl
+++ b/src/shaders/conv2d_grad_weight_gemm.wgsl
@@ -1,0 +1,147 @@
+// Conv2d backward w.r.t. kernel via implicit GEMM.
+//
+// grad_weight[Co, Ci*kH*kW] = grad_out_flat[Co, N*oH*oW] × im2col(input)[N*oH*oW, Ci*kH*kW]
+// C[Co, Ci*kH*kW] = A[Co, K] × B[K, Ci*kH*kW], K = batch*oH*oW.
+//
+// BM=64, BN=64, KTILE=16, TM=4, TN=4, workgroup [16,16,1]
+// Dispatch: [ceil(Ci*kH*kW / 64), ceil(Co / 64), 1]
+
+struct Params {
+    batch: u32,
+    in_channels: u32,
+    in_h: u32,
+    in_w: u32,
+    out_channels: u32,
+    kernel_h: u32,
+    kernel_w: u32,
+    stride: u32,
+    padding: u32,
+    out_h: u32,
+    out_w: u32,
+    _pad: u32,
+}
+
+var<storage> grad_out: array<f32>;           // [N, Co, oH, oW]
+var<storage> src: array<f32>;                // input [N, Ci, H, W]
+var<storage, read_write> dst: array<f32>;    // grad_kernel [Co, Ci, kH, kW]
+var<uniform> params: Params;
+var<workgroup> shared_a: array<f32, 1024>;   // A tile: [64, 16]
+var<workgroup> shared_b: array<f32, 1024>;   // B tile: [16, 64]
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
+    let tx = lid.x;
+    let ty = lid.y;
+    let tile_row = wgid.y * 64u;   // M (Co) tile start
+    let tile_col = wgid.x * 64u;   // N (Ci*kH*kW) tile start
+    let tid = ty * 16u + tx;
+
+    let m_total = params.out_channels;                   // Co
+    let kernel_hw = params.kernel_h * params.kernel_w;
+    let n_total = params.in_channels * kernel_hw;        // Ci*kH*kW
+    let go_spatial = params.out_h * params.out_w;        // oH*oW
+    let k_total = params.batch * go_spatial;             // N*oH*oW
+    let input_spatial = params.in_h * params.in_w;
+
+    // 16 accumulator registers (4×4 per thread)
+    var s0_0 = 0.0; var s0_1 = 0.0; var s0_2 = 0.0; var s0_3 = 0.0;
+    var s1_0 = 0.0; var s1_1 = 0.0; var s1_2 = 0.0; var s1_3 = 0.0;
+    var s2_0 = 0.0; var s2_1 = 0.0; var s2_2 = 0.0; var s2_3 = 0.0;
+    var s3_0 = 0.0; var s3_1 = 0.0; var s3_2 = 0.0; var s3_3 = 0.0;
+
+    var t = 0u;
+    loop {
+        if t >= k_total { break; }
+
+        // Load A tile: grad_out_flat[Co, N*oH*oW] → shared_a[64, 16]
+        // A[co, n*oH*oW + oh*oW + ow] = grad_out[n, co, oh, ow]
+        for (var e = 0u; e < 4u; e++) {
+            let flat = tid + e * 256u;
+            let row_local = flat / 16u;  // M dimension (Co)
+            let col_local = flat % 16u;  // K dimension
+            let co = tile_row + row_local;
+            let k_idx = t + col_local;
+
+            var val = 0.0;
+            if co < m_total && k_idx < k_total {
+                let n = k_idx / go_spatial;
+                let rem = k_idx - n * go_spatial;
+                let oh = rem / params.out_w;
+                let ow = rem - oh * params.out_w;
+                val = grad_out[((n * params.out_channels + co) * params.out_h + oh) * params.out_w + ow];
+            }
+            shared_a[row_local * 16u + col_local] = val;
+        }
+
+        // Load B tile: im2col(input)[N*oH*oW, Ci*kH*kW] → shared_b[16, 64]
+        // B[k_idx, col] where k_idx = n*oH*oW + oh*oW + ow, col = ci*kH*kW + kh*kW + kw
+        // B[k_idx, col] = input[n, ci, oh*stride+kh-padding, ow*stride+kw-padding]
+        for (var e = 0u; e < 4u; e++) {
+            let flat = tid + e * 256u;
+            let row_local = flat / 64u;  // K dimension (within KTILE=16)
+            let col_local = flat % 64u;  // N dimension (Ci*kH*kW)
+            let k_idx = t + row_local;
+            let col_idx = tile_col + col_local;
+
+            var val = 0.0;
+            if k_idx < k_total && col_idx < n_total {
+                // Decompose k_idx → (n, oh, ow)
+                let n = k_idx / go_spatial;
+                let rem = k_idx - n * go_spatial;
+                let oh = rem / params.out_w;
+                let ow = rem - oh * params.out_w;
+                // Decompose col_idx → (ci, kh, kw)
+                let ci = col_idx / kernel_hw;
+                let k_rem = col_idx - ci * kernel_hw;
+                let kh = k_rem / params.kernel_w;
+                let kw = k_rem - kh * params.kernel_w;
+                // Input position
+                let ih = i32(oh * params.stride + kh) - i32(params.padding);
+                let iw = i32(ow * params.stride + kw) - i32(params.padding);
+                if ih >= 0 && u32(ih) < params.in_h && iw >= 0 && u32(iw) < params.in_w {
+                    val = src[((n * params.in_channels + ci) * params.in_h + u32(ih)) * params.in_w + u32(iw)];
+                }
+            }
+            shared_b[row_local * 64u + col_local] = val;
+        }
+
+        workgroupBarrier();
+
+        // Compute: 4×4 register-tiled matmul over KTILE=16
+        for (var kk = 0u; kk < 16u; kk++) {
+            let a0 = shared_a[(ty * 4u + 0u) * 16u + kk];
+            let a1 = shared_a[(ty * 4u + 1u) * 16u + kk];
+            let a2 = shared_a[(ty * 4u + 2u) * 16u + kk];
+            let a3 = shared_a[(ty * 4u + 3u) * 16u + kk];
+            let b0 = shared_b[kk * 64u + tx * 4u + 0u];
+            let b1 = shared_b[kk * 64u + tx * 4u + 1u];
+            let b2 = shared_b[kk * 64u + tx * 4u + 2u];
+            let b3 = shared_b[kk * 64u + tx * 4u + 3u];
+            s0_0 += a0 * b0; s0_1 += a0 * b1; s0_2 += a0 * b2; s0_3 += a0 * b3;
+            s1_0 += a1 * b0; s1_1 += a1 * b1; s1_2 += a1 * b2; s1_3 += a1 * b3;
+            s2_0 += a2 * b0; s2_1 += a2 * b1; s2_2 += a2 * b2; s2_3 += a2 * b3;
+            s3_0 += a3 * b0; s3_1 += a3 * b1; s3_2 += a3 * b2; s3_3 += a3 * b3;
+        }
+
+        workgroupBarrier();
+        t += 16u;
+    }
+
+    // Store: grad_kernel[co, ci*kH*kW + kh*kW + kw]
+    // Output layout: [Co, Ci, kH, kW] = [Co, Ci*kH*kW] row-major
+    let s = array<array<f32, 4>, 4>(
+        array<f32, 4>(s0_0, s0_1, s0_2, s0_3),
+        array<f32, 4>(s1_0, s1_1, s1_2, s1_3),
+        array<f32, 4>(s2_0, s2_1, s2_2, s2_3),
+        array<f32, 4>(s3_0, s3_1, s3_2, s3_3),
+    );
+    for (var i = 0u; i < 4u; i++) {
+        for (var j = 0u; j < 4u; j++) {
+            let co = tile_row + ty * 4u + i;
+            let cikk = tile_col + tx * 4u + j;
+            if co < m_total && cikk < n_total {
+                dst[co * n_total + cikk] = s[i][j];
+            }
+        }
+    }
+}

--- a/src/shaders/conv2d_grad_weight_gemm_small.wgsl
+++ b/src/shaders/conv2d_grad_weight_gemm_small.wgsl
@@ -1,0 +1,125 @@
+// Conv2d backward w.r.t. kernel via implicit GEMM — small-tile variant.
+// BM=32, BN=32, KTILE=16, TM=2, TN=2, workgroup [16,16,1]
+// 4× more workgroups than the 64×64 variant for better occupancy on small matrices.
+//
+// Dispatch: [ceil(Ci*kH*kW / 32), ceil(Co / 32), 1]
+
+struct Params {
+    batch: u32,
+    in_channels: u32,
+    in_h: u32,
+    in_w: u32,
+    out_channels: u32,
+    kernel_h: u32,
+    kernel_w: u32,
+    stride: u32,
+    padding: u32,
+    out_h: u32,
+    out_w: u32,
+    _pad: u32,
+}
+
+var<storage> grad_out: array<f32>;
+var<storage> src: array<f32>;
+var<storage, read_write> dst: array<f32>;
+var<uniform> params: Params;
+var<workgroup> shared_a: array<f32, 512>;  // 32 * 16
+var<workgroup> shared_b: array<f32, 512>;  // 16 * 32
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
+    let tx = lid.x;
+    let ty = lid.y;
+    let tile_row = wgid.y * 32u;   // M (Co) tile start
+    let tile_col = wgid.x * 32u;   // N (Ci*kH*kW) tile start
+    let tid = ty * 16u + tx;
+
+    let m_total = params.out_channels;
+    let kernel_hw = params.kernel_h * params.kernel_w;
+    let n_total = params.in_channels * kernel_hw;
+    let go_spatial = params.out_h * params.out_w;
+    let k_total = params.batch * go_spatial;
+    let input_spatial = params.in_h * params.in_w;
+
+    var s0_0 = 0.0; var s0_1 = 0.0;
+    var s1_0 = 0.0; var s1_1 = 0.0;
+
+    var t = 0u;
+    loop {
+        if t >= k_total { break; }
+
+        // Load A tile: grad_out_flat[Co, N*oH*oW] → shared_a[32, 16]
+        for (var e = 0u; e < 2u; e++) {
+            let flat = tid + e * 256u;
+            let row_local = flat / 16u;
+            let col_local = flat % 16u;
+            let co = tile_row + row_local;
+            let k_idx = t + col_local;
+
+            var val = 0.0;
+            if co < m_total && k_idx < k_total {
+                let n = k_idx / go_spatial;
+                let rem = k_idx - n * go_spatial;
+                let oh = rem / params.out_w;
+                let ow = rem - oh * params.out_w;
+                val = grad_out[((n * params.out_channels + co) * params.out_h + oh) * params.out_w + ow];
+            }
+            shared_a[row_local * 16u + col_local] = val;
+        }
+
+        // Load B tile: im2col(input)[N*oH*oW, Ci*kH*kW] → shared_b[16, 32]
+        for (var e = 0u; e < 2u; e++) {
+            let flat = tid + e * 256u;
+            let row_local = flat / 32u;
+            let col_local = flat % 32u;
+            let k_idx = t + row_local;
+            let col_idx = tile_col + col_local;
+
+            var val = 0.0;
+            if k_idx < k_total && col_idx < n_total {
+                let n = k_idx / go_spatial;
+                let rem = k_idx - n * go_spatial;
+                let oh = rem / params.out_w;
+                let ow = rem - oh * params.out_w;
+                let ci = col_idx / kernel_hw;
+                let k_rem = col_idx - ci * kernel_hw;
+                let kh = k_rem / params.kernel_w;
+                let kw = k_rem - kh * params.kernel_w;
+                let ih = i32(oh * params.stride + kh) - i32(params.padding);
+                let iw = i32(ow * params.stride + kw) - i32(params.padding);
+                if ih >= 0 && u32(ih) < params.in_h && iw >= 0 && u32(iw) < params.in_w {
+                    val = src[((n * params.in_channels + ci) * params.in_h + u32(ih)) * params.in_w + u32(iw)];
+                }
+            }
+            shared_b[row_local * 32u + col_local] = val;
+        }
+
+        workgroupBarrier();
+
+        for (var kk = 0u; kk < 16u; kk++) {
+            let a0 = shared_a[(ty * 2u + 0u) * 16u + kk];
+            let a1 = shared_a[(ty * 2u + 1u) * 16u + kk];
+            let b0 = shared_b[kk * 32u + tx * 2u + 0u];
+            let b1 = shared_b[kk * 32u + tx * 2u + 1u];
+            s0_0 += a0 * b0; s0_1 += a0 * b1;
+            s1_0 += a1 * b0; s1_1 += a1 * b1;
+        }
+
+        workgroupBarrier();
+        t += 16u;
+    }
+
+    let s = array<array<f32, 2>, 2>(
+        array<f32, 2>(s0_0, s0_1),
+        array<f32, 2>(s1_0, s1_1),
+    );
+    for (var i = 0u; i < 2u; i++) {
+        for (var j = 0u; j < 2u; j++) {
+            let co = tile_row + ty * 2u + i;
+            let cikk = tile_col + tx * 2u + j;
+            if co < m_total && cikk < n_total {
+                dst[co * n_total + cikk] = s[i][j];
+            }
+        }
+    }
+}

--- a/src/shaders/group_norm_silu.wgsl
+++ b/src/shaders/group_norm_silu.wgsl
@@ -1,0 +1,106 @@
+// Fused GroupNorm + SiLU forward: input[N, C, H, W] → output[N, C, H, W]
+// Same as group_norm.wgsl but applies SiLU(x) = x / (1 + exp(-x)) after normalization.
+// Eliminates one intermediate buffer read/write and one dispatch barrier.
+// Dispatch: [N * num_groups, 1, 1]  workgroup_size(256)
+
+struct Params {
+    batch: u32,
+    channels: u32,
+    spatial: u32,
+    num_groups: u32,
+    eps_bits: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+}
+
+var<storage> src: array<f32>;
+var<storage> src_b: array<f32>;     // weight[C]
+var<storage> bias: array<f32>;      // bias[C]
+var<storage, read_write> dst: array<f32>;
+var<uniform> params: Params;
+var<workgroup> wg_data: array<f32, 256>;
+
+@compute @workgroup_size(256)
+fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
+    let ng = wgid.x;
+    if ng >= params.batch * params.num_groups { return; }
+
+    let n = ng / params.num_groups;
+    let group = ng % params.num_groups;
+    let tid = lid.x;
+    let eps = bitcast<f32>(params.eps_bits);
+
+    let channels_per_group = params.channels / params.num_groups;
+    let group_size = channels_per_group * params.spatial;
+    let c_start = group * channels_per_group;
+
+    // Phase 1: compute mean
+    var sum_val = 0.0;
+    var j = tid;
+    loop {
+        if j >= group_size { break; }
+        let c_local = j / params.spatial;
+        let hw = j % params.spatial;
+        let c = c_start + c_local;
+        let idx = ((n * params.channels + c) * params.spatial) + hw;
+        sum_val += src[idx];
+        j += 256u;
+    }
+    wg_data[tid] = sum_val;
+    workgroupBarrier();
+
+    var stride = 128u;
+    loop {
+        if stride == 0u { break; }
+        if tid < stride {
+            wg_data[tid] += wg_data[tid + stride];
+        }
+        workgroupBarrier();
+        stride >>= 1u;
+    }
+    let mean = wg_data[0] / f32(group_size);
+    workgroupBarrier();
+
+    // Phase 2: compute variance
+    var var_val = 0.0;
+    j = tid;
+    loop {
+        if j >= group_size { break; }
+        let c_local = j / params.spatial;
+        let hw = j % params.spatial;
+        let c = c_start + c_local;
+        let idx = ((n * params.channels + c) * params.spatial) + hw;
+        let d = src[idx] - mean;
+        var_val += d * d;
+        j += 256u;
+    }
+    wg_data[tid] = var_val;
+    workgroupBarrier();
+
+    stride = 128u;
+    loop {
+        if stride == 0u { break; }
+        if tid < stride {
+            wg_data[tid] += wg_data[tid + stride];
+        }
+        workgroupBarrier();
+        stride >>= 1u;
+    }
+    let variance = wg_data[0] / f32(group_size);
+    let inv_std = inverseSqrt(variance + eps);
+
+    // Phase 3: normalize, scale, shift, then SiLU
+    j = tid;
+    loop {
+        if j >= group_size { break; }
+        let c_local = j / params.spatial;
+        let hw = j % params.spatial;
+        let c = c_start + c_local;
+        let idx = ((n * params.channels + c) * params.spatial) + hw;
+        let normalized = (src[idx] - mean) * inv_std;
+        let x = normalized * src_b[c] + bias[c];
+        dst[idx] = x / (1.0 + exp(-x));  // SiLU
+        j += 256u;
+    }
+}

--- a/src/shaders/matmul_coop.wgsl
+++ b/src/shaders/matmul_coop.wgsl
@@ -113,10 +113,10 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
         // Cooperative matrix multiply-add: C += A × B
         // shared_b{0,1} hold A-matrix row tiles; shared_a{0,1} hold B-matrix column tiles.
         // Load A data into role-A (left operand), B data into role-B (right operand).
-        let a0 = coopLoad<$COOP_AB>(&shared_b0[0], $TILE_SIZE_U);
-        let a1 = coopLoad<$COOP_AB>(&shared_b1[0], $TILE_SIZE_U);
-        let b0 = coopLoad<$COOP_BA>(&shared_a0[0], $TILE_SIZE_U);
-        let b1 = coopLoad<$COOP_BA>(&shared_a1[0], $TILE_SIZE_U);
+        let a0 = coopLoadT<$COOP_AB>(&shared_b0[0], $TILE_SIZE_U);
+        let a1 = coopLoadT<$COOP_AB>(&shared_b1[0], $TILE_SIZE_U);
+        let b0 = coopLoadT<$COOP_BA>(&shared_a0[0], $TILE_SIZE_U);
+        let b1 = coopLoadT<$COOP_BA>(&shared_a1[0], $TILE_SIZE_U);
         acc00 = coopMultiplyAdd(a0, b0, acc00);
         acc01 = coopMultiplyAdd(a0, b1, acc01);
         acc10 = coopMultiplyAdd(a1, b0, acc10);
@@ -127,14 +127,14 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
     }
 
     // Store results
-    coopStore(acc00, &matrix_c[c00], n);
+    coopStoreT(acc00, &matrix_c[c00], n);
     if n1_valid {
-        coopStore(acc01, &matrix_c[c01], n);
+        coopStoreT(acc01, &matrix_c[c01], n);
     }
     if m1_valid {
-        coopStore(acc10, &matrix_c[c10], n);
+        coopStoreT(acc10, &matrix_c[c10], n);
     }
     if n1_valid && m1_valid {
-        coopStore(acc11, &matrix_c[c11], n);
+        coopStoreT(acc11, &matrix_c[c11], n);
     }
 }

--- a/src/train.rs
+++ b/src/train.rs
@@ -231,8 +231,18 @@ pub fn build_inference_session(forward_graph: &Graph) -> Session {
 
     // Optimize with egglog (fusions still help for inference)
     log::info!("running egglog optimization...");
-    let optimized = optimize::optimize(forward_graph);
+    let mut optimized = optimize::optimize(forward_graph);
     log::info!("optimized graph: {} nodes", optimized.nodes().len());
+
+    // Inference-only fusions (no backward pass needed)
+    let mut inference_fusions = Vec::new();
+    optimize::apply_group_norm_silu_fusions(&mut optimized, &mut inference_fusions);
+    if !inference_fusions.is_empty() {
+        log::info!(
+            "inference fusions: {}x GroupNorm+Silu→GroupNormSilu",
+            inference_fusions.len()
+        );
+    }
 
     // Compile to execution plan
     log::info!("compiling execution plan...");

--- a/tests/gpu_smoke.rs
+++ b/tests/gpu_smoke.rs
@@ -1124,3 +1124,92 @@ fn conv2d_backward_smoke() {
         );
     }
 }
+
+/// Verify RoPE applies per-head rotation correctly (not global-dim rotation).
+/// With 2 heads of head_dim=4, the rotation pairs within each head should use
+/// exponents based on head_dim=4, NOT the full dim=8.
+#[test]
+fn rope_per_head_correctness() {
+    let seq = 2usize;
+    let num_heads = 2u32;
+    let head_dim = 4u32;
+    let dim = (num_heads * head_dim) as usize; // 8
+    let theta: f32 = 10000.0;
+
+    // Build graph: just RoPE
+    let mut g = Graph::new();
+    let x = g.input("x", &[seq, dim]);
+    let y = g.rope(x, theta, head_dim);
+    g.set_outputs(vec![y]);
+    let mut session = build_inference_session(&g);
+
+    // Input: all ones — makes it easy to verify rotation
+    let input = vec![1.0f32; seq * dim];
+    session.set_input("x", &input);
+    session.step();
+    session.wait();
+    let output = session.read_output(seq * dim);
+
+    // Compute expected values on CPU
+    let half_head = (head_dim / 2) as usize;
+    let mut expected = vec![0.0f32; seq * dim];
+    for row in 0..seq {
+        let pos = row as f32;
+        for head in 0..num_heads as usize {
+            for pair in 0..half_head {
+                let exponent = -2.0 * pair as f32 / head_dim as f32;
+                let inv_freq = theta.powf(exponent);
+                let angle = pos * inv_freq;
+                let cos_val = angle.cos();
+                let sin_val = angle.sin();
+
+                let base = row * dim + head * head_dim as usize;
+                let v0 = 1.0f32; // input value
+                let v1 = 1.0f32;
+                expected[base + pair] = v0 * cos_val - v1 * sin_val;
+                expected[base + pair + half_head] = v0 * sin_val + v1 * cos_val;
+            }
+        }
+    }
+
+    // Compare
+    let mut max_err: f32 = 0.0;
+    for i in 0..output.len() {
+        let err = (output[i] - expected[i]).abs();
+        if err > max_err {
+            max_err = err;
+        }
+        assert!(
+            err < 1e-4,
+            "rope[{}]: got={:.6}, expected={:.6}, err={:.2e}",
+            i,
+            output[i],
+            expected[i],
+            err
+        );
+    }
+    eprintln!("rope_per_head_correctness: max_err={max_err:.2e}");
+
+    // Verify position 0 is identity-like (cos(0)=1, sin(0)=0)
+    // For pos=0: output should equal input (rotation by 0)
+    for i in 0..dim {
+        assert!(
+            (output[i] - 1.0).abs() < 1e-5,
+            "pos=0 should be identity: output[{}]={:.6}",
+            i,
+            output[i]
+        );
+    }
+
+    // Verify position 1, head 0 pair 0 uses exponent -2*0/4 = 0 → angle = 1*1 = 1.0
+    // cos(1)≈0.5403, sin(1)≈0.8415
+    // output[dim+0] = 1*cos(1) - 1*sin(1) ≈ -0.3012
+    // output[dim+2] = 1*sin(1) + 1*cos(1) ≈ 1.3818
+    let pos1_h0_pair0 = output[dim]; // first element of pos=1
+    assert!(
+        (pos1_h0_pair0 - (1.0f32.cos() - 1.0f32.sin())).abs() < 1e-4,
+        "pos=1 head=0 pair=0 first: got={:.6}, expected={:.6}",
+        pos1_h0_pair0,
+        1.0f32.cos() - 1.0f32.sin()
+    );
+}


### PR DESCRIPTION
…test

Conv2dGradWeight GEMM: Reformulate weight gradient as standard matmul
  grad_weight[Co, Ci*kH*kW] = grad_out_flat[Co, N*oH*oW] @ im2col(input)
  Replaces naive per-element tree reduction (1 WG per output element,
  7 barriers each) with 64×64 tiled GEMM. SD U-Net tiny: 42ms→10ms
  for this op alone, overall 47ms→18ms/step (2.7× speedup).

Coop matrix fixes: coopLoad→coopLoadT, coopStore→coopStoreT in all
  cooperative matrix shaders to match naga 29's row-major convention.
  Fixes self-test failure on RADV/RDNA3.

Conv2dGradInput coop GEMM: New cooperative matrix variant for grad_input
  implicit GEMM (conv2d_grad_input_gemm_coop.wgsl). Runtime selects it
  when workgroup count exceeds threshold (512 for conv2d).

GPU profiling for SD benchmark: MEGANEURA_PROFILE=1 support via
  blade's 3-step timestamp dance.

RoPE per-head test: Verifies per-head rotation (head_dim=4, 2 heads)
  against CPU reference, catches the global-dim RoPE bug.