### PR TITLE
Preserve user outputs through autodiff

### DIFF
--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -925,23 +925,25 @@ pub fn differentiate(forward: &Graph) -> Graph {
         }
     }
 
-    // Collect parameter gradients as outputs.
+    // Preserve all user-supplied outputs (loss + any extras observed during
+    // training) and append one gradient-output entry per Parameter node.
     // Every Parameter gets an output entry (even dead ones with no gradient)
     // to maintain positional alignment with param_buffers in compile.rs.
-    let mut outputs = vec![loss_node];
+    graph.set_outputs(forward.outputs().to_vec());
+    let mut grad_outputs = Vec::new();
     for node in forward.nodes() {
         if let Op::Parameter { .. } = node.op {
             if let Some(&grad_id) = grads.get(&node.id) {
-                outputs.push(grad_id);
+                grad_outputs.push(grad_id);
             } else {
                 // Dead parameter (optimizer Nop'd its consumer) — use a
                 // zero-sized constant as placeholder so positions align.
                 let zero = graph.scalar(0.0);
-                outputs.push(zero);
+                grad_outputs.push(zero);
             }
         }
     }
-    graph.set_outputs(outputs);
+    graph.append_param_grad_outputs(&grad_outputs);
 
     graph
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -647,30 +647,40 @@ impl<'a> Compiler<'a> {
             };
         }
 
-        // Set loss buffer (first output) and collect all output buffers
-        for &out_id in self.graph.outputs() {
+        // Outputs layout (from autodiff): [user_outputs..., param_grads...]
+        // Where `param_grads` is the last `num_param_grad_outputs()` entries
+        // (one per Parameter node, exactly aligned with param_buffers order).
+        // For inference (no autodiff), num_param_grad_outputs() == 0 and every
+        // output is user-facing.
+        let outputs = self.graph.outputs();
+        let num_grads = self.graph.num_param_grad_outputs();
+        let num_user = outputs.len() - num_grads;
+
+        // Collect user-facing output buffers (accessible via read_output_by_index).
+        for &out_id in &outputs[..num_user] {
             self.plan.output_buffers.push(self.get_buffer(out_id));
         }
-        if let Some(&loss_id) = self.graph.outputs().first() {
+        if let Some(&loss_id) = outputs.first() {
             self.plan.loss_buffer = Some(self.get_buffer(loss_id));
         }
 
-        // Build param→grad pairs from outputs
-        // Outputs are [loss, grad_param1, grad_param2, ...]
-        let outputs = self.graph.outputs();
-        if outputs.len() > 1 {
+        // Build param→grad pairs from the trailing grad outputs.
+        if num_grads > 0 {
             let param_names: Vec<String> = self
                 .plan
                 .param_buffers
                 .iter()
                 .map(|entry| entry.0.clone())
                 .collect();
-            for (i, _name) in param_names.iter().enumerate() {
-                if i + 1 < outputs.len() {
-                    let param_buf = self.plan.param_buffers[i].1;
-                    let grad_buf = self.get_buffer(outputs[i + 1]);
-                    self.plan.param_grad_pairs.push((param_buf, grad_buf));
-                }
+            assert_eq!(
+                param_names.len(),
+                num_grads,
+                "autodiff must emit one grad output per Parameter",
+            );
+            for i in 0..num_grads {
+                let param_buf = self.plan.param_buffers[i].1;
+                let grad_buf = self.get_buffer(outputs[num_user + i]);
+                self.plan.param_grad_pairs.push((param_buf, grad_buf));
             }
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -489,6 +489,11 @@ pub struct DerivedParam {
 pub struct Graph {
     nodes: Vec<Node>,
     outputs: Vec<NodeId>,
+    /// Number of trailing entries in `outputs` that are parameter gradients
+    /// appended by autodiff (positionally aligned with `param_buffers` in the
+    /// compiled plan). The leading `outputs.len() - num_param_grad_outputs`
+    /// entries are user-facing outputs supplied via `set_outputs`.
+    num_param_grad_outputs: usize,
     /// Parameters created by the optimizer from concatenating original params.
     pub derived_params: Vec<DerivedParam>,
 }
@@ -498,6 +503,7 @@ impl Graph {
         Self {
             nodes: Vec::new(),
             outputs: Vec::new(),
+            num_param_grad_outputs: 0,
             derived_params: Vec::new(),
         }
     }
@@ -570,6 +576,9 @@ impl Graph {
             .filter_map(|&out| old_to_new[out as usize])
             .collect();
         new_graph.set_outputs(new_outputs);
+        // Preserve the user/grad output boundary. set_outputs resets this,
+        // so we restore it after. Clamp in case some outputs were Nop'd.
+        new_graph.num_param_grad_outputs = self.num_param_grad_outputs.min(new_graph.outputs.len());
         new_graph.derived_params = self.derived_params.clone();
         new_graph
     }
@@ -586,8 +595,28 @@ impl Graph {
         &self.outputs
     }
 
+    /// Number of user-supplied outputs (those passed to `set_outputs`).
+    /// The remaining `num_param_grad_outputs()` entries are parameter
+    /// gradients appended by autodiff.
+    pub fn num_user_outputs(&self) -> usize {
+        self.outputs.len() - self.num_param_grad_outputs
+    }
+
+    /// Number of trailing outputs that are param gradients (appended by autodiff).
+    pub fn num_param_grad_outputs(&self) -> usize {
+        self.num_param_grad_outputs
+    }
+
     pub fn set_outputs(&mut self, outputs: Vec<NodeId>) {
         self.outputs = outputs;
+        self.num_param_grad_outputs = 0;
+    }
+
+    /// Append parameter-gradient outputs after user outputs. Only called by
+    /// autodiff. `num_grads` must equal the number of entries appended.
+    pub fn append_param_grad_outputs(&mut self, grads: &[NodeId]) {
+        self.outputs.extend_from_slice(grads);
+        self.num_param_grad_outputs += grads.len();
     }
 
     pub fn add_raw_node(&mut self, op: Op, inputs: Vec<NodeId>, ty: TensorType) -> NodeId {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -973,7 +973,9 @@ fn clone_graph(graph: &Graph) -> Graph {
     for node in graph.nodes() {
         new_graph.add_raw_node(node.op.clone(), node.inputs.clone(), node.ty.clone());
     }
-    new_graph.set_outputs(graph.outputs().to_vec());
+    let num_user = graph.num_user_outputs();
+    new_graph.set_outputs(graph.outputs()[..num_user].to_vec());
+    new_graph.append_param_grad_outputs(&graph.outputs()[num_user..]);
     new_graph.derived_params = graph.derived_params.clone();
     new_graph
 }

--- a/tests/gpu_smoke.rs
+++ b/tests/gpu_smoke.rs
@@ -1597,9 +1597,9 @@ fn conv2d_backward_smoke() {
     let loss_val = session.read_output(1);
     assert!(loss_val[0].abs() > 0.0, "loss should be non-zero");
 
-    // Read kernel gradient (output index 1 = first param gradient)
+    // Read kernel gradient by parameter name.
     let mut grad_kernel = vec![0.0f32; kernel_size];
-    session.read_output_by_index(1, &mut grad_kernel);
+    session.read_param_grad("kernel", &mut grad_kernel);
 
     // Finite difference check for kernel gradient
     let eps = 1e-3;

--- a/tests/intermediate_output_aliasing.rs
+++ b/tests/intermediate_output_aliasing.rs
@@ -1,0 +1,82 @@
+//! Reproducer for the bug where an intermediate node (with both forward
+//! consumers and a backward gradient path) returned to the user via
+//! `set_outputs` becomes corrupted after `step()` at batch_size > 1.
+
+use meganeura::{Graph, build_session, nn};
+
+#[test]
+fn intermediate_node_output_is_stable_across_batch_sizes() {
+    for &bs in &[1usize, 2, 4] {
+        let mut g = Graph::new();
+        let x = g.input("x", &[bs, 4]);
+        let target = g.input("target", &[bs, 3]);
+
+        let fc1 = nn::Linear::new(&mut g, "fc1", 4, 4);
+        let norm = nn::RmsNorm::new(&mut g, "norm.weight", 4, 1e-5);
+        let fc_out = nn::Linear::new(&mut g, "fc_out", 4, 3);
+        let fc2 = nn::Linear::new(&mut g, "fc2", 3, 3);
+
+        let h = fc1.forward(&mut g, x);
+        let h = g.relu(h);
+        let h = norm.forward(&mut g, h);
+        let y = fc_out.forward(&mut g, h);
+        let y2 = fc2.forward(&mut g, y);
+        let loss = g.mse_loss(y2, target);
+        g.set_outputs(vec![loss, y]);
+
+        let mut s = build_session(&g);
+        s.set_parameter("fc1.weight", &vec![0.1; 16]);
+        s.set_parameter("fc1.bias", &vec![0.1; 4]);
+        s.set_parameter("norm.weight", &vec![1.0; 4]);
+        s.set_parameter("fc_out.weight", &vec![0.2; 12]);
+        s.set_parameter("fc_out.bias", &vec![0.0; 3]);
+        s.set_parameter("fc2.weight", &vec![0.3; 9]);
+        s.set_parameter("fc2.bias", &vec![0.0; 3]);
+
+        let input: Vec<f32> = (0..bs * 4).map(|i| (i as f32 + 1.0) * 0.1).collect();
+        s.set_input("x", &input);
+        s.set_input("target", &vec![0.0f32; bs * 3]);
+        s.set_learning_rate(0.0);
+        s.step();
+        s.wait();
+
+        let mut out = vec![-999.0f32; bs * 3];
+        s.read_output_by_index(1, &mut out);
+        eprintln!("bs={bs}: {out:?}");
+
+        // Each row should match fc_out(norm(relu(fc1(x_row)))) computed by
+        // a pure forward-only session. No cross-row bleed, no NaN, no stale.
+        //
+        // Build a second session with only forward to compute expected.
+        let mut fg = Graph::new();
+        let fx = fg.input("x", &[bs, 4]);
+        let ffc1 = nn::Linear::new(&mut fg, "fc1", 4, 4);
+        let fnorm = nn::RmsNorm::new(&mut fg, "norm.weight", 4, 1e-5);
+        let ffc_out = nn::Linear::new(&mut fg, "fc_out", 4, 3);
+        let fh = ffc1.forward(&mut fg, fx);
+        let fh = fg.relu(fh);
+        let fh = fnorm.forward(&mut fg, fh);
+        let fy = ffc_out.forward(&mut fg, fh);
+        fg.set_outputs(vec![fy]);
+        let mut fs = meganeura::train::build_inference_session(&fg);
+        fs.set_parameter("fc1.weight", &vec![0.1; 16]);
+        fs.set_parameter("fc1.bias", &vec![0.1; 4]);
+        fs.set_parameter("norm.weight", &vec![1.0; 4]);
+        fs.set_parameter("fc_out.weight", &vec![0.2; 12]);
+        fs.set_parameter("fc_out.bias", &vec![0.0; 3]);
+        fs.set_input("x", &input);
+        fs.step();
+        fs.wait();
+        let mut expected = vec![0.0f32; bs * 3];
+        fs.read_output_by_index(0, &mut expected);
+        eprintln!("bs={bs} expected: {expected:?}");
+
+        for (i, (a, e)) in out.iter().zip(expected.iter()).enumerate() {
+            let diff = (a - e).abs();
+            assert!(
+                diff < 1e-4,
+                "bs={bs} elem {i}: got {a}, expected {e} (diff {diff})"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Autodiff was overwriting the graph's output list with [loss, param_grad1, param_grad2, ...], discarding any user-supplied extra outputs (beyond loss). Reading `read_output_by_index(1)` for a graph built with `set_outputs(vec![loss, intermediate])` returned the first parameter's gradient buffer instead of the intermediate — hence the "cross-row bleed" / stale values reported by users.

The fix preserves the full user outputs list and appends one gradient-output per Parameter node after. Graph now tracks the user/grad boundary via `num_param_grad_outputs`, propagated through toposort and clone_graph. Compile builds `output_buffers` from the user slice and `param_grad_pairs` from the grad slice.

`read_output_by_index` now addresses user outputs only; callers that were using index 1 to read the first param gradient should use `read_param_grad(name)` instead (updated conv2d_backward_smoke).

Added `tests/intermediate_output_aliasing.rs` as a regression test (builds the repro from the issue, compares against a forward-only session across batch sizes 1/2/4).

https://claude.ai/code/session_015DBdSM2A3bhjpMMpvXpgi6