### PR TITLE
Don't Nop graph-output nodes during fusion

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -569,16 +569,25 @@ impl Graph {
             new_graph.add_raw_node(node.op.clone(), new_inputs, node.ty.clone());
         }
 
-        // Remap outputs
-        let new_outputs: Vec<NodeId> = self
-            .outputs
-            .iter()
-            .filter_map(|&out| old_to_new[out as usize])
-            .collect();
+        // Remap outputs. An output being Nop'd would silently drop it and
+        // shift downstream indices — assert loudly instead so fusion bugs
+        // surface at build time rather than as `read_output_by_index`
+        // panics at inference time.
+        let mut new_outputs: Vec<NodeId> = Vec::with_capacity(self.outputs.len());
+        for (i, &out) in self.outputs.iter().enumerate() {
+            match old_to_new[out as usize] {
+                Some(new_id) => new_outputs.push(new_id),
+                None => panic!(
+                    "toposort: output #{i} (node {out}, op {:?}) was removed as Nop. \
+                     A fusion pass Nop'd a node that's listed in `set_outputs`. \
+                     Add an `is_output(id)` guard to that fusion.",
+                    self.nodes[out as usize].op,
+                ),
+            }
+        }
         new_graph.set_outputs(new_outputs);
-        // Preserve the user/grad output boundary. set_outputs resets this,
-        // so we restore it after. Clamp in case some outputs were Nop'd.
-        new_graph.num_param_grad_outputs = self.num_param_grad_outputs.min(new_graph.outputs.len());
+        // Preserve the user/grad output boundary (set_outputs resets it).
+        new_graph.num_param_grad_outputs = self.num_param_grad_outputs;
         new_graph.derived_params = self.derived_params.clone();
         new_graph
     }
@@ -593,6 +602,13 @@ impl Graph {
 
     pub fn outputs(&self) -> &[NodeId] {
         &self.outputs
+    }
+
+    /// Returns true if `id` is a graph output (user-facing or param-grad).
+    /// Fusions must not Nop nodes that are outputs — their values are
+    /// read back by the user or consumed by the optimizer.
+    pub fn is_output(&self, id: NodeId) -> bool {
+        self.outputs.contains(&id)
     }
 
     /// Number of user-supplied outputs (those passed to `set_outputs`).

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -610,6 +610,11 @@ fn apply_matmul_add_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u32)>)
         if mm_use_count != 1 {
             continue;
         }
+        // Don't fuse if the matmul is a graph output — its value is read
+        // back by the user or is a param gradient consumed by the trainer.
+        if graph.is_output(mm_id) {
+            continue;
+        }
 
         let mm_node = graph.node(mm_id);
         let (a, b) = (mm_node.inputs[0], mm_node.inputs[1]);
@@ -665,6 +670,10 @@ fn apply_swiglu_concat_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u32
             .filter(|n| n.inputs.contains(&up_id) && !matches!(n.op, Op::Nop))
             .count();
         if gate_uses != 1 || up_uses != 1 {
+            continue;
+        }
+        // Don't fuse if either matmul is a graph output.
+        if graph.is_output(gate_id) || graph.is_output(up_id) {
             continue;
         }
 
@@ -762,6 +771,9 @@ pub fn apply_group_norm_silu_fusions(graph: &mut Graph, fusions: &mut Vec<(Strin
         if gn_use_count != 1 {
             continue;
         }
+        if graph.is_output(gn_id) {
+            continue;
+        }
         let (x, w, b) = (gn_node.inputs[0], gn_node.inputs[1], gn_node.inputs[2]);
         // Rewrite Silu node to GroupNormSilu
         graph.nodes_mut()[id].op = Op::GroupNormSilu {
@@ -802,6 +814,9 @@ fn apply_rms_norm_matmul_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u
             .filter(|n| n.inputs.contains(&norm_id) && !matches!(n.op, Op::Nop))
             .count();
         if norm_use_count != 1 {
+            continue;
+        }
+        if graph.is_output(norm_id) {
             continue;
         }
 
@@ -878,6 +893,9 @@ fn apply_rope_attention_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u3
         if q_uses != 1 || k_uses != 1 {
             continue;
         }
+        if graph.is_output(q_id) || graph.is_output(k_id) {
+            continue;
+        }
 
         // Replace CausalAttention with CausalAttentionRoPE using un-rotated Q, K
         graph.nodes_mut()[id].op = Op::CausalAttentionRoPE {
@@ -928,6 +946,9 @@ fn apply_silu_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u32)>) {
         if sig_use_count != 1 {
             continue;
         }
+        if graph.is_output(sig_id) {
+            continue;
+        }
         graph.nodes_mut()[id].op = Op::Silu;
         graph.nodes_mut()[id].inputs = vec![x];
         graph.nodes_mut()[sig_id as usize].op = Op::Nop;
@@ -959,6 +980,9 @@ fn apply_swiglu_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u32)>) {
             .filter(|n| n.inputs.contains(&silu_id) && !matches!(n.op, Op::Nop))
             .count();
         if silu_use_count != 1 {
+            continue;
+        }
+        if graph.is_output(silu_id) {
             continue;
         }
         graph.nodes_mut()[id].op = Op::SwiGLU;

--- a/tests/fusion_preserves_outputs.rs
+++ b/tests/fusion_preserves_outputs.rs
@@ -1,0 +1,59 @@
+//! Reproducer for the bug where an intermediate MatMul that's also a user
+//! output gets Nop'd by the MatMul+Add fusion (e.g. when followed by
+//! `mse_loss(matmul(h, W), target)`). Toposort then silently drops the
+//! dead output from `outputs()`, collapsing `num_outputs()` and making
+//! `read_output_by_index(1)` panic.
+
+use meganeura::{Graph, build_session, nn};
+
+#[test]
+fn output_matmul_survives_matmul_add_fusion() {
+    // Graph: pred = fc(h); loss = mse_loss(pred, target)
+    // mse_loss decomposes to Add(pred, -target) -> Mul(diff, diff) -> MeanAll.
+    // The MatMul+Add fusion used to Nop `pred` even though it was a user
+    // output, silently dropping it.
+    let bs = 2usize;
+    let mut g = Graph::new();
+    let h = g.input("h", &[bs, 4]);
+    let target = g.input("target", &[bs, 3]);
+    let fc = nn::Linear::new(&mut g, "fc", 4, 3);
+    let pred_pre_bias = g.matmul(h, fc.weight);
+    // Use a raw matmul (not fc.forward) so there's no bias — the only
+    // Add operation on `pred_pre_bias` is the one inside mse_loss.
+    let loss = g.mse_loss(pred_pre_bias, target);
+    g.set_outputs(vec![loss, pred_pre_bias]);
+
+    let mut s = build_session(&g);
+    assert_eq!(
+        s.num_outputs(),
+        2,
+        "both loss and pred should survive optimization (got {})",
+        s.num_outputs()
+    );
+    s.set_parameter("fc.weight", &vec![0.2; 12]);
+    s.set_parameter("fc.bias", &vec![0.0; 3]);
+    let input: Vec<f32> = (0..bs * 4).map(|i| (i as f32 + 1.0) * 0.1).collect();
+    s.set_input("h", &input);
+    s.set_input("target", &vec![0.0f32; bs * 3]);
+    s.set_learning_rate(0.0);
+    s.step();
+    s.wait();
+
+    let mut pred = vec![-999.0f32; bs * 3];
+    s.read_output_by_index(1, &mut pred);
+
+    // Compute expected pred = h @ W (W = 0.2 all-ones 4x3).
+    // row i: sum_j h[i,j] * 0.2 = 0.2 * sum of that row
+    for i in 0..bs {
+        let row_sum: f32 = input[i * 4..(i + 1) * 4].iter().sum();
+        let expected = 0.2 * row_sum;
+        for j in 0..3 {
+            let got = pred[i * 3 + j];
+            let diff = (got - expected).abs();
+            assert!(
+                diff < 1e-5,
+                "pred[{i},{j}]: got {got}, expected {expected} (diff {diff})"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fusion rules in `optimize::apply_*` would rewrite a producer/consumer pair into a fused op and mark the producer as `Op::Nop`, relying on toposort to drop it. But if the producer was also listed in `set_outputs` (e.g. the user wants to observe the MatMul result in `mse_loss(matmul(h, W), target)` while training), toposort silently dropped that output, collapsing `num_outputs()` and making `read_output_by_index` panic at inference time.

Guard each `*_id = Op::Nop` site with `graph.is_output(*_id)` so the fusion is skipped when the producer's value is visible to the user or needed as a param gradient. Covers:
  MatMul+Add → FusedMatMul*Add
  GroupNorm+Silu → GroupNormSilu
  RmsNorm+MatMul → FusedRmsNormMatMul
  RoPE(Q,K) → CausalAttentionRoPE
  Mul+Sigmoid → Silu
  Silu+Mul → SwiGLU
  SwiGLU gate+up concat

Also make `toposort` panic loudly if any output node was Nop'd, instead of silently filtering it out with `filter_map`. This way, future fusion rules that forget the guard fail at build time with a clear message rather than as subtle output-index corruption.

Regression test: `tests/fusion_preserves_outputs.rs` builds the `mse_loss(matmul(h, W), target)` pattern with `pred` in the user outputs; without the guard, the MatMul+Add rewrite would Nop `pred` and `num_outputs()` would drop from 2 to 1.

https://claude.ai/code/session_015DBdSM2A3bhjpMMpvXpgi6