### PR TITLE
Fix Whisper training: add Identity op for zero-cost reshape

### DIFF
--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -449,6 +449,13 @@ pub fn differentiate(forward: &Graph) -> Graph {
             // Leaf nodes
             Op::Input { .. } | Op::Parameter { .. } | Op::Constant { .. } | Op::Greater => {}
             Op::Nop => {}
+            Op::Identity => {
+                // Identity/reshape backward: reshape gradient back to input shape
+                let x = node.inputs[0];
+                let x_ty = forward.nodes()[x as usize].ty.clone();
+                let grad_x = graph.add_raw_node(Op::Identity, vec![grad_output], x_ty);
+                accumulate_grad(&mut graph, &mut grads, x, grad_x);
+            }
             // Backward grad ops: never appear in forward pass
             Op::MultiHeadAttnGradQ { .. }
             | Op::MultiHeadAttnGradK { .. }
@@ -464,6 +471,12 @@ pub fn differentiate(forward: &Graph) -> Graph {
             | Op::RoPEGrad { .. }
             | Op::GlobalAvgPoolGrad { .. } => {}
             Op::Gelu => {
+                eprintln!(
+                    "GELU backward: x={} x_shape={:?} grad_output_id={}",
+                    node.inputs[0],
+                    forward.nodes()[node.inputs[0] as usize].ty.shape,
+                    grad_output
+                );
                 // gelu(x) ≈ x * sigmoid(1.702 * x) (sigmoid approximation)
                 // gelu'(x) ≈ sigmoid(1.702x) * (1 + 1.702*x*(1 - sigmoid(1.702x)))
                 let x = node.inputs[0];
@@ -793,16 +806,18 @@ pub fn differentiate(forward: &Graph) -> Graph {
                 let x = node.inputs[0];
                 let w = node.inputs[1];
                 let b = node.inputs[2];
-                let cols = forward.nodes()[w as usize].ty.shape[0] as u32;
-                // grad_wb = LayerNormGradWB(dy, x, w) → [2*cols]
-                let grad_wb = graph.layer_norm_grad_wb(grad_output, x, w, eps);
-                // Split into grad_w [0..cols] and grad_b [cols..2*cols]
-                let grad_w = graph.split_a(grad_wb, 1, cols, cols, 1);
-                let grad_b = graph.split_b(grad_wb, 1, cols, cols, 1);
+                let w_ty = forward.nodes()[w as usize].ty.clone();
+                let b_ty = forward.nodes()[b as usize].ty.clone();
+                // grad_weight via dedicated LayerNormGradWB shader
+                let grad_w = graph.layer_norm_grad_wb(grad_output, x, w, eps);
+                // grad_bias = sum_rows(dy) — sum over the row (batch) dimension
+                let grad_b = graph.sum_rows(grad_output, &b_ty);
+                // grad_input via LayerNormGradX
                 let grad_x = graph.layer_norm_grad_x(grad_output, x, w, eps);
                 accumulate_grad(&mut graph, &mut grads, w, grad_w);
                 accumulate_grad(&mut graph, &mut grads, b, grad_b);
                 accumulate_grad(&mut graph, &mut grads, x, grad_x);
+                let _ = w_ty; // keep for future use
             }
             Op::FullAttention {
                 num_heads,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -548,6 +548,13 @@ impl<'a> Compiler<'a> {
     fn compile(&mut self) {
         // First pass: allocate buffers for all nodes
         for node in self.graph.nodes() {
+            // Identity is a zero-cost reshape: alias the input buffer
+            if matches!(node.op, Op::Identity) && !node.inputs.is_empty() {
+                if let Some(&input_buf) = self.node_buffers.get(&node.inputs[0]) {
+                    self.node_buffers.insert(node.id, input_buf);
+                    continue;
+                }
+            }
             let size = node.ty.size_bytes();
             let buf = self.alloc_buffer(size);
             self.node_buffers.insert(node.id, buf);
@@ -673,7 +680,11 @@ impl<'a> Compiler<'a> {
 
         match node.op {
             // Leaf nodes and dead nodes: no dispatch needed
-            Op::Input { .. } | Op::Parameter { .. } | Op::Constant { .. } | Op::Nop => {}
+            Op::Input { .. }
+            | Op::Parameter { .. }
+            | Op::Constant { .. }
+            | Op::Nop
+            | Op::Identity => {}
 
             Op::MatMul => {
                 let a = self.get_buffer(node.inputs[0]);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -111,6 +111,9 @@ pub enum Op {
 
     // Dead node (consumed by fusion, skip during compilation)
     Nop,
+    /// Identity / reshape: zero-cost view with potentially different shape.
+    /// Compiled as buffer alias (no GPU dispatch). Backward reshapes grad back.
+    Identity,
 
     // Log-softmax (for numerical stability)
     LogSoftmax,
@@ -774,8 +777,9 @@ impl Graph {
             old_elems, new_elems,
             "reshape: element count mismatch ({old_elems} vs {new_elems})"
         );
-        let zero = self.constant(vec![0.0; new_elems], new_shape);
-        self.add_raw_node(Op::Add, vec![x, zero], TensorType::f32(new_shape.to_vec()))
+        // Reshape is a zero-cost view — just reinterprets the shape.
+        // Uses Identity op (compiled as buffer alias, no GPU dispatch).
+        self.add_raw_node(Op::Identity, vec![x], TensorType::f32(new_shape.to_vec()))
     }
 
     /// Element-wise division: `a / b` = `a * recip(b)`.
@@ -896,9 +900,8 @@ impl Graph {
     }
 
     pub fn layer_norm_grad_wb(&mut self, dy: NodeId, x: NodeId, w: NodeId, eps: f32) -> NodeId {
-        let cols = self.node(w).ty.shape[0];
-        let ty = TensorType::f32(vec![2 * cols]);
-        self.add_raw_node(Op::LayerNormGradWB { eps }, vec![dy, x, w], ty)
+        let w_ty = self.node(w).ty.clone();
+        self.add_raw_node(Op::LayerNormGradWB { eps }, vec![dy, x, w], w_ty)
     }
 
     pub fn layer_norm_grad_x(&mut self, dy: NodeId, x: NodeId, w: NodeId, eps: f32) -> NodeId {

--- a/src/models/whisper.rs
+++ b/src/models/whisper.rs
@@ -177,15 +177,14 @@ pub fn build_encoder(g: &mut Graph, config: &WhisperConfig, batch: u32, mel_len:
 pub fn build_training_graph(config: &WhisperConfig, batch: u32, mel_len: u32) -> Graph {
     let mut g = Graph::new();
     let encoder_out = build_encoder(&mut g, config, batch, mel_len);
-    // MSE loss against zero target (simple benchmark loss)
-    let seq_len = mel_len / 2; // conv stride=2
-    let _out_size = (batch * seq_len) as usize * config.d_model;
-    let seq_len_usize = seq_len as usize;
-    let target = g.input("target", &[seq_len_usize, config.d_model]);
-    let neg_target = g.neg(target);
-    let diff = g.add(encoder_out, neg_target);
-    let sq = g.mul(diff, diff);
-    let loss = g.mean_all(sq);
+    // Project encoder output to a small dimension, then cross-entropy loss.
+    // This exercises the full backward through attention + LayerNorm + GELU.
+    let seq_len = (mel_len / 2) as usize;
+    let num_classes = 64;
+    let proj_w = g.parameter("train_proj.weight", &[config.d_model, num_classes]);
+    let logits = g.matmul(encoder_out, proj_w); // [seq, num_classes]
+    let labels = g.input("labels", &[seq_len, num_classes]);
+    let loss = g.cross_entropy_loss(logits, labels);
     g.set_outputs(vec![loss]);
     g
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -240,6 +240,7 @@ fn graph_to_egglog(graph: &Graph) -> String {
   (ScatterAdd i64 Op Op)
   (Silu Op)
   (Gelu Op)
+  (Identity Op)
   ; --- Shape / reduction ---
   (Transpose Op)
   (Softmax Op)
@@ -469,6 +470,7 @@ fn node_to_egglog_expr(node: &Node) -> String {
             format!("(CachedAttention n{} n{} n{} n{})", i[0], i[1], i[2], i[3])
         }
         Op::Nop => unreachable!("Nop nodes are filtered before encoding"),
+        Op::Identity => format!("(Identity n{})", i[0]),
     }
 }
 

--- a/src/shaders/layer_norm_grad.wgsl
+++ b/src/shaders/layer_norm_grad.wgsl
@@ -31,7 +31,6 @@ fn layer_norm_grad_wb(@builtin(global_invocation_id) gid: vec3<u32>) {
     if j >= cols { return; }
 
     var grad_w = 0.0;
-    var grad_b = 0.0;
 
     for (var i = 0u; i < rows; i++) {
         let offset = i * cols;
@@ -50,11 +49,9 @@ fn layer_norm_grad_wb(@builtin(global_invocation_id) gid: vec3<u32>) {
         let normed = (src_b[offset + j] - mean) * rstd;
 
         grad_w += src_a[offset + j] * normed;
-        grad_b += src_a[offset + j];
     }
 
     dst[j] = grad_w;
-    dst[cols + j] = grad_b;
 }
 
 // grad_x[i,j] = rstd * (dy[i,j]*w[j] - normed[i,j]*s_i - mean(dy*w)/cols)

--- a/tests/training_correctness.rs
+++ b/tests/training_correctness.rs
@@ -476,20 +476,13 @@ fn resnet50_training_loss_decreases() {
 
 #[test]
 fn whisper_encoder_training_loss_decreases() {
-    // Skip: FullAttention backward + LayerNormGradWB shape issues need debugging
-    eprintln!("SKIPPED: Whisper training backward needs shape debugging");
-    return;
-}
-
-#[allow(dead_code)]
-fn _whisper_encoder_training_loss_decreases() {
     use meganeura::models::whisper::{self, WhisperConfig};
 
     let config = WhisperConfig::whisper_tiny();
     let batch = 1;
     let mel_len = 100; // short clip for testing
-    let seq_len = mel_len / 2; // conv stride=2
-    let out_size = seq_len as usize * config.d_model;
+    let seq_len = (mel_len / 2) as usize;
+    let num_classes = 64;
 
     let g = whisper::build_training_graph(&config, batch, mel_len);
 
@@ -498,9 +491,12 @@ fn _whisper_encoder_training_loss_decreases() {
         |s| {
             let mel_size = (batch * config.n_mels as u32 * mel_len) as usize;
             let mel: Vec<f32> = (0..mel_size).map(|i| (i as f32 * 0.01).sin()).collect();
-            let target = vec![0.0f32; out_size];
+            let mut labels = vec![0.0f32; seq_len * num_classes];
+            for i in 0..seq_len {
+                labels[i * num_classes + (i % num_classes)] = 1.0;
+            }
             s.set_input("mel", &mel);
-            s.set_input("target", &target);
+            s.set_input("labels", &labels);
         },
         5,
         0.001,


### PR DESCRIPTION
The reshape function previously faked shape changes as Add(x, zeros), which caused gradient shape mismatches in the backward pass because Add passes through gradients with the output shape rather than reshaping back to the input shape.

Fix: introduce Op::Identity — a zero-cost view operation that aliases the input buffer (no GPU dispatch). The backward creates another Identity to reshape the gradient back to the original shape.

Also fix Whisper build_training_graph to use cross-entropy loss (exercises the full backward through attention + LayerNorm + GELU) and remove the grad_bias from LayerNormGradWB (use SumRows instead, avoiding the SplitA/SplitB shape issues).

All 8 training correctness tests pass on both AMD and NVIDIA:
  smollm2, smolvla, resnet50, whisper, sd_unet (+kv_cache, weight_sharing)