### PR TITLE
Add CI latency benchmark with regression detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,11 @@ jobs:
 
       - name: Vision ops smoke test
         run: cargo test --test vision_ops_smoke -- --skip vision_encoder_one_layer
+
+      - name: Latency benchmark
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p bench/results
+          cargo run --release --example bench_ci_latency > bench/results/ci_latency.json 2>/dev/null
+          cat bench/results/ci_latency.json
+          python3 bench/check_latency.py bench/results/ci_latency.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,9 @@ name = "onnx_compare"
 path = "examples/onnx_compare.rs"
 
 [[example]]
+name = "bench_ci_latency"
+path = "bench/bench_ci_latency.rs"
+
+[[example]]
 name = "grad_check"
 path = "bench/grad_check.rs"

--- a/bench/bench_ci_latency.rs
+++ b/bench/bench_ci_latency.rs
@@ -1,0 +1,152 @@
+/// CI latency benchmark: measures data upload + GPU processing + result download.
+///
+/// Runs a small MLP that exercises the full runtime path. Compilation
+/// happens before timing — only the hot loop (upload, dispatch, readback)
+/// is measured.
+///
+/// Usage:
+///   cargo run --release --example bench_ci_latency
+use std::time::Instant;
+
+use meganeura::{Graph, build_inference_session, build_session};
+
+fn main() {
+    env_logger::init();
+
+    let batch = 16;
+    let input_dim = 128;
+    let hidden = 64;
+    let classes = 10;
+
+    // ── Build & compile (not timed) ──
+
+    // Training graph (forward + backward + SGD)
+    let mut g = Graph::new();
+    let x = g.input("x", &[batch, input_dim]);
+    let labels = g.input("labels", &[batch, classes]);
+    let w1 = g.parameter("w1", &[input_dim, hidden]);
+    let b1 = g.parameter("b1", &[hidden]);
+    let h1 = g.matmul(x, w1);
+    let h1 = g.bias_add(h1, b1);
+    let h1 = g.relu(h1);
+    let w2 = g.parameter("w2", &[hidden, hidden]);
+    let b2 = g.parameter("b2", &[hidden]);
+    let h2 = g.matmul(h1, w2);
+    let h2 = g.bias_add(h2, b2);
+    let h2 = g.relu(h2);
+    let w3 = g.parameter("w3", &[hidden, classes]);
+    let out = g.matmul(h2, w3);
+    let loss = g.cross_entropy_loss(out, labels);
+    g.set_outputs(vec![loss]);
+    let mut train_session = build_session(&g);
+
+    // Inference graph (forward only, logits output)
+    let mut g_inf = Graph::new();
+    let xi = g_inf.input("x", &[batch, input_dim]);
+    let w1i = g_inf.parameter("w1", &[input_dim, hidden]);
+    let b1i = g_inf.parameter("b1", &[hidden]);
+    let h1i = g_inf.matmul(xi, w1i);
+    let h1i = g_inf.bias_add(h1i, b1i);
+    let h1i = g_inf.relu(h1i);
+    let w2i = g_inf.parameter("w2", &[hidden, hidden]);
+    let b2i = g_inf.parameter("b2", &[hidden]);
+    let h2i = g_inf.matmul(h1i, w2i);
+    let h2i = g_inf.bias_add(h2i, b2i);
+    let h2i = g_inf.relu(h2i);
+    let w3i = g_inf.parameter("w3", &[hidden, classes]);
+    let logits = g_inf.matmul(h2i, w3i);
+    g_inf.set_outputs(vec![logits]);
+    let mut inf_session = build_inference_session(&g_inf);
+
+    // Load weights (not timed)
+    let w1_data = vec![0.01_f32; input_dim * hidden];
+    let b1_data = vec![0.0_f32; hidden];
+    let w2_data = vec![0.01_f32; hidden * hidden];
+    let b2_data = vec![0.0_f32; hidden];
+    let w3_data = vec![0.01_f32; hidden * classes];
+    for s in [
+        &mut train_session as &mut meganeura::Session,
+        &mut inf_session,
+    ] {
+        s.set_parameter("w1", &w1_data);
+        s.set_parameter("b1", &b1_data);
+        s.set_parameter("w2", &w2_data);
+        s.set_parameter("b2", &b2_data);
+        s.set_parameter("w3", &w3_data);
+    }
+
+    let x_data: Vec<f32> = (0..batch * input_dim)
+        .map(|i| ((i * 7 + 13) % 256) as f32 / 255.0)
+        .collect();
+    let mut labels_data = vec![0.0_f32; batch * classes];
+    for b in 0..batch {
+        labels_data[b * classes + (b % classes)] = 1.0;
+    }
+
+    // ── Warmup (not timed) ──
+    let warmup = 3;
+    for _ in 0..warmup {
+        inf_session.set_input("x", &x_data);
+        inf_session.step();
+        inf_session.wait();
+        let _ = inf_session.read_output(batch * classes);
+    }
+    for _ in 0..warmup {
+        train_session.set_input("x", &x_data);
+        train_session.set_input("labels", &labels_data);
+        train_session.step();
+        train_session.wait();
+        let _ = train_session.read_loss();
+    }
+
+    // ── Timed: upload + dispatch + readback ──
+    let runs = 10;
+
+    // Forward (inference)
+    let mut fwd_times = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let t0 = Instant::now();
+        inf_session.set_input("x", &x_data);
+        inf_session.step();
+        inf_session.wait();
+        let _ = inf_session.read_output(batch * classes);
+        fwd_times.push(t0.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    // Training step (forward + backward + SGD)
+    let mut train_times = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let t0 = Instant::now();
+        train_session.set_input("x", &x_data);
+        train_session.set_input("labels", &labels_data);
+        train_session.step();
+        train_session.wait();
+        let _ = train_session.read_loss();
+        train_times.push(t0.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    // ── Statistics ──
+    let fwd_avg = fwd_times.iter().sum::<f64>() / runs as f64;
+    let fwd_med = median(&mut fwd_times);
+    let train_avg = train_times.iter().sum::<f64>() / runs as f64;
+    let train_med = median(&mut train_times);
+    let loss_val = train_session.read_loss();
+    assert!(loss_val.is_finite(), "loss not finite: {}", loss_val);
+
+    // ── JSON output ──
+    println!("{{");
+    println!("  \"benchmark\": \"ci_latency\",");
+    println!("  \"forward_avg_ms\": {:.2},", fwd_avg);
+    println!("  \"forward_median_ms\": {:.2},", fwd_med);
+    println!("  \"train_step_avg_ms\": {:.2},", train_avg);
+    println!("  \"train_step_median_ms\": {:.2},", train_med);
+    println!("  \"loss\": {:.6},", loss_val);
+    println!("  \"runs\": {},", runs);
+    println!("  \"warmup\": {}", warmup);
+    println!("}}");
+}
+
+fn median(v: &mut [f64]) -> f64 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v[v.len() / 2]
+}

--- a/bench/bench_ci_latency_pytorch.py
+++ b/bench/bench_ci_latency_pytorch.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""PyTorch reference for the CI latency benchmark.
+
+Same 3-layer MLP (128->64->10, batch=16) as bench_ci_latency.rs.
+Measures upload + forward + backward + readback latency.
+
+Usage:
+  python3 bench/bench_ci_latency_pytorch.py [--device cpu|cuda|mps]
+"""
+
+import argparse
+import json
+import time
+
+import torch
+import torch.nn as nn
+
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(128, 64)
+        self.fc2 = nn.Linear(64, 64)
+        self.fc3 = nn.Linear(64, 10, bias=False)
+
+    def forward(self, x):
+        x = torch.relu(self.fc1(x))
+        x = torch.relu(self.fc2(x))
+        return self.fc3(x)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--runs", type=int, default=10)
+    parser.add_argument("--warmup", type=int, default=3)
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    model = MLP().to(device).float()
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    batch = 16
+    x_data = torch.tensor(
+        [((i * 7 + 13) % 256) / 255.0 for i in range(batch * 128)],
+        dtype=torch.float32,
+    ).reshape(batch, 128)
+    labels = torch.tensor([i % 10 for i in range(batch)], dtype=torch.long)
+
+    # --- Warmup (forward) ---
+    model.eval()
+    with torch.no_grad():
+        for _ in range(args.warmup):
+            x = x_data.to(device)
+            out = model(x)
+            _ = out.cpu()
+
+    # --- Warmup (training) ---
+    model.train()
+    for _ in range(args.warmup):
+        x = x_data.to(device)
+        lab = labels.to(device)
+        optimizer.zero_grad()
+        out = model(x)
+        loss = criterion(out, lab)
+        loss.backward()
+        optimizer.step()
+        _ = loss.item()
+
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+
+    # --- Benchmark forward ---
+    model.eval()
+    fwd_times = []
+    with torch.no_grad():
+        for _ in range(args.runs):
+            t0 = time.perf_counter()
+            x = x_data.to(device)
+            out = model(x)
+            _ = out.cpu()
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            fwd_times.append((time.perf_counter() - t0) * 1000)
+
+    # --- Benchmark training ---
+    model.train()
+    train_times = []
+    for _ in range(args.runs):
+        t0 = time.perf_counter()
+        x = x_data.to(device)
+        lab = labels.to(device)
+        optimizer.zero_grad()
+        out = model(x)
+        loss = criterion(out, lab)
+        loss.backward()
+        optimizer.step()
+        loss_val = loss.item()
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        train_times.append((time.perf_counter() - t0) * 1000)
+
+    fwd_times.sort()
+    train_times.sort()
+    result = {
+        "benchmark": "ci_latency",
+        "framework": "pytorch",
+        "device": args.device,
+        "forward_avg_ms": round(sum(fwd_times) / len(fwd_times), 2),
+        "forward_median_ms": round(fwd_times[len(fwd_times) // 2], 2),
+        "train_step_avg_ms": round(sum(train_times) / len(train_times), 2),
+        "train_step_median_ms": round(train_times[len(train_times) // 2], 2),
+        "loss": round(loss_val, 6),
+        "runs": args.runs,
+        "warmup": args.warmup,
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/check_latency.py
+++ b/bench/check_latency.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Compare CI latency benchmark results against a baseline.
+
+Reads bench/ci_latency_baseline.json (checked in) and compares against
+a fresh run. Exits non-zero if any metric regresses beyond the threshold.
+
+Usage:
+  python3 bench/check_latency.py bench/results/ci_latency.json
+"""
+
+import json
+import os
+import sys
+
+BASELINE_PATH = os.path.join(os.path.dirname(__file__), "ci_latency_baseline.json")
+# Allow 20% regression before failing (lavapipe is noisy)
+THRESHOLD = 0.20
+
+METRICS = [
+    ("forward_median_ms", "Forward median"),
+    ("train_step_median_ms", "Train step median"),
+]
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <results.json>")
+        sys.exit(1)
+
+    results_path = sys.argv[1]
+
+    if not os.path.exists(BASELINE_PATH):
+        print(f"No baseline found at {BASELINE_PATH} — saving current results as baseline.")
+        with open(results_path) as f:
+            data = json.load(f)
+        with open(BASELINE_PATH, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        print("Baseline created. Re-run to compare.")
+        sys.exit(0)
+
+    with open(BASELINE_PATH) as f:
+        baseline = json.load(f)
+    with open(results_path) as f:
+        current = json.load(f)
+
+    print(f"{'Metric':<24} {'Baseline':>12} {'Current':>12} {'Change':>10} {'Status':>8}")
+    print("-" * 70)
+
+    regressions = []
+    for key, label in METRICS:
+        base_val = baseline.get(key)
+        curr_val = current.get(key)
+        if base_val is None or curr_val is None:
+            print(f"{label:<24} {'N/A':>12} {'N/A':>12} {'':>10} {'SKIP':>8}")
+            continue
+
+        if base_val > 0:
+            change = (curr_val - base_val) / base_val
+        else:
+            change = 0.0  # no baseline yet, skip regression check
+
+        status = "OK"
+        if base_val == 0:
+            status = "NEW"
+        elif change > THRESHOLD:
+            status = "REGRESS"
+            regressions.append((label, base_val, curr_val, change))
+        elif change < -THRESHOLD:
+            status = "FASTER"
+
+        print(
+            f"{label:<24} {base_val:>10.2f}ms {curr_val:>10.2f}ms "
+            f"{change:>+9.1%} {status:>8}"
+        )
+
+    print()
+    if regressions:
+        print(f"FAIL: {len(regressions)} metric(s) regressed beyond {THRESHOLD:.0%} threshold:")
+        for label, base, curr, change in regressions:
+            print(f"  {label}: {base:.2f}ms -> {curr:.2f}ms ({change:+.1%})")
+        sys.exit(1)
+    else:
+        print("PASS: no latency regressions detected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/ci_latency_baseline.json
+++ b/bench/ci_latency_baseline.json
@@ -1,0 +1,10 @@
+{
+  "benchmark": "ci_latency",
+  "forward_avg_ms": 3.15,
+  "forward_median_ms": 3.11,
+  "train_step_avg_ms": 6.83,
+  "train_step_median_ms": 6.62,
+  "loss": 2.302585,
+  "runs": 10,
+  "warmup": 3
+}


### PR DESCRIPTION
## Summary
- Add CI latency benchmark (`bench/<bench_ci_latency.rs>`): small MLP (128→64→10, batch=16) that measures upload + GPU dispatch + readback for both forward and training steps
- Add PyTorch reference (`bench/bench_ci_latency_pytorch.py`) for same-model comparison
- Add regression checker (`bench/check_latency.py`) that compares against `bench/ci_latency_baseline.json` and fails CI on >20% regression
- Add benchmark step to CI workflow (Linux/lavapipe only)

## Metrics tracked
- `forward_median_ms` — inference latency (upload + forward dispatch + readback)
- `train_step_median_ms` — training latency (upload + forward + backward + SGD + readback)

## Baseline (SwiftShader software Vulkan)
| Metric | Meganeura | PyTorch CPU |
|--------|-----------|-------------|
| Forward median | 3.11 ms | 0.04 ms |
| Train step median | 6.62 ms | 0.38 ms |

Gap is dispatch overhead on software Vulkan with a tiny model — real GPU benchmarks in README show meganeura ahead on Radeon 890M.

<https://claude.ai/code/session_015DBdSM2A3bhjpMMpvXpgi6>
