### PR TITLE
Lower coop matmul threshold from 32 to 16 workgroups

### DIFF
--- a/bench/bench_smolvla_meganeura.rs
+++ b/bench/bench_smolvla_meganeura.rs
@@ -350,20 +350,16 @@ fn main() {
     for _ in 0..warmup {
         run_denoise(&mut session);
     }
-    // Run one more step to trigger encoder.start() which collects timings
-    // from the previous submission.
-    {
-        session.set_input("noisy_actions", &noisy_actions);
-        session.set_input("timestep", &timestep);
-        for i in 0..config.expert.num_layers {
-            if i % config.expert.self_attn_every_n_layers != 0 {
-                session.set_input(&format!("vlm_kv_layer_{}", i), &vlm_kv);
-            }
-        }
-        session.step();
-        session.dump_gpu_timings();
-        session.wait();
-    }
+    // Run one profiled step to get per-dispatch GPU timings.
+    // With double-buffered command buffers, timings appear after TWO
+    // subsequent start() calls (rotate_left(1) cycles through 2 buffers).
+    session.set_profiling(true);
+    run_denoise(&mut session);
+    session.set_profiling(false);
+    // Two more steps to rotate back to the profiled buffer's timestamps.
+    run_denoise(&mut session);
+    run_denoise(&mut session);
+    session.dump_gpu_timings();
 
     // --- Benchmark ---
     eprintln!(

--- a/examples/analyze_shaders.rs
+++ b/examples/analyze_shaders.rs
@@ -205,9 +205,8 @@ fn main() {
         let sm = meganeura::codegen::generate_module(meganeura::codegen::ShaderGroup::Conv2dGemm);
         analyze_spirv("conv2d_gemm_64x64", &sm.module, dump);
 
-        let sm_small = meganeura::codegen::generate_module(
-            meganeura::codegen::ShaderGroup::Conv2dGemmSmall,
-        );
+        let sm_small =
+            meganeura::codegen::generate_module(meganeura::codegen::ShaderGroup::Conv2dGemmSmall);
         analyze_spirv("conv2d_gemm_32x32", &sm_small.module, dump);
     }
 
@@ -228,9 +227,8 @@ fn main() {
     // 7. Attention
     println!("\nAttention:");
     {
-        let sm = meganeura::codegen::generate_module(
-            meganeura::codegen::ShaderGroup::CausalAttention,
-        );
+        let sm =
+            meganeura::codegen::generate_module(meganeura::codegen::ShaderGroup::CausalAttention);
         analyze_spirv("causal_attention", &sm.module, dump);
     }
 

--- a/examples/dispatch_overhead.rs
+++ b/examples/dispatch_overhead.rs
@@ -13,9 +13,7 @@
 
 use std::time::Instant;
 
-use meganeura::{
-    CompileOptions, Graph, Mode, NodeId, SessionConfig, Session, build,
-};
+use meganeura::{CompileOptions, Graph, Mode, NodeId, Session, SessionConfig, build};
 
 fn raw_opts() -> CompileOptions {
     // Turn off the pointwise-fusion pass so a chain of unary ops stays as

--- a/examples/resnet.rs
+++ b/examples/resnet.rs
@@ -115,19 +115,27 @@ fn hf_name(torchvision_name: &str) -> String {
                     let idx_rest: Vec<&str> = suffix.splitn(2, '.').collect();
                     let layer_idx = idx_rest[0].parse::<usize>().unwrap_or(1) - 1;
                     let attr = idx_rest.get(1).unwrap_or(&"weight");
-                    return format!("resnet.encoder.stages.{stage}.layers.{block}.layer.{layer_idx}.convolution.{attr}");
+                    return format!(
+                        "resnet.encoder.stages.{stage}.layers.{block}.layer.{layer_idx}.convolution.{attr}"
+                    );
                 }
                 if let Some(suffix) = field.strip_prefix("bn") {
                     let idx_rest: Vec<&str> = suffix.splitn(2, '.').collect();
                     let layer_idx = idx_rest[0].parse::<usize>().unwrap_or(1) - 1;
                     let attr = idx_rest.get(1).unwrap_or(&"weight");
-                    return format!("resnet.encoder.stages.{stage}.layers.{block}.layer.{layer_idx}.normalization.{attr}");
+                    return format!(
+                        "resnet.encoder.stages.{stage}.layers.{block}.layer.{layer_idx}.normalization.{attr}"
+                    );
                 }
                 if let Some(suffix) = field.strip_prefix("downsample.0.") {
-                    return format!("resnet.encoder.stages.{stage}.layers.{block}.shortcut.convolution.{suffix}");
+                    return format!(
+                        "resnet.encoder.stages.{stage}.layers.{block}.shortcut.convolution.{suffix}"
+                    );
                 }
                 if let Some(suffix) = field.strip_prefix("downsample.1.") {
-                    return format!("resnet.encoder.stages.{stage}.layers.{block}.shortcut.normalization.{suffix}");
+                    return format!(
+                        "resnet.encoder.stages.{stage}.layers.{block}.shortcut.normalization.{suffix}"
+                    );
                 }
             }
         }
@@ -238,8 +246,6 @@ fn load_resnet_weights(session: &mut meganeura::Session, model: &SafeTensorsMode
         .tensor_f32_auto_transposed(&hf_name("fc.weight"))
         .expect("fc weight");
     session.set_parameter("fc.weight", &fc_w);
-    let fc_b = model
-        .tensor_f32_auto(&hf_name("fc.bias"))
-        .expect("fc bias");
+    let fc_b = model.tensor_f32_auto(&hf_name("fc.bias")).expect("fc bias");
     session.set_parameter("fc.bias", &fc_b);
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -405,9 +405,7 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::MultiHeadAttnGradQ => parse_wgsl(include_str!("shaders/mha_grad_q.wgsl")),
         ShaderGroup::FlashGradQ => generate_flash_grad_q_module(64),
         ShaderGroup::MultiHeadAttnGradK => parse_wgsl(include_str!("shaders/mha_grad_k.wgsl")),
-        ShaderGroup::MultiHeadAttnGradKV => {
-            parse_wgsl(include_str!("shaders/mha_grad_kv.wgsl"))
-        }
+        ShaderGroup::MultiHeadAttnGradKV => parse_wgsl(include_str!("shaders/mha_grad_kv.wgsl")),
         ShaderGroup::FlashGradKV => generate_flash_grad_kv_module(64),
         ShaderGroup::MultiHeadAttnGradV => parse_wgsl(include_str!("shaders/mha_grad_v.wgsl")),
         ShaderGroup::SwiGLUGrad => parse_wgsl(include_str!("shaders/swiglu_grad.wgsl")),
@@ -1322,7 +1320,9 @@ pub fn generate_attention_module(head_dim: u32) -> ShaderModule {
     src.push_str("    let kv_len = select(kv_seq, pos + 1u, kv_seq == 0u);\n");
     // Sliding window: window_size>0 limits how far back we attend
     src.push_str("    let window_size = params.window_size;\n");
-    src.push_str("    let kv_start = select(0u, kv_len - min(kv_len, window_size), window_size > 0u);\n\n");
+    src.push_str(
+        "    let kv_start = select(0u, kv_len - min(kv_len, window_size), window_size > 0u);\n\n",
+    );
 
     // GQA head mapping
     src.push_str("    let kv_head = head / (num_heads / num_kv_heads);\n");
@@ -1339,7 +1339,10 @@ pub fn generate_attention_module(head_dim: u32) -> ShaderModule {
 
     // --- Tiled KV loop: process BKV positions per reduction ---
     let _ = writeln!(src, "    let kv_range = kv_len - kv_start;");
-    let _ = writeln!(src, "    let tile_end = kv_start + (kv_range / {bkv}u) * {bkv}u;");
+    let _ = writeln!(
+        src,
+        "    let tile_end = kv_start + (kv_range / {bkv}u) * {bkv}u;"
+    );
     src.push_str("    var t = kv_start;\n");
     let _ = writeln!(src, "    for (; t < tile_end; t += {bkv}u) {{");
     let _ = writeln!(src, "        for (var i = 0u; i < {bkv}u; i++) {{");
@@ -1510,7 +1513,9 @@ pub fn generate_flash_attention_module(head_dim: u32) -> ShaderModule {
     src.push_str("    let valid = pos < q_seq && head < num_heads;\n\n");
 
     // Per-position KV range (causal + sliding window)
-    src.push_str("    let my_kv_len = select(kv_seq, select(pos + 1u, 0u, !valid), kv_seq == 0u);\n");
+    src.push_str(
+        "    let my_kv_len = select(kv_seq, select(pos + 1u, 0u, !valid), kv_seq == 0u);\n",
+    );
     src.push_str("    let window_size = params.window_size;\n");
     src.push_str("    let my_kv_start = select(0u, my_kv_len - min(my_kv_len, window_size), window_size > 0u);\n\n");
 
@@ -1518,7 +1523,10 @@ pub fn generate_flash_attention_module(head_dim: u32) -> ShaderModule {
     // loop range so they hit identical barriers.
     // max_kv_len: from the LAST valid position in the tile (largest range).
     // min_kv_start: from the FIRST position in the tile (earliest start).
-    let _ = writeln!(src, "    let last_pos = min(wgid.x * {bq}u + {bq}u - 1u, q_seq - 1u);");
+    let _ = writeln!(
+        src,
+        "    let last_pos = min(wgid.x * {bq}u + {bq}u - 1u, q_seq - 1u);"
+    );
     let _ = writeln!(src, "    let first_pos = wgid.x * {bq}u;");
     src.push_str("    let max_kv_len = select(kv_seq, last_pos + 1u, kv_seq == 0u);\n");
     src.push_str("    let first_kv_len = select(kv_seq, first_pos + 1u, kv_seq == 0u);\n");
@@ -1559,27 +1567,15 @@ pub fn generate_flash_attention_module(head_dim: u32) -> ShaderModule {
     for l in 0..loads_per_thread {
         let offset = l * wg_size;
         if offset == 0 {
-            let _ = writeln!(
-                src,
-                "        if lid.x < {k_tile_size}u {{"
-            );
-            let _ = writeln!(
-                src,
-                "            let ki = lid.x / {hd}u;"
-            );
+            let _ = writeln!(src, "        if lid.x < {k_tile_size}u {{");
+            let _ = writeln!(src, "            let ki = lid.x / {hd}u;");
             src.push_str(
                 "            shared_k[lid.x] = src_b[(t + ki) * kv_dim + kv_head_off + (lid.x % head_dim)];\n",
             );
             src.push_str("        }\n");
         } else {
-            let _ = writeln!(
-                src,
-                "        if lid.x + {offset}u < {k_tile_size}u {{"
-            );
-            let _ = writeln!(
-                src,
-                "            let ki2 = (lid.x + {offset}u) / {hd}u;"
-            );
+            let _ = writeln!(src, "        if lid.x + {offset}u < {k_tile_size}u {{");
+            let _ = writeln!(src, "            let ki2 = (lid.x + {offset}u) / {hd}u;");
             let _ = writeln!(
                 src,
                 "            shared_k[lid.x + {offset}u] = src_b[(t + ki2) * kv_dim + kv_head_off + ((lid.x + {offset}u) % head_dim)];"
@@ -1590,11 +1586,7 @@ pub fn generate_flash_attention_module(head_dim: u32) -> ShaderModule {
     src.push_str("        workgroupBarrier();\n\n");
 
     // Each group computes BKV dot products using shared K
-    let _ = writeln!(
-        src,
-        "        let grp_base = qi * {}u;",
-        bkv * hd
-    );
+    let _ = writeln!(src, "        let grp_base = qi * {}u;", bkv * hd);
     let _ = writeln!(src, "        for (var i = 0u; i < {bkv}u; i++) {{");
     let _ = writeln!(
         src,
@@ -1616,12 +1608,8 @@ pub fn generate_flash_attention_module(head_dim: u32) -> ShaderModule {
     src.push_str("                let correction = exp(max_score - new_max);\n");
     src.push_str("                let weight = exp(score - new_max);\n");
     src.push_str("                sum_exp = sum_exp * correction + weight;\n");
-    src.push_str(
-        "                let v_base = kv_pos * kv_dim + kv_head_off;\n",
-    );
-    src.push_str(
-        "                my_out = my_out * correction + weight * bias[v_base + d];\n",
-    );
+    src.push_str("                let v_base = kv_pos * kv_dim + kv_head_off;\n");
+    src.push_str("                my_out = my_out * correction + weight * bias[v_base + d];\n");
     src.push_str("                max_score = new_max;\n");
     src.push_str("            }\n");
     src.push_str("        }\n");
@@ -1633,23 +1621,15 @@ pub fn generate_flash_attention_module(head_dim: u32) -> ShaderModule {
     src.push_str("    for (; t < max_kv_len; t++) {\n");
     // Load single K position into shared_k (first hd threads)
     let _ = writeln!(src, "        if lid.x < {hd}u {{");
-    src.push_str(
-        "            shared_k[lid.x] = src_b[t * kv_dim + kv_head_off + lid.x];\n",
-    );
+    src.push_str("            shared_k[lid.x] = src_b[t * kv_dim + kv_head_off + lid.x];\n");
     src.push_str("        }\n");
     src.push_str("        workgroupBarrier();\n\n");
 
     // Each group computes dot product using shared K
     let _ = writeln!(src, "        let dot_base = qi * {hd}u;");
-    let _ = writeln!(
-        src,
-        "        wg_dot[dot_base + d] = q_val * shared_k[d];"
-    );
+    let _ = writeln!(src, "        wg_dot[dot_base + d] = q_val * shared_k[d];");
     src.push_str("        tree_reduce_grouped(lid.x);\n");
-    let _ = writeln!(
-        src,
-        "        let score = wg_dot[qi * {hd}u] * scale;\n"
-    );
+    let _ = writeln!(src, "        let score = wg_dot[qi * {hd}u] * scale;\n");
 
     // Per-position causal mask
     src.push_str("        if valid && t >= my_kv_start && t < my_kv_len {\n");
@@ -1675,9 +1655,7 @@ pub fn generate_flash_attention_module(head_dim: u32) -> ShaderModule {
     src.push_str("        if d == 0u {\n");
     src.push_str("            let idx = (pos * num_heads + head) * 2u;\n");
     src.push_str("            lse[idx] = max_score;\n");
-    src.push_str(
-        "            lse[idx + 1u] = select(log(sum_exp), -1e30, sum_exp == 0.0);\n",
-    );
+    src.push_str("            lse[idx + 1u] = select(log(sum_exp), -1e30, sum_exp == 0.0);\n");
     src.push_str("        }\n");
     src.push_str("    }\n");
     src.push_str("}\n");
@@ -1735,7 +1713,10 @@ pub fn generate_flash_grad_q_module(head_dim: u32) -> ShaderModule {
     let mut stride = hd / 2;
     while stride > 0 {
         src.push_str("    workgroupBarrier();\n");
-        let _ = writeln!(src, "    if local < {stride}u {{ wg_a[base + local] += wg_a[base + local + {stride}u]; wg_b[base + local] += wg_b[base + local + {stride}u]; }}");
+        let _ = writeln!(
+            src,
+            "    if local < {stride}u {{ wg_a[base + local] += wg_a[base + local + {stride}u]; wg_b[base + local] += wg_b[base + local + {stride}u]; }}"
+        );
         stride /= 2;
     }
     src.push_str("    workgroupBarrier();\n}\n\n");
@@ -1747,7 +1728,10 @@ pub fn generate_flash_grad_q_module(head_dim: u32) -> ShaderModule {
     stride = hd / 2;
     while stride > 0 {
         src.push_str("    workgroupBarrier();\n");
-        let _ = writeln!(src, "    if local < {stride}u {{ wg_a[base + local] += wg_a[base + local + {stride}u]; }}");
+        let _ = writeln!(
+            src,
+            "    if local < {stride}u {{ wg_a[base + local] += wg_a[base + local + {stride}u]; }}"
+        );
         stride /= 2;
     }
     src.push_str("    workgroupBarrier();\n}\n\n");
@@ -1787,11 +1771,18 @@ pub fn generate_flash_grad_q_module(head_dim: u32) -> ShaderModule {
     src.push_str("    let row_sum = wg_a[grp];\n\n");
 
     // Per-position KV range
-    src.push_str("    let my_kv_len = select(kv_seq, select(pos + 1u, 0u, !valid), kv_seq == 0u);\n");
+    src.push_str(
+        "    let my_kv_len = select(kv_seq, select(pos + 1u, 0u, !valid), kv_seq == 0u);\n",
+    );
     src.push_str("    let window = params.window_size;\n");
-    src.push_str("    let my_kv_start = select(0u, my_kv_len - min(my_kv_len, window), window > 0u);\n");
+    src.push_str(
+        "    let my_kv_start = select(0u, my_kv_len - min(my_kv_len, window), window > 0u);\n",
+    );
     // Workgroup-wide bounds
-    let _ = writeln!(src, "    let last_pos = min(wgid.x * {bq}u + {bq}u - 1u, q_seq - 1u);");
+    let _ = writeln!(
+        src,
+        "    let last_pos = min(wgid.x * {bq}u + {bq}u - 1u, q_seq - 1u);"
+    );
     let _ = writeln!(src, "    let first_pos = wgid.x * {bq}u;");
     src.push_str("    let max_kv_len = select(kv_seq, last_pos + 1u, kv_seq == 0u);\n");
     src.push_str("    let first_kv_len = select(kv_seq, first_pos + 1u, kv_seq == 0u);\n");
@@ -1829,9 +1820,15 @@ pub fn generate_flash_grad_q_module(head_dim: u32) -> ShaderModule {
     src.push_str("}\n");
 
     let module = naga::front::wgsl::parse_str(&src).unwrap_or_else(|e| {
-        panic!("generated flash grad_q WGSL failed to parse:\n{}\n---\n{}", e, src)
+        panic!(
+            "generated flash grad_q WGSL failed to parse:\n{}\n---\n{}",
+            e, src
+        )
     });
-    ShaderModule { module, source: src }
+    ShaderModule {
+        module,
+        source: src,
+    }
 }
 
 /// Generate a Flash Attention 2 backward dK/dV kernel with BKV>1 tiling.
@@ -1878,7 +1875,10 @@ pub fn generate_flash_grad_kv_module(head_dim: u32) -> ShaderModule {
     let mut stride = hd / 2;
     while stride > 0 {
         src.push_str("    workgroupBarrier();\n");
-        let _ = writeln!(src, "    if local < {stride}u {{ wg_a[base + local] += wg_a[base + local + {stride}u]; wg_b[base + local] += wg_b[base + local + {stride}u]; wg_c[base + local] += wg_c[base + local + {stride}u]; }}");
+        let _ = writeln!(
+            src,
+            "    if local < {stride}u {{ wg_a[base + local] += wg_a[base + local + {stride}u]; wg_b[base + local] += wg_b[base + local + {stride}u]; wg_c[base + local] += wg_c[base + local + {stride}u]; }}"
+        );
         stride /= 2;
     }
     src.push_str("    workgroupBarrier();\n}\n\n");
@@ -1917,7 +1917,10 @@ pub fn generate_flash_grad_kv_module(head_dim: u32) -> ShaderModule {
     // All groups must agree on the loop range for barriers
     // start_pos depends on t (per-group for causal). Use min across groups.
     let _ = writeln!(src, "    let first_t = wgid.x * {bkv}u;");
-    let _ = writeln!(src, "    let last_t = min(wgid.x * {bkv}u + {bkv}u - 1u, effective_kv_seq - 1u);");
+    let _ = writeln!(
+        src,
+        "    let last_t = min(wgid.x * {bkv}u + {bkv}u - 1u, effective_kv_seq - 1u);"
+    );
     src.push_str("    let wg_start = select(0u, first_t, kv_seq == 0u);\n");
     src.push_str("    let wg_end = select(q_seq, min(q_seq, last_t + window), window > 0u);\n\n");
 
@@ -1938,7 +1941,9 @@ pub fn generate_flash_grad_kv_module(head_dim: u32) -> ShaderModule {
     let _ = writeln!(src, "            let grp = ki * {hd}u;");
     src.push_str("            wg_a[grp + d] = shared_q[d] * k_val;\n");
     src.push_str("            wg_b[grp + d] = shared_do[d] * shared_o[d];\n");
-    src.push_str("            wg_c[grp + d] = shared_do[d] * select(0.0, bias[kv_base + d], valid);\n");
+    src.push_str(
+        "            wg_c[grp + d] = shared_do[d] * select(0.0, bias[kv_base + d], valid);\n",
+    );
     src.push_str("            grouped_triple_reduce(lid.x);\n\n");
 
     // Per-position mask: does Q position `pos` attend to KV position `t`?
@@ -1947,7 +1952,9 @@ pub fn generate_flash_grad_kv_module(head_dim: u32) -> ShaderModule {
     src.push_str("                let row_sum = wg_b[grp];\n");
     src.push_str("                let dp_t = wg_c[grp];\n");
     src.push_str("                let lse_idx = (pos * num_heads + head) * 2u;\n");
-    src.push_str("                let p_t = exp(min(score - lse[lse_idx], 0.0) - lse[lse_idx + 1u]);\n");
+    src.push_str(
+        "                let p_t = exp(min(score - lse[lse_idx], 0.0) - lse[lse_idx + 1u]);\n",
+    );
     src.push_str("                let ds_t = p_t * (dp_t - row_sum);\n");
     src.push_str("                my_dk += ds_t * scale * shared_q[d];\n");
     src.push_str("                my_dv += p_t * shared_do[d];\n");
@@ -1963,9 +1970,15 @@ pub fn generate_flash_grad_kv_module(head_dim: u32) -> ShaderModule {
     src.push_str("}\n");
 
     let module = naga::front::wgsl::parse_str(&src).unwrap_or_else(|e| {
-        panic!("generated flash grad_kv WGSL failed to parse:\n{}\n---\n{}", e, src)
+        panic!(
+            "generated flash grad_kv WGSL failed to parse:\n{}\n---\n{}",
+            e, src
+        )
     });
-    ShaderModule { module, source: src }
+    ShaderModule {
+        module,
+        source: src,
+    }
 }
 
 fn gen_conv2d_gemm_coop() -> ShaderModule {
@@ -2245,10 +2258,7 @@ mod tests {
                 ShaderGroup::MultiHeadAttnGradQ,
                 naga::valid::Capabilities::empty(),
             ),
-            (
-                ShaderGroup::FlashGradQ,
-                naga::valid::Capabilities::empty(),
-            ),
+            (ShaderGroup::FlashGradQ, naga::valid::Capabilities::empty()),
             (
                 ShaderGroup::MultiHeadAttnGradK,
                 naga::valid::Capabilities::empty(),
@@ -2257,10 +2267,7 @@ mod tests {
                 ShaderGroup::MultiHeadAttnGradKV,
                 naga::valid::Capabilities::empty(),
             ),
-            (
-                ShaderGroup::FlashGradKV,
-                naga::valid::Capabilities::empty(),
-            ),
+            (ShaderGroup::FlashGradKV, naga::valid::Capabilities::empty()),
             (
                 ShaderGroup::MultiHeadAttnGradV,
                 naga::valid::Capabilities::empty(),

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -295,9 +295,9 @@ impl ShaderEntry {
             ShaderEntry::Upsample2x => "main",
             ShaderEntry::Upsample2xGrad => "main",
             ShaderEntry::Conv2d => "main",
-            ShaderEntry::Conv2dGemm | ShaderEntry::Conv2dGemmSmall | ShaderEntry::Conv2dGemmCoop => {
-                "main"
-            }
+            ShaderEntry::Conv2dGemm
+            | ShaderEntry::Conv2dGemmSmall
+            | ShaderEntry::Conv2dGemmCoop => "main",
             ShaderEntry::Conv2dGradInput => "main",
             ShaderEntry::Conv2dGradInputGemm
             | ShaderEntry::Conv2dGradInputGemmSmall
@@ -1077,7 +1077,10 @@ impl<'a> Compiler<'a> {
     fn attention_dispatch(q_seq: u32, head_dim: u32, num_heads: u32) -> (ShaderEntry, [u32; 3]) {
         let bq = (256 / head_dim).max(1);
         if bq >= 2 && q_seq >= bq {
-            (ShaderEntry::FlashAttention, [q_seq.div_ceil(bq), num_heads, 1])
+            (
+                ShaderEntry::FlashAttention,
+                [q_seq.div_ceil(bq), num_heads, 1],
+            )
         } else {
             (ShaderEntry::MultiHeadAttn, [q_seq, num_heads, 1])
         }
@@ -1839,7 +1842,13 @@ impl<'a> Compiler<'a> {
                     input_buffers: vec![q, k, v],
                     output_buffer: out_buf,
                     extra_outputs: vec![lse_buf],
-                    params: vec![seq, 0, (num_heads << 16) | num_kv_heads, head_dim, window_size],
+                    params: vec![
+                        seq,
+                        0,
+                        (num_heads << 16) | num_kv_heads,
+                        head_dim,
+                        window_size,
+                    ],
                     use_coop: false,
                     use_small_tiles: false,
                     ..Default::default()
@@ -2631,9 +2640,7 @@ impl<'a> Compiler<'a> {
 
                 // Fused GradKV: pre-allocate dV buffer. When GradV is later
                 // compiled for the same fwd_node, it reuses this buffer.
-                let dv_buf = self.alloc_buffer(
-                    self.graph.node(node.inputs[3]).ty.size_bytes(),
-                );
+                let dv_buf = self.alloc_buffer(self.graph.node(node.inputs[3]).ty.size_bytes());
                 self.fused_grad_kv_dv.insert(fwd_node, dv_buf);
                 let (grad_kv_shader, grad_kv_wgs) =
                     Self::attention_dispatch(dispatch_kv, head_dim, num_kv_heads);
@@ -2816,8 +2823,7 @@ impl<'a> Compiler<'a> {
                     // Two-pass row-parallel approach for better GPU occupancy:
                     // Pass 1: one WG per row computes partial[row,col] = dy*x*rsqrt
                     // Pass 2: SumRows reduces partial → grad_w[col]
-                    let temp_buf =
-                        self.alloc_buffer((rows as usize) * (cols as usize) * 4);
+                    let temp_buf = self.alloc_buffer((rows as usize) * (cols as usize) * 4);
                     self.plan.dispatches.push(Dispatch {
                         shader: ShaderEntry::RmsNormGradWRowPar,
                         workgroups: [rows, 1, 1],
@@ -2885,8 +2891,7 @@ impl<'a> Compiler<'a> {
                 let cols = x_shape[1] as u32;
                 if rows >= 4 {
                     // Row-parallel: each WG handles one row, SumRows reduces.
-                    let temp_buf =
-                        self.alloc_buffer((rows as usize) * (cols as usize) * 4);
+                    let temp_buf = self.alloc_buffer((rows as usize) * (cols as usize) * 4);
                     self.plan.dispatches.push(Dispatch {
                         shader: ShaderEntry::LayerNormGradWB,
                         workgroups: [rows, 1, 1],

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -49,14 +49,10 @@ impl std::fmt::Display for MemorySummary {
 ///
 /// On discrete GPUs (NVIDIA, AMD dGPU), tensor core throughput is so much higher
 /// than scalar ALUs that the coop path wins even at moderate workgroup counts.
-/// A threshold of 8 allows coop for most practical matmul shapes while avoiding
-/// extremely small dispatches (e.g. 1×1 tile grids) where the overhead dominates.
-///
-/// On integrated GPUs with few CUs, the scalar path may still be faster at low
-/// workgroup counts due to limited parallelism, but the coop path self-selects
-/// out when the GPU doesn't advertise cooperative matrix support.
-const MIN_COOP_WORKGROUPS: u32 = 32;
-const MIN_COOP_WORKGROUPS_HIGH_K: u32 = 32;
+/// Minimum cooperative matrix workgroups for conv2d backward GEMM.
+/// Conv2d backward has all-scalar staging with heavy im2col decomposition
+/// and only 64 threads vs 256 for the scalar shader.
+const MIN_COOP_WORKGROUPS_CONV_BWD: u32 = 64;
 
 // ---- ShaderData structs matching codegen global variable names ----
 
@@ -275,7 +271,6 @@ struct FourBufData {
     dst: blade_graphics::BufferPiece,
     params: MatMulParams,
 }
-
 
 // rope_dynamic: var src, dst, pos_offset_buf, params
 #[derive(blade_macros::ShaderData)]
@@ -733,12 +728,8 @@ impl Pipelines {
                     ShaderGroup::FlashAttention => {
                         crate::codegen::generate_flash_attention_module(hd)
                     }
-                    ShaderGroup::FlashGradQ => {
-                        crate::codegen::generate_flash_grad_q_module(hd)
-                    }
-                    ShaderGroup::FlashGradKV => {
-                        crate::codegen::generate_flash_grad_kv_module(hd)
-                    }
+                    ShaderGroup::FlashGradQ => crate::codegen::generate_flash_grad_q_module(hd),
+                    ShaderGroup::FlashGradKV => crate::codegen::generate_flash_grad_kv_module(hd),
                     _ => crate::codegen::generate_attention_module(hd),
                 };
                 let shader = gpu.create_shader(bg::ShaderDesc {
@@ -995,9 +986,9 @@ fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayout {
         }
         ShaderEntry::SwiGLUGradGate => TernaryData::layout(),
         ShaderEntry::SwiGLUGradUp | ShaderEntry::SiluGrad => BinaryData::layout(),
-        ShaderEntry::RmsNormGradW
-        | ShaderEntry::RmsNormGradWRowPar
-        | ShaderEntry::RmsNormGradX => FourBufData::layout(),
+        ShaderEntry::RmsNormGradW | ShaderEntry::RmsNormGradWRowPar | ShaderEntry::RmsNormGradX => {
+            FourBufData::layout()
+        }
         ShaderEntry::LayerNormGradWB | ShaderEntry::LayerNormGradX => FourBufData::layout(),
         ShaderEntry::FusedRmsNormMatMul => FourBufData::layout(),
         ShaderEntry::RmsNormRsqrt => UnaryData::layout(),
@@ -1377,7 +1368,7 @@ impl Session {
             for dispatch in &mut plan.dispatches {
                 let group = dispatch.shader.shader_group();
                 // Extract (m, n, k, batch) from dispatch params based on shader group.
-                let (m, n, k, batch) = match group {
+                let (m, n, _k, batch) = match group {
                     ShaderGroup::MatMul | ShaderGroup::MatMulAdd => (
                         dispatch.params[0],
                         dispatch.params[2],
@@ -1427,11 +1418,9 @@ impl Session {
                 // for the scalar shader. Require more workgroups to amortize.
                 let is_conv_bwd = matches!(group, ShaderGroup::Conv2dGradInputGemm);
                 let min_wgs = if is_conv_bwd {
-                    64
-                } else if k >= 1024 {
-                    MIN_COOP_WORKGROUPS_HIGH_K
+                    MIN_COOP_WORKGROUPS_CONV_BWD
                 } else {
-                    MIN_COOP_WORKGROUPS
+                    16 // enables coop for attention K/V projections (N=320, 20 WGs)
                 };
                 if coop_wgs >= min_wgs {
                     dispatch.use_coop = true;
@@ -1461,27 +1450,27 @@ impl Session {
         // produces very few workgroups (< 16). The 4× more workgroups from
         // smaller tiles improve occupancy on GPUs with many SMs.
         {
-        use crate::codegen::ShaderGroup;
-        for dispatch in plan.dispatches.iter_mut() {
-            if dispatch.use_coop || dispatch.use_small_tiles {
-                continue;
+            use crate::codegen::ShaderGroup;
+            for dispatch in plan.dispatches.iter_mut() {
+                if dispatch.use_coop || dispatch.use_small_tiles {
+                    continue;
+                }
+                let group = dispatch.shader.shader_group();
+                let wgs_64: u32 = dispatch.workgroups.iter().product();
+                let has_small = matches!(
+                    group,
+                    ShaderGroup::MatMul
+                        | ShaderGroup::MatMulAdd
+                        | ShaderGroup::MatMulAT
+                        | ShaderGroup::MatMulBT
+                );
+                if has_small && wgs_64 < 16 {
+                    dispatch.use_small_tiles = true;
+                    // 32×32 tiles → double the WG count in each spatial dimension
+                    dispatch.workgroups[0] *= 2;
+                    dispatch.workgroups[1] *= 2;
+                }
             }
-            let group = dispatch.shader.shader_group();
-            let wgs_64: u32 = dispatch.workgroups.iter().product();
-            let has_small = matches!(
-                group,
-                ShaderGroup::MatMul
-                    | ShaderGroup::MatMulAdd
-                    | ShaderGroup::MatMulAT
-                    | ShaderGroup::MatMulBT
-            );
-            if has_small && wgs_64 < 16 {
-                dispatch.use_small_tiles = true;
-                // 32×32 tiles → double the WG count in each spatial dimension
-                dispatch.workgroups[0] *= 2;
-                dispatch.workgroups[1] *= 2;
-            }
-        }
         }
 
         // Reorder dispatches by dependency level so parallel branches (e.g. Q/K/V

--- a/src/train.rs
+++ b/src/train.rs
@@ -269,10 +269,7 @@ pub struct SessionConfig<'a> {
 /// Build stages (`optimize_forward`, `autodiff`, `optimize_full`,
 /// `compile`, `gpu_init`) are captured as tracing spans and appear in
 /// Perfetto traces when profiling is active.
-pub fn build(
-    forward_graph: &Graph,
-    cfg: SessionConfig<'_>,
-) -> (Session, OptimizeReport) {
+pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, OptimizeReport) {
     let _span = tracing::info_span!("build_session").entered();
     log::info!("building {:?} session", cfg.mode);
     log::info!("forward graph:\n{}", forward_graph);
@@ -295,7 +292,10 @@ pub fn build(
         let _span = tracing::info_span!("optimize_forward").entered();
         optimize::optimize_with_report(forward_graph)
     };
-    log::info!("optimized forward: {} nodes", optimized_forward.nodes().len());
+    log::info!(
+        "optimized forward: {} nodes",
+        optimized_forward.nodes().len()
+    );
 
     let (final_graph, report) = match cfg.mode {
         Mode::Inference => {
@@ -320,7 +320,10 @@ pub fn build(
                 let _span = tracing::info_span!("autodiff").entered();
                 autodiff::differentiate(&sorted)
             };
-            log::info!("full graph (forward + backward): {} nodes", full.nodes().len());
+            log::info!(
+                "full graph (forward + backward): {} nodes",
+                full.nodes().len()
+            );
             if cfg.skip_full_optimize {
                 (full, forward_report)
             } else {


### PR DESCRIPTION
Enables tensor cores for attention K/V projections (N=320, 20 WGs) that were previously stuck on the scalar matmul path. Saves ~0.4ms per SmolVLA inference step on the K projection matmuls.

Also adds per-dispatch GPU profiling to the SmolVLA benchmark (set_profiling + dump_gpu_timings after a double-buffered drain cycle).