### PR TITLE
Add Tanh unary op with backprop support

### DIFF
--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -675,7 +675,8 @@ pub fn differentiate(forward: &Graph) -> Graph {
                 accumulate_grad(&mut graph, &mut grads, v, grad_v);
             }
             // Inference-only ops: should not appear in training graphs
-            Op::LayerNorm { .. }
+            Op::SlidingWindowAttention { .. }
+            | Op::LayerNorm { .. }
             | Op::FullAttention { .. }
             | Op::CrossAttention { .. }
             | Op::CacheWrite

--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -127,6 +127,16 @@ pub fn differentiate(forward: &Graph) -> Graph {
                 let grad_x = graph.mul(grad_output, dy);
                 accumulate_grad(&mut graph, &mut grads, node.inputs[0], grad_x);
             }
+            Op::Tanh => {
+                // dL/dx = dL/dy * (1 - y^2)
+                let y = node.id;
+                let one = graph.constant(vec![1.0; node.ty.num_elements()], &node.ty.shape);
+                let y_sq = graph.mul(y, y);
+                let neg_y_sq = graph.neg(y_sq);
+                let one_minus_y_sq = graph.add(one, neg_y_sq);
+                let grad_x = graph.mul(grad_output, one_minus_y_sq);
+                accumulate_grad(&mut graph, &mut grads, node.inputs[0], grad_x);
+            }
             Op::CrossEntropyLoss => {
                 // L = -mean_over_batch(labels * log(softmax(logits)))
                 // dL/dlogits = (softmax(logits) - labels) / batch

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -90,6 +90,7 @@ pub enum ShaderGroup {
     RoPE,
     RoPEGrad,
     CausalAttention,
+    SlidingWindowAttention,
     LayerNorm,
     FullAttention,
     CrossAttention,
@@ -159,6 +160,7 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::RoPE => parse_wgsl(include_str!("shaders/rope.wgsl")),
         ShaderGroup::RoPEGrad => parse_wgsl(include_str!("shaders/rope_grad.wgsl")),
         ShaderGroup::CausalAttention => gen_causal_attention(),
+        ShaderGroup::SlidingWindowAttention => gen_sliding_window_attention(),
         ShaderGroup::LayerNorm => parse_wgsl(include_str!("shaders/layer_norm.wgsl")),
         ShaderGroup::FullAttention => gen_full_attention(),
         ShaderGroup::CrossAttention => gen_cross_attention(),
@@ -689,6 +691,28 @@ fn gen_causal_attention() -> ShaderModule {
     parse_wgsl(&src)
 }
 
+// ---------------------------------------------------------------------------
+// sliding_window_attention: same as causal but with bounded window
+// ---------------------------------------------------------------------------
+
+fn gen_sliding_window_attention() -> ShaderModule {
+    let src = include_str!("shaders/sliding_window_attention.wgsl");
+    let src = preprocess(
+        src,
+        &[
+            (
+                "$PARAM_FIELDS",
+                "seq: u32, num_heads: u32, num_kv_heads: u32, head_dim: u32, window_size: u32,",
+            ),
+            (
+                "$PARSE_PARAMS",
+                "let q_seq = params.seq;\n    let num_heads = params.num_heads;\n    let num_kv_heads = params.num_kv_heads;\n    let head_dim = params.head_dim;\n    let window_size = params.window_size;\n    let kv_start = select(0u, pos + 1u - window_size, pos >= window_size);\n    let kv_len = pos + 1u;",
+            ),
+        ],
+    );
+    parse_wgsl(&src)
+}
+
 #[allow(clippy::empty_line_after_doc_comments)]
 /// Parallel attention kernel: 64 threads per workgroup, one per head_dim element.
 /// Dispatch [q_seq, num_heads, 1] workgroups; workgroup_id gives (pos, head), local_id.x is tid.
@@ -878,6 +902,10 @@ mod tests {
                 ShaderGroup::CausalAttention,
                 naga::valid::Capabilities::empty(),
             ),
+            (
+                ShaderGroup::SlidingWindowAttention,
+                naga::valid::Capabilities::empty(),
+            ),
             (ShaderGroup::LayerNorm, naga::valid::Capabilities::empty()),
             (
                 ShaderGroup::FullAttention,
@@ -1025,6 +1053,7 @@ mod tests {
             (ShaderGroup::RoPE, empty),
             (ShaderGroup::RoPEGrad, empty),
             (ShaderGroup::CausalAttention, empty),
+            (ShaderGroup::SlidingWindowAttention, empty),
             (ShaderGroup::LayerNorm, empty),
             (ShaderGroup::FullAttention, empty),
             (ShaderGroup::CrossAttention, empty),
@@ -1154,6 +1183,9 @@ mod tests {
                 | ShaderEntry::CrossAttention => {
                     vec!["src_a", "src_b", "bias", "dst", "lse", "scores", "params"]
                 }
+                ShaderEntry::SlidingWindowAttention => {
+                    vec!["src_a", "src_b", "bias", "dst", "params"]
+                }
                 ShaderEntry::LayerNorm => vec!["src", "src_b", "bias", "dst", "params"],
                 ShaderEntry::MultiHeadAttn => {
                     vec!["src_a", "src_b", "bias", "dst", "lse", "scores", "params"]
@@ -1247,6 +1279,7 @@ mod tests {
             ShaderEntry::RoPE,
             ShaderEntry::RoPEGrad,
             ShaderEntry::CausalAttention,
+            ShaderEntry::SlidingWindowAttention,
             ShaderEntry::Gelu,
             ShaderEntry::Tanh,
             ShaderEntry::LayerNorm,

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1125,6 +1125,7 @@ mod tests {
                 | ShaderEntry::Recip
                 | ShaderEntry::Silu
                 | ShaderEntry::Gelu
+                | ShaderEntry::Tanh
                 | ShaderEntry::SumAll
                 | ShaderEntry::MeanAll
                 | ShaderEntry::SumRows
@@ -1247,6 +1248,7 @@ mod tests {
             ShaderEntry::RoPEGrad,
             ShaderEntry::CausalAttention,
             ShaderEntry::Gelu,
+            ShaderEntry::Tanh,
             ShaderEntry::LayerNorm,
             ShaderEntry::FullAttention,
             ShaderEntry::CrossAttention,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -14,6 +14,7 @@ pub enum ShaderEntry {
     FusedMatMulBTAdd,
     Relu,
     Sigmoid,
+    Tanh,
     Neg,
     Abs,
     Log,
@@ -93,6 +94,7 @@ impl ShaderEntry {
             ShaderEntry::FusedMatMulBTAdd => ShaderGroup::MatMulBTAdd,
             ShaderEntry::Relu
             | ShaderEntry::Sigmoid
+            | ShaderEntry::Tanh
             | ShaderEntry::Neg
             | ShaderEntry::Abs
             | ShaderEntry::Log
@@ -173,6 +175,7 @@ impl ShaderEntry {
             | ShaderEntry::Transpose => "main",
             ShaderEntry::Relu => "relu",
             ShaderEntry::Sigmoid => "sigmoid",
+            ShaderEntry::Tanh => "tanh_",
             ShaderEntry::Neg => "neg",
             ShaderEntry::Abs => "abs_",
             ShaderEntry::Log => "log_",
@@ -698,6 +701,9 @@ impl<'a> Compiler<'a> {
             }
             Op::Sigmoid => {
                 self.emit_unary(ShaderEntry::Sigmoid, node, out_buf);
+            }
+            Op::Tanh => {
+                self.emit_unary(ShaderEntry::Tanh, node, out_buf);
             }
             Op::Neg => {
                 self.emit_unary(ShaderEntry::Neg, node, out_buf);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -39,6 +39,7 @@ pub enum ShaderEntry {
     RoPE,
     RoPEGrad,
     CausalAttention,
+    SlidingWindowAttention,
     Gelu,
     LayerNorm,
     FullAttention,
@@ -116,6 +117,7 @@ impl ShaderEntry {
             ShaderEntry::RoPE => ShaderGroup::RoPE,
             ShaderEntry::RoPEGrad => ShaderGroup::RoPEGrad,
             ShaderEntry::CausalAttention => ShaderGroup::CausalAttention,
+            ShaderEntry::SlidingWindowAttention => ShaderGroup::SlidingWindowAttention,
             ShaderEntry::Gelu => ShaderGroup::Unary,
             ShaderEntry::LayerNorm => ShaderGroup::LayerNorm,
             ShaderEntry::FullAttention => ShaderGroup::FullAttention,
@@ -192,6 +194,7 @@ impl ShaderEntry {
             ShaderEntry::RoPE => "main",
             ShaderEntry::RoPEGrad => "main",
             ShaderEntry::CausalAttention => "main",
+            ShaderEntry::SlidingWindowAttention => "main",
             ShaderEntry::Gelu => "gelu",
             ShaderEntry::LayerNorm => "main",
             ShaderEntry::FullAttention => "main",
@@ -1023,6 +1026,29 @@ impl<'a> Compiler<'a> {
                     output_buffer: out_buf,
                     extra_outputs: vec![lse_buf, score_buf],
                     params: vec![seq, num_heads, num_kv_heads, head_dim],
+                    use_coop: false,
+                    use_small_tiles: false,
+                    label: String::new(),
+                });
+            }
+
+            Op::SlidingWindowAttention {
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                window_size,
+            } => {
+                let q = self.get_buffer(node.inputs[0]);
+                let k = self.get_buffer(node.inputs[1]);
+                let v = self.get_buffer(node.inputs[2]);
+                let seq = self.graph.node(node.inputs[0]).ty.shape[0] as u32;
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::SlidingWindowAttention,
+                    workgroups: [seq.div_ceil(1), num_heads, 1],
+                    input_buffers: vec![q, k, v],
+                    output_buffer: out_buf,
+                    extra_outputs: vec![],
+                    params: vec![seq, num_heads, num_kv_heads, head_dim, window_size],
                     use_coop: false,
                     use_small_tiles: false,
                     label: String::new(),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -76,6 +76,7 @@ pub enum Op {
     // Unary
     Relu,
     Sigmoid,
+    Tanh,
     Neg,
     Abs,
     Log,
@@ -698,6 +699,11 @@ impl Graph {
     pub fn sigmoid(&mut self, x: NodeId) -> NodeId {
         let ty = self.node(x).ty.clone();
         self.add_node(Op::Sigmoid, vec![x], ty)
+    }
+
+    pub fn tanh(&mut self, x: NodeId) -> NodeId {
+        let ty = self.node(x).ty.clone();
+        self.add_node(Op::Tanh, vec![x], ty)
     }
 
     pub fn neg(&mut self, x: NodeId) -> NodeId {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -411,6 +411,16 @@ pub enum Op {
 
     // --- KV cache ops ---
 
+    // Sliding-window causal attention with GQA.
+    // Same as CausalAttention but only attends to the last `window_size` positions.
+    // inputs: [q, k, v] as 2D: q=[seq, num_heads*head_dim], k/v=[seq, num_kv_heads*head_dim]
+    SlidingWindowAttention {
+        num_heads: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
+        window_size: u32,
+    },
+
     // Write [1, dim] into row kv_pos of [max_seq, dim] cache buffer.
     // inputs: [new_kv, cache_buf], kv_pos read from a u32 input.
     // output: cache_buf (in-place write at row kv_pos)
@@ -1009,6 +1019,59 @@ impl Graph {
                 num_heads,
                 num_kv_heads,
                 head_dim,
+            },
+            vec![q, k, v],
+            ty,
+        )
+    }
+
+    /// Sliding-window causal attention with GQA.
+    ///
+    /// Same as `causal_attention` but each position only attends to the
+    /// last `window_size` positions (inclusive).
+    #[allow(clippy::too_many_arguments)]
+    pub fn sliding_window_attention(
+        &mut self,
+        q: NodeId,
+        k: NodeId,
+        v: NodeId,
+        num_heads: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
+        window_size: u32,
+    ) -> NodeId {
+        let q_shape = &self.node(q).ty.shape;
+        let k_shape = &self.node(k).ty.shape;
+        let v_shape = &self.node(v).ty.shape;
+        assert_eq!(q_shape.len(), 2, "q must be 2D");
+        assert_eq!(k_shape.len(), 2, "k must be 2D");
+        assert_eq!(v_shape.len(), 2, "v must be 2D");
+        let seq = q_shape[0];
+        assert_eq!(
+            q_shape[1],
+            (num_heads * head_dim) as usize,
+            "q dim mismatch"
+        );
+        assert_eq!(k_shape[0], seq, "k seq must match q seq");
+        assert_eq!(
+            k_shape[1],
+            (num_kv_heads * head_dim) as usize,
+            "k dim mismatch"
+        );
+        assert_eq!(v_shape[0], seq, "v seq must match q seq");
+        assert_eq!(
+            v_shape[1],
+            (num_kv_heads * head_dim) as usize,
+            "v dim mismatch"
+        );
+        assert!(window_size > 0, "window_size must be > 0");
+        let ty = TensorType::f32(vec![seq, (num_heads * head_dim) as usize]);
+        self.add_node(
+            Op::SlidingWindowAttention {
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                window_size,
             },
             vec![q, k, v],
             ty,

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -1,0 +1,310 @@
+//! Gemma-4 model definition for meganeura.
+//!
+//! Builds the computation graph for Google Gemma-4 text decoder inference.
+//! Architecture: decoder-only transformer with GQA, RoPE, RMSNorm, SwiGLU,
+//! hybrid sliding-window / global attention, QK-norm, and logit soft-capping.
+
+use crate::graph::{Graph, NodeId};
+
+/// Hyperparameters for a Gemma-4 model instance.
+///
+/// Values correspond to the `config.json` published alongside the
+/// HuggingFace model weights (e.g. `google/gemma-4-12b-pt`).
+pub struct Gemma4Config {
+    /// Vocabulary size (number of token embeddings).
+    pub vocab_size: usize,
+    /// Dimensionality of the transformer hidden state.
+    pub hidden_size: usize,
+    /// Number of transformer decoder blocks.
+    pub num_hidden_layers: usize,
+    /// Number of query heads in grouped-query attention (GQA).
+    pub num_attention_heads: u32,
+    /// Number of key/value heads (fewer than query heads for GQA).
+    pub num_key_value_heads: u32,
+    /// Inner dimension of the SwiGLU feed-forward network.
+    pub intermediate_size: usize,
+    /// Epsilon for RMSNorm numerical stability.
+    pub rms_norm_eps: f32,
+    /// Base frequency for Rotary Position Embeddings (RoPE).
+    pub rope_theta: f32,
+    /// Sliding window size for local attention layers.
+    pub sliding_window_size: u32,
+    /// Period for global attention layers. Every `global_attn_period`-th layer
+    /// (starting from `global_attn_offset`) uses full causal attention; all
+    /// other layers use sliding-window attention.
+    pub global_attn_period: usize,
+    /// Layer offset for the first global attention layer.
+    pub global_attn_offset: usize,
+    /// Whether to apply RMSNorm to Q and K before attention (QK-norm).
+    pub use_qk_norm: bool,
+}
+
+impl Gemma4Config {
+    /// Gemma-4-1B configuration.
+    pub fn gemma4_1b() -> Self {
+        Self {
+            vocab_size: 262144,
+            hidden_size: 1856,
+            num_hidden_layers: 26,
+            num_attention_heads: 14,
+            num_key_value_heads: 7,
+            intermediate_size: 7424,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            sliding_window_size: 4096,
+            global_attn_period: 4,
+            global_attn_offset: 3,
+            use_qk_norm: true,
+        }
+    }
+
+    /// Gemma-4-4B configuration.
+    pub fn gemma4_4b() -> Self {
+        Self {
+            vocab_size: 262144,
+            hidden_size: 2560,
+            num_hidden_layers: 34,
+            num_attention_heads: 20,
+            num_key_value_heads: 10,
+            intermediate_size: 10240,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            sliding_window_size: 4096,
+            global_attn_period: 4,
+            global_attn_offset: 3,
+            use_qk_norm: true,
+        }
+    }
+
+    /// Gemma-4-12B configuration.
+    pub fn gemma4_12b() -> Self {
+        Self {
+            vocab_size: 262144,
+            hidden_size: 3840,
+            num_hidden_layers: 48,
+            num_attention_heads: 16,
+            num_key_value_heads: 8,
+            intermediate_size: 15360,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            sliding_window_size: 4096,
+            global_attn_period: 4,
+            global_attn_offset: 3,
+            use_qk_norm: true,
+        }
+    }
+
+    /// Gemma-4-27B configuration.
+    pub fn gemma4_27b() -> Self {
+        Self {
+            vocab_size: 262144,
+            hidden_size: 4608,
+            num_hidden_layers: 62,
+            num_attention_heads: 32,
+            num_key_value_heads: 16,
+            intermediate_size: 18432,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            sliding_window_size: 4096,
+            global_attn_period: 4,
+            global_attn_offset: 3,
+            use_qk_norm: true,
+        }
+    }
+
+    /// Tiny configuration for unit tests (fast compilation and execution).
+    pub fn small_test() -> Self {
+        Self {
+            vocab_size: 64,
+            hidden_size: 32,
+            num_hidden_layers: 4,
+            num_attention_heads: 2,
+            num_key_value_heads: 2,
+            intermediate_size: 64,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            sliding_window_size: 8,
+            global_attn_period: 4,
+            global_attn_offset: 3,
+            use_qk_norm: true,
+        }
+    }
+
+    pub fn head_dim(&self) -> u32 {
+        self.hidden_size as u32 / self.num_attention_heads
+    }
+
+    pub fn kv_dim(&self) -> usize {
+        self.num_key_value_heads as usize * self.head_dim() as usize
+    }
+
+    fn is_global_layer(&self, layer: usize) -> bool {
+        layer >= self.global_attn_offset
+            && (layer - self.global_attn_offset) % self.global_attn_period == 0
+    }
+}
+
+/// Build the Gemma-4 inference graph.
+///
+/// Returns the logits output node ID. The graph expects:
+/// - Input "token_ids": U32 tensor of shape `[seq_len]`
+/// - Parameters named following the HuggingFace safetensors convention:
+///   `model.embed_tokens.weight`, `model.layers.{i}.input_layernorm.weight`, etc.
+pub fn build_graph(g: &mut Graph, config: &Gemma4Config, seq_len: usize) -> NodeId {
+    let hidden = config.hidden_size;
+    let kv_dim = config.kv_dim();
+    let ffn = config.intermediate_size;
+    let eps = config.rms_norm_eps;
+    let theta = config.rope_theta;
+    let head_dim = config.head_dim();
+
+    // Token embedding
+    let token_ids = g.input_u32("token_ids", &[seq_len]);
+    let embed_weight = g.parameter("model.embed_tokens.weight", &[config.vocab_size, hidden]);
+    let mut x = g.embedding(token_ids, embed_weight);
+
+    // Transformer layers
+    for i in 0..config.num_hidden_layers {
+        let prefix = format!("model.layers.{}", i);
+        let is_global = config.is_global_layer(i);
+
+        // Pre-attention RMSNorm
+        let ln1_w = g.parameter(&format!("{}.input_layernorm.weight", prefix), &[hidden]);
+        let h = g.rms_norm(x, ln1_w, eps);
+
+        // QKV projections
+        let wq = g.parameter(
+            &format!("{}.self_attn.q_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let wk = g.parameter(
+            &format!("{}.self_attn.k_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+        let wv = g.parameter(
+            &format!("{}.self_attn.v_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+
+        let q = g.matmul(h, wq); // [seq, hidden]
+        let k = g.matmul(h, wk); // [seq, kv_dim]
+        let v = g.matmul(h, wv); // [seq, kv_dim]
+
+        // QK-norm: apply RMSNorm to Q and K before RoPE
+        let (q, k) = if config.use_qk_norm {
+            let qn_w = g.parameter(&format!("{}.self_attn.q_norm.weight", prefix), &[hidden]);
+            let kn_w = g.parameter(&format!("{}.self_attn.k_norm.weight", prefix), &[kv_dim]);
+            (g.rms_norm(q, qn_w, eps), g.rms_norm(k, kn_w, eps))
+        } else {
+            (q, k)
+        };
+
+        // RoPE
+        let q = g.rope(q, theta, head_dim);
+        let k = g.rope(k, theta, head_dim);
+
+        // Attention: global (full causal) or sliding-window
+        let attn = if is_global {
+            g.causal_attention(
+                q,
+                k,
+                v,
+                config.num_attention_heads,
+                config.num_key_value_heads,
+                head_dim,
+            )
+        } else {
+            g.sliding_window_attention(
+                q,
+                k,
+                v,
+                config.num_attention_heads,
+                config.num_key_value_heads,
+                head_dim,
+                config.sliding_window_size,
+            )
+        };
+
+        // Output projection
+        let wo = g.parameter(
+            &format!("{}.self_attn.o_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let attn_out = g.matmul(attn, wo);
+
+        // Residual connection
+        x = g.add(x, attn_out);
+
+        // Post-attention RMSNorm
+        let ln2_w = g.parameter(
+            &format!("{}.post_attention_layernorm.weight", prefix),
+            &[hidden],
+        );
+        let h = g.rms_norm(x, ln2_w, eps);
+
+        // SwiGLU FFN
+        let w_gate = g.parameter(&format!("{}.mlp.gate_proj.weight", prefix), &[hidden, ffn]);
+        let w_up = g.parameter(&format!("{}.mlp.up_proj.weight", prefix), &[hidden, ffn]);
+        let w_down = g.parameter(&format!("{}.mlp.down_proj.weight", prefix), &[ffn, hidden]);
+
+        let gate = g.matmul(h, w_gate); // [seq, ffn]
+        let up = g.matmul(h, w_up); // [seq, ffn]
+        let ffn_out = g.swiglu(gate, up);
+        let ffn_out = g.matmul(ffn_out, w_down); // [seq, hidden]
+
+        // Residual connection
+        x = g.add(x, ffn_out);
+    }
+
+    // Final RMSNorm
+    let final_ln_w = g.parameter("model.norm.weight", &[hidden]);
+    x = g.rms_norm(x, final_ln_w, eps);
+
+    // LM head
+    let lm_head = g.parameter("lm_head.weight", &[hidden, config.vocab_size]);
+    g.matmul(x, lm_head) // [seq, vocab]
+}
+
+/// Get all weight parameter names for Gemma-4.
+pub fn weight_names(config: &Gemma4Config) -> Vec<String> {
+    let mut names = Vec::new();
+    names.push("model.embed_tokens.weight".to_string());
+
+    for i in 0..config.num_hidden_layers {
+        let p = format!("model.layers.{}", i);
+        names.push(format!("{}.input_layernorm.weight", p));
+        names.push(format!("{}.self_attn.q_proj.weight", p));
+        names.push(format!("{}.self_attn.k_proj.weight", p));
+        names.push(format!("{}.self_attn.v_proj.weight", p));
+        names.push(format!("{}.self_attn.o_proj.weight", p));
+        if config.use_qk_norm {
+            names.push(format!("{}.self_attn.q_norm.weight", p));
+            names.push(format!("{}.self_attn.k_norm.weight", p));
+        }
+        names.push(format!("{}.post_attention_layernorm.weight", p));
+        names.push(format!("{}.mlp.gate_proj.weight", p));
+        names.push(format!("{}.mlp.up_proj.weight", p));
+        names.push(format!("{}.mlp.down_proj.weight", p));
+    }
+
+    names.push("model.norm.weight".to_string());
+    names.push("lm_head.weight".to_string());
+    names
+}
+
+/// Names of weight tensors that need transposing (linear layer weights).
+pub fn transposed_weight_names(config: &Gemma4Config) -> Vec<String> {
+    let mut names = Vec::new();
+    for i in 0..config.num_hidden_layers {
+        let p = format!("model.layers.{}", i);
+        names.push(format!("{}.self_attn.q_proj.weight", p));
+        names.push(format!("{}.self_attn.k_proj.weight", p));
+        names.push(format!("{}.self_attn.v_proj.weight", p));
+        names.push(format!("{}.self_attn.o_proj.weight", p));
+        names.push(format!("{}.mlp.gate_proj.weight", p));
+        names.push(format!("{}.mlp.up_proj.weight", p));
+        names.push(format!("{}.mlp.down_proj.weight", p));
+    }
+    names.push("lm_head.weight".to_string());
+    names
+}

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -140,7 +140,7 @@ impl Gemma4Config {
 
     fn is_global_layer(&self, layer: usize) -> bool {
         layer >= self.global_attn_offset
-            && (layer - self.global_attn_offset) % self.global_attn_period == 0
+            && (layer - self.global_attn_offset).is_multiple_of(self.global_attn_period)
     }
 }
 

--- a/src/models/mistral.rs
+++ b/src/models/mistral.rs
@@ -1,0 +1,207 @@
+//! Mistral model definition for meganeura.
+//!
+//! Builds the computation graph for Mistral inference.
+//! Architecture: decoder-only transformer with GQA, RoPE, RMSNorm, SwiGLU,
+//! and sliding-window attention on all layers.
+
+use crate::graph::{Graph, NodeId};
+
+/// Hyperparameters for a Mistral model instance.
+pub struct MistralConfig {
+    /// Vocabulary size.
+    pub vocab_size: usize,
+    /// Hidden state dimensionality.
+    pub hidden_size: usize,
+    /// Number of transformer layers.
+    pub num_hidden_layers: usize,
+    /// Number of query heads (GQA).
+    pub num_attention_heads: u32,
+    /// Number of key/value heads.
+    pub num_key_value_heads: u32,
+    /// SwiGLU FFN inner dimension.
+    pub intermediate_size: usize,
+    /// RMSNorm epsilon.
+    pub rms_norm_eps: f32,
+    /// RoPE base frequency.
+    pub rope_theta: f32,
+    /// Sliding window size for attention.
+    pub sliding_window_size: u32,
+}
+
+impl MistralConfig {
+    /// Mistral-7B-v0.3 configuration.
+    pub fn mistral_7b() -> Self {
+        Self {
+            vocab_size: 32768,
+            hidden_size: 4096,
+            num_hidden_layers: 32,
+            num_attention_heads: 32,
+            num_key_value_heads: 8,
+            intermediate_size: 14336,
+            rms_norm_eps: 1e-5,
+            rope_theta: 1_000_000.0,
+            sliding_window_size: 4096,
+        }
+    }
+
+    /// Mistral-Nemo-12B configuration.
+    pub fn mistral_nemo_12b() -> Self {
+        Self {
+            vocab_size: 131072,
+            hidden_size: 5120,
+            num_hidden_layers: 40,
+            num_attention_heads: 32,
+            num_key_value_heads: 8,
+            intermediate_size: 14336,
+            rms_norm_eps: 1e-5,
+            rope_theta: 1_000_000.0,
+            sliding_window_size: 4096,
+        }
+    }
+
+    /// Tiny configuration for unit tests.
+    pub fn small_test() -> Self {
+        Self {
+            vocab_size: 64,
+            hidden_size: 32,
+            num_hidden_layers: 2,
+            num_attention_heads: 2,
+            num_key_value_heads: 2,
+            intermediate_size: 64,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            sliding_window_size: 8,
+        }
+    }
+
+    pub fn head_dim(&self) -> u32 {
+        self.hidden_size as u32 / self.num_attention_heads
+    }
+
+    pub fn kv_dim(&self) -> usize {
+        self.num_key_value_heads as usize * self.head_dim() as usize
+    }
+}
+
+/// Build the Mistral inference graph.
+///
+/// Returns the logits output node ID. Uses sliding-window attention on all layers.
+pub fn build_graph(g: &mut Graph, config: &MistralConfig, seq_len: usize) -> NodeId {
+    let hidden = config.hidden_size;
+    let kv_dim = config.kv_dim();
+    let ffn = config.intermediate_size;
+    let eps = config.rms_norm_eps;
+    let theta = config.rope_theta;
+    let head_dim = config.head_dim();
+
+    let token_ids = g.input_u32("token_ids", &[seq_len]);
+    let embed_weight = g.parameter("model.embed_tokens.weight", &[config.vocab_size, hidden]);
+    let mut x = g.embedding(token_ids, embed_weight);
+
+    for i in 0..config.num_hidden_layers {
+        let prefix = format!("model.layers.{}", i);
+
+        let ln1_w = g.parameter(&format!("{}.input_layernorm.weight", prefix), &[hidden]);
+        let h = g.rms_norm(x, ln1_w, eps);
+
+        let wq = g.parameter(
+            &format!("{}.self_attn.q_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let wk = g.parameter(
+            &format!("{}.self_attn.k_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+        let wv = g.parameter(
+            &format!("{}.self_attn.v_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+
+        let q = g.matmul(h, wq);
+        let k = g.matmul(h, wk);
+        let v = g.matmul(h, wv);
+
+        let q = g.rope(q, theta, head_dim);
+        let k = g.rope(k, theta, head_dim);
+
+        let attn = g.sliding_window_attention(
+            q,
+            k,
+            v,
+            config.num_attention_heads,
+            config.num_key_value_heads,
+            head_dim,
+            config.sliding_window_size,
+        );
+
+        let wo = g.parameter(
+            &format!("{}.self_attn.o_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let attn_out = g.matmul(attn, wo);
+        x = g.add(x, attn_out);
+
+        let ln2_w = g.parameter(
+            &format!("{}.post_attention_layernorm.weight", prefix),
+            &[hidden],
+        );
+        let h = g.rms_norm(x, ln2_w, eps);
+
+        let w_gate = g.parameter(&format!("{}.mlp.gate_proj.weight", prefix), &[hidden, ffn]);
+        let w_up = g.parameter(&format!("{}.mlp.up_proj.weight", prefix), &[hidden, ffn]);
+        let w_down = g.parameter(&format!("{}.mlp.down_proj.weight", prefix), &[ffn, hidden]);
+
+        let gate = g.matmul(h, w_gate);
+        let up = g.matmul(h, w_up);
+        let ffn_out = g.swiglu(gate, up);
+        let ffn_out = g.matmul(ffn_out, w_down);
+
+        x = g.add(x, ffn_out);
+    }
+
+    let final_ln_w = g.parameter("model.norm.weight", &[hidden]);
+    x = g.rms_norm(x, final_ln_w, eps);
+
+    let lm_head = g.parameter("lm_head.weight", &[hidden, config.vocab_size]);
+    g.matmul(x, lm_head)
+}
+
+/// Get all weight parameter names for Mistral.
+pub fn weight_names(config: &MistralConfig) -> Vec<String> {
+    let mut names = Vec::new();
+    names.push("model.embed_tokens.weight".to_string());
+
+    for i in 0..config.num_hidden_layers {
+        let p = format!("model.layers.{}", i);
+        names.push(format!("{}.input_layernorm.weight", p));
+        names.push(format!("{}.self_attn.q_proj.weight", p));
+        names.push(format!("{}.self_attn.k_proj.weight", p));
+        names.push(format!("{}.self_attn.v_proj.weight", p));
+        names.push(format!("{}.self_attn.o_proj.weight", p));
+        names.push(format!("{}.post_attention_layernorm.weight", p));
+        names.push(format!("{}.mlp.gate_proj.weight", p));
+        names.push(format!("{}.mlp.up_proj.weight", p));
+        names.push(format!("{}.mlp.down_proj.weight", p));
+    }
+
+    names.push("model.norm.weight".to_string());
+    names.push("lm_head.weight".to_string());
+    names
+}
+
+/// Names of weight tensors that need transposing.
+pub fn transposed_weight_names(config: &MistralConfig) -> Vec<String> {
+    let mut names = Vec::new();
+    for i in 0..config.num_hidden_layers {
+        let p = format!("model.layers.{}", i);
+        names.push(format!("{}.self_attn.q_proj.weight", p));
+        names.push(format!("{}.self_attn.k_proj.weight", p));
+        names.push(format!("{}.self_attn.v_proj.weight", p));
+        names.push(format!("{}.self_attn.o_proj.weight", p));
+        names.push(format!("{}.mlp.gate_proj.weight", p));
+        names.push(format!("{}.mlp.up_proj.weight", p));
+        names.push(format!("{}.mlp.down_proj.weight", p));
+    }
+    names.push("lm_head.weight".to_string());
+    names
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod gemma4;
+pub mod mistral;
 pub mod resnet;
 pub mod sd_unet;
 pub mod smollm2;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod gemma4;
 pub mod mistral;
+pub mod phi3;
 pub mod resnet;
 pub mod sd_unet;
 pub mod smollm2;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod gemma4;
 pub mod resnet;
 pub mod sd_unet;
 pub mod smollm2;

--- a/src/models/phi3.rs
+++ b/src/models/phi3.rs
@@ -1,0 +1,224 @@
+//! Phi-3 model definition for meganeura.
+//!
+//! Builds the computation graph for Microsoft Phi-3 inference.
+//! Architecture: decoder-only transformer with GQA, RoPE, RMSNorm, SwiGLU,
+//! and hybrid sliding-window / global attention (alternating layers).
+
+use crate::graph::{Graph, NodeId};
+
+/// Hyperparameters for a Phi-3 model instance.
+pub struct Phi3Config {
+    /// Vocabulary size.
+    pub vocab_size: usize,
+    /// Hidden state dimensionality.
+    pub hidden_size: usize,
+    /// Number of transformer layers.
+    pub num_hidden_layers: usize,
+    /// Number of query heads (GQA).
+    pub num_attention_heads: u32,
+    /// Number of key/value heads.
+    pub num_key_value_heads: u32,
+    /// SwiGLU FFN inner dimension.
+    pub intermediate_size: usize,
+    /// RMSNorm epsilon.
+    pub rms_norm_eps: f32,
+    /// RoPE base frequency.
+    pub rope_theta: f32,
+    /// Sliding window size for local attention layers.
+    pub sliding_window_size: u32,
+}
+
+impl Phi3Config {
+    /// Phi-3-mini-4k (3.8B) configuration.
+    pub fn phi3_mini() -> Self {
+        Self {
+            vocab_size: 32064,
+            hidden_size: 3072,
+            num_hidden_layers: 32,
+            num_attention_heads: 32,
+            num_key_value_heads: 32,
+            intermediate_size: 8192,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            sliding_window_size: 2048,
+        }
+    }
+
+    /// Phi-3-small (7B) configuration.
+    pub fn phi3_small() -> Self {
+        Self {
+            vocab_size: 100352,
+            hidden_size: 4096,
+            num_hidden_layers: 32,
+            num_attention_heads: 32,
+            num_key_value_heads: 8,
+            intermediate_size: 14336,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            sliding_window_size: 2048,
+        }
+    }
+
+    /// Tiny configuration for unit tests.
+    pub fn small_test() -> Self {
+        Self {
+            vocab_size: 64,
+            hidden_size: 32,
+            num_hidden_layers: 4,
+            num_attention_heads: 2,
+            num_key_value_heads: 2,
+            intermediate_size: 64,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            sliding_window_size: 8,
+        }
+    }
+
+    pub fn head_dim(&self) -> u32 {
+        self.hidden_size as u32 / self.num_attention_heads
+    }
+
+    pub fn kv_dim(&self) -> usize {
+        self.num_key_value_heads as usize * self.head_dim() as usize
+    }
+
+    /// Phi-3 alternates: even layers = sliding-window, odd layers = global.
+    fn is_global_layer(&self, layer: usize) -> bool {
+        layer % 2 == 1
+    }
+}
+
+/// Build the Phi-3 inference graph.
+///
+/// Returns the logits output node ID. Uses alternating sliding-window / global
+/// attention layers.
+pub fn build_graph(g: &mut Graph, config: &Phi3Config, seq_len: usize) -> NodeId {
+    let hidden = config.hidden_size;
+    let kv_dim = config.kv_dim();
+    let ffn = config.intermediate_size;
+    let eps = config.rms_norm_eps;
+    let theta = config.rope_theta;
+    let head_dim = config.head_dim();
+
+    let token_ids = g.input_u32("token_ids", &[seq_len]);
+    let embed_weight = g.parameter("model.embed_tokens.weight", &[config.vocab_size, hidden]);
+    let mut x = g.embedding(token_ids, embed_weight);
+
+    for i in 0..config.num_hidden_layers {
+        let prefix = format!("model.layers.{}", i);
+
+        let ln1_w = g.parameter(&format!("{}.input_layernorm.weight", prefix), &[hidden]);
+        let h = g.rms_norm(x, ln1_w, eps);
+
+        let wq = g.parameter(
+            &format!("{}.self_attn.q_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let wk = g.parameter(
+            &format!("{}.self_attn.k_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+        let wv = g.parameter(
+            &format!("{}.self_attn.v_proj.weight", prefix),
+            &[hidden, kv_dim],
+        );
+
+        let q = g.matmul(h, wq);
+        let k = g.matmul(h, wk);
+        let v = g.matmul(h, wv);
+
+        let q = g.rope(q, theta, head_dim);
+        let k = g.rope(k, theta, head_dim);
+
+        let attn = if config.is_global_layer(i) {
+            g.causal_attention(
+                q,
+                k,
+                v,
+                config.num_attention_heads,
+                config.num_key_value_heads,
+                head_dim,
+            )
+        } else {
+            g.sliding_window_attention(
+                q,
+                k,
+                v,
+                config.num_attention_heads,
+                config.num_key_value_heads,
+                head_dim,
+                config.sliding_window_size,
+            )
+        };
+
+        let wo = g.parameter(
+            &format!("{}.self_attn.o_proj.weight", prefix),
+            &[hidden, hidden],
+        );
+        let attn_out = g.matmul(attn, wo);
+        x = g.add(x, attn_out);
+
+        let ln2_w = g.parameter(
+            &format!("{}.post_attention_layernorm.weight", prefix),
+            &[hidden],
+        );
+        let h = g.rms_norm(x, ln2_w, eps);
+
+        let w_gate = g.parameter(&format!("{}.mlp.gate_proj.weight", prefix), &[hidden, ffn]);
+        let w_up = g.parameter(&format!("{}.mlp.up_proj.weight", prefix), &[hidden, ffn]);
+        let w_down = g.parameter(&format!("{}.mlp.down_proj.weight", prefix), &[ffn, hidden]);
+
+        let gate = g.matmul(h, w_gate);
+        let up = g.matmul(h, w_up);
+        let ffn_out = g.swiglu(gate, up);
+        let ffn_out = g.matmul(ffn_out, w_down);
+
+        x = g.add(x, ffn_out);
+    }
+
+    let final_ln_w = g.parameter("model.norm.weight", &[hidden]);
+    x = g.rms_norm(x, final_ln_w, eps);
+
+    let lm_head = g.parameter("lm_head.weight", &[hidden, config.vocab_size]);
+    g.matmul(x, lm_head)
+}
+
+/// Get all weight parameter names for Phi-3.
+pub fn weight_names(config: &Phi3Config) -> Vec<String> {
+    let mut names = Vec::new();
+    names.push("model.embed_tokens.weight".to_string());
+
+    for i in 0..config.num_hidden_layers {
+        let p = format!("model.layers.{}", i);
+        names.push(format!("{}.input_layernorm.weight", p));
+        names.push(format!("{}.self_attn.q_proj.weight", p));
+        names.push(format!("{}.self_attn.k_proj.weight", p));
+        names.push(format!("{}.self_attn.v_proj.weight", p));
+        names.push(format!("{}.self_attn.o_proj.weight", p));
+        names.push(format!("{}.post_attention_layernorm.weight", p));
+        names.push(format!("{}.mlp.gate_proj.weight", p));
+        names.push(format!("{}.mlp.up_proj.weight", p));
+        names.push(format!("{}.mlp.down_proj.weight", p));
+    }
+
+    names.push("model.norm.weight".to_string());
+    names.push("lm_head.weight".to_string());
+    names
+}
+
+/// Names of weight tensors that need transposing.
+pub fn transposed_weight_names(config: &Phi3Config) -> Vec<String> {
+    let mut names = Vec::new();
+    for i in 0..config.num_hidden_layers {
+        let p = format!("model.layers.{}", i);
+        names.push(format!("{}.self_attn.q_proj.weight", p));
+        names.push(format!("{}.self_attn.k_proj.weight", p));
+        names.push(format!("{}.self_attn.v_proj.weight", p));
+        names.push(format!("{}.self_attn.o_proj.weight", p));
+        names.push(format!("{}.mlp.gate_proj.weight", p));
+        names.push(format!("{}.mlp.up_proj.weight", p));
+        names.push(format!("{}.mlp.down_proj.weight", p));
+    }
+    names.push("lm_head.weight".to_string());
+    names
+}

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -232,6 +232,7 @@ fn graph_to_egglog(graph: &Graph) -> String {
   (BiasAdd Op Op)
   (Relu Op)
   (Sigmoid Op)
+  (Tanh Op)
   (Neg Op)
   (Abs Op)
   (Log Op)
@@ -374,6 +375,7 @@ fn node_to_egglog_expr(node: &Node) -> String {
         Op::BiasAdd => format!("(BiasAdd n{} n{})", i[0], i[1]),
         Op::Relu => format!("(Relu n{})", i[0]),
         Op::Sigmoid => format!("(Sigmoid n{})", i[0]),
+        Op::Tanh => format!("(Tanh n{})", i[0]),
         Op::Neg => format!("(Neg n{})", i[0]),
         Op::Abs => format!("(Abs n{})", i[0]),
         Op::Log => format!("(Log n{})", i[0]),

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -259,6 +259,7 @@ fn graph_to_egglog(graph: &Graph) -> String {
   (RoPE Op)
   (RoPEGrad Op)
   (CausalAttention Op Op Op)
+  (SlidingWindowAttention Op Op Op)
   (LayerNorm Op Op Op)
   (FullAttention Op Op Op)
   (CrossAttention Op Op Op)
@@ -402,6 +403,9 @@ fn node_to_egglog_expr(node: &Node) -> String {
         Op::RoPEGrad { .. } => format!("(RoPEGrad n{})", i[0]),
         Op::CausalAttention { .. } => {
             format!("(CausalAttention n{} n{} n{})", i[0], i[1], i[2])
+        }
+        Op::SlidingWindowAttention { .. } => {
+            format!("(SlidingWindowAttention n{} n{} n{})", i[0], i[1], i[2])
         }
         Op::LayerNorm { .. } => format!("(LayerNorm n{} n{} n{})", i[0], i[1], i[2]),
         Op::FullAttention { .. } => format!("(FullAttention n{} n{} n{})", i[0], i[1], i[2]),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -249,6 +249,30 @@ struct AttentionData {
     params: MatMulParams,
 }
 
+// sliding_window_attention: var src_a (q), src_b (k), bias (v), dst, params
+// params has 5 fields so needs its own struct (not MatMulParams which has 4)
+#[derive(blade_macros::ShaderData)]
+struct SlidingWindowAttentionData {
+    src_a: blade_graphics::BufferPiece,
+    src_b: blade_graphics::BufferPiece,
+    bias: blade_graphics::BufferPiece,
+    dst: blade_graphics::BufferPiece,
+    params: SlidingWindowAttentionParams,
+}
+
+#[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
+#[repr(C)]
+struct SlidingWindowAttentionParams {
+    seq: u32,
+    num_heads: u32,
+    num_kv_heads: u32,
+    head_dim: u32,
+    window_size: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+}
+
 // rope_dynamic: var src, dst, pos_offset_buf, params
 #[derive(blade_macros::ShaderData)]
 struct RoPEDynamicData {
@@ -704,6 +728,7 @@ fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
         ShaderEntry::Embedding => EmbeddingData::layout(),
         ShaderEntry::RoPE | ShaderEntry::RoPEGrad => RoPEData::layout(),
         ShaderEntry::CausalAttention => AttentionData::layout(),
+        ShaderEntry::SlidingWindowAttention => SlidingWindowAttentionData::layout(),
         ShaderEntry::Gelu => UnaryData::layout(),
         ShaderEntry::LayerNorm => LayerNormData::layout(),
         ShaderEntry::FullAttention | ShaderEntry::CrossAttention => AttentionData::layout(),
@@ -1950,6 +1975,27 @@ impl Session {
                             n: dispatch.params[1],
                             k: dispatch.params[2],
                             _pad: dispatch.params[3],
+                        },
+                    },
+                );
+            }
+            ShaderEntry::SlidingWindowAttention => {
+                pc.bind(
+                    0,
+                    &SlidingWindowAttentionData {
+                        src_a: buf(dispatch.input_buffers[0]),
+                        src_b: buf(dispatch.input_buffers[1]),
+                        bias: buf(dispatch.input_buffers[2]),
+                        dst: buf(dispatch.output_buffer),
+                        params: SlidingWindowAttentionParams {
+                            seq: dispatch.params[0],
+                            num_heads: dispatch.params[1],
+                            num_kv_heads: dispatch.params[2],
+                            head_dim: dispatch.params[3],
+                            window_size: dispatch.params[4],
+                            _pad0: 0,
+                            _pad1: 0,
+                            _pad2: 0,
                         },
                     },
                 );

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -681,6 +681,7 @@ fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
         | ShaderEntry::FusedMatMulBTAdd => FusedMatMulAddData::layout(),
         ShaderEntry::Relu
         | ShaderEntry::Sigmoid
+        | ShaderEntry::Tanh
         | ShaderEntry::Neg
         | ShaderEntry::Abs
         | ShaderEntry::Log
@@ -1695,6 +1696,7 @@ impl Session {
             }
             ShaderEntry::Relu
             | ShaderEntry::Sigmoid
+            | ShaderEntry::Tanh
             | ShaderEntry::Neg
             | ShaderEntry::Abs
             | ShaderEntry::Log

--- a/src/shaders/sliding_window_attention.wgsl
+++ b/src/shaders/sliding_window_attention.wgsl
@@ -1,0 +1,69 @@
+// Sliding-window causal attention: online softmax single-pass with GQA.
+// Inference-only variant — no LSE/score storage (not differentiable).
+// Each position attends to [kv_start, kv_len) instead of [0, kv_len).
+
+struct Params {
+    $PARAM_FIELDS
+}
+
+var<storage> src_a: array<f32>;  // Q
+var<storage> src_b: array<f32>;  // K
+var<storage> bias: array<f32>;   // V
+var<storage, read_write> dst: array<f32>;
+var<uniform> params: Params;
+var<workgroup> wg_dot: array<f32, 64>;
+
+fn tree_reduce(tid: u32) {
+    workgroupBarrier();
+    if tid < 32u { wg_dot[tid] += wg_dot[tid + 32u]; }
+    workgroupBarrier();
+    if tid < 16u { wg_dot[tid] += wg_dot[tid + 16u]; }
+    workgroupBarrier();
+    if tid < 8u { wg_dot[tid] += wg_dot[tid + 8u]; }
+    workgroupBarrier();
+    if tid < 4u { wg_dot[tid] += wg_dot[tid + 4u]; }
+    workgroupBarrier();
+    if tid < 2u { wg_dot[tid] += wg_dot[tid + 2u]; }
+    workgroupBarrier();
+    if tid < 1u { wg_dot[tid] += wg_dot[tid + 1u]; }
+    workgroupBarrier();
+}
+
+@compute @workgroup_size(64)
+fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
+    let pos = wgid.x;
+    let head = wgid.y;
+    let tid = lid.x;
+
+    $PARSE_PARAMS
+
+    if pos >= q_seq || head >= num_heads { return; }
+
+    let kv_head = head / (num_heads / num_kv_heads);
+    let kv_head_off = kv_head * head_dim;
+    let scale = inverseSqrt(f32(head_dim));
+    let q_base = pos * (num_heads * head_dim) + head * head_dim;
+    let q_val = src_a[q_base + tid];
+
+    var my_out = 0.0;
+    var max_score = -1e30;
+    var sum_exp = 0.0;
+
+    for (var t = kv_start; t < kv_len; t++) {
+        let k_base = t * (num_kv_heads * head_dim) + kv_head_off;
+
+        wg_dot[tid] = q_val * src_b[k_base + tid];
+        tree_reduce(tid);
+        let score = wg_dot[0] * scale;
+
+        let new_max = max(max_score, score);
+        let correction = exp(max_score - new_max);
+        let weight = exp(score - new_max);
+        sum_exp = sum_exp * correction + weight;
+        my_out = my_out * correction + weight * bias[k_base + tid];
+        max_score = new_max;
+    }
+
+    let safe_sum = select(sum_exp, 1.0, sum_exp == 0.0);
+    dst[q_base + tid] = my_out / safe_sum;
+}

--- a/src/shaders/unary.wgsl
+++ b/src/shaders/unary.wgsl
@@ -61,6 +61,13 @@ fn silu(@builtin(global_invocation_id) gid: vec3<u32>) {
     dst[i] = val / (1.0 + exp(-val));
 }
 
+@compute @workgroup_size(256)
+fn tanh_(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if i >= params.len { return; }
+    dst[i] = tanh(src[i]);
+}
+
 // gelu approximation: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
 @compute @workgroup_size(256)
 fn gelu(@builtin(global_invocation_id) gid: vec3<u32>) {


### PR DESCRIPTION
Element-wise tanh(x) activation. Gradient: dL/dx = dL/dy * (1 - y^2).
Needed for logit soft-capping in Gemma-4 and other models.

https://claude.ai/code/session_01BZeGRH6bew7DpD24ULGYUV