### PR TITLE
Add external buffer interop for GPU-to-GPU data sharing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ name = "mnist"
 path = "examples/mnist.rs"
 
 [[example]]
+name = "external_buffer"
+path = "examples/external_buffer.rs"
+
+[[example]]
 name = "diffusion"
 path = "examples/diffusion.rs"
 

--- a/examples/external_buffer.rs
+++ b/examples/external_buffer.rs
@@ -1,80 +1,100 @@
-//! External object interop: share a GPU buffer between a standalone
-//! Blade context (playing the role of a host renderer / game engine)
-//! and meganeura.
+//! External object interop: share a GPU buffer between two fully
+//! independent Blade contexts.
 //!
-//! The input tensor is allocated and populated *outside* meganeura —
-//! directly on a `blade_graphics::Context` the caller owns. Meganeura
-//! then consumes that buffer in place, runs a small compute graph, and
-//! we read the result back to CPU at the end.
+//! The host application (playing the role of a game engine, renderer,
+//! or any producer that already has tensor data on the GPU) owns its
+//! own `blade_graphics::Context`. Meganeura owns a *separate* context.
+//! The two are connected only through the shared underlying memory of
+//! an external-memory allocation: the producer exports an
+//! `ExternalMemorySource` handle (a Vulkan opaque FD, a DMA-BUF, a
+//! Win32 HANDLE, or a host pointer), meganeura re-imports it into its
+//! own context, and both see the same bytes with no CPU roundtrip on
+//! the input path.
 //!
-//! This mirrors the intended embedding pattern: the host app already
-//! has its data resident on the GPU (from rendering, simulation, a
-//! game engine, ...), and we want neural inference to consume it
-//! without a CPU roundtrip.
+//! This example uses `ExternalMemorySource::HostAllocation` because
+//! it's the one variant that lets us populate the memory with a plain
+//! CPU memcpy without standing up a staging + compute pipeline on the
+//! producer side. The same API works for FD / DMA-BUF / Win32 handles
+//! — see [`blade_graphics::ExternalMemorySource`].
+//!
+//! Platform note: Blade's external-memory implementation is Vulkan
+//! only at the moment; the Metal and GLES backends will panic from
+//! `unimplemented!()` during the import.
 
-use std::sync::Arc;
+use std::alloc::{Layout, alloc_zeroed, dealloc};
 
 use blade_graphics as bg;
-use meganeura::{ExternalSlot, Graph, Mode, SessionConfig, build};
+use meganeura::{ExternalSlot, Graph, build_inference_session};
 
 fn main() {
     env_logger::init();
 
-    // --- Host application's Blade context ---
-    //
-    // In a real embedding this is owned by the renderer / game. We
-    // wrap it in `Arc` so both sides can share it.
-    let gpu = Arc::new(
-        unsafe {
-            bg::Context::init(bg::ContextDesc {
-                validation: cfg!(debug_assertions),
-                timing: false,
-                capture: false,
-                overlay: false,
-                device_id: std::env::var("MEGANEURA_DEVICE_ID")
-                    .ok()
-                    .and_then(|s| s.parse().ok()),
-                ..Default::default()
-            })
-        }
-        .expect("failed to initialise blade GPU context"),
-    );
-    eprintln!(
-        "running on {}",
-        gpu.device_information().device_name
-    );
-
-    // Problem: y = relu(x @ W), where:
-    //   x is a [ROWS, COLS] tensor the *host* produced
-    //   W is a [COLS, OUT] weight matrix owned by meganeura
+    // Problem: y = relu(x @ W)
     const ROWS: usize = 4;
     const COLS: usize = 6;
     const OUT: usize = 3;
+    const INPUT_BYTES: usize = ROWS * COLS * 4;
+    // HostAllocation imports have a driver-imposed alignment requirement
+    // (minImportedHostPointerAlignment — typically 64 or the page size).
+    // A page-sized alignment is always safe.
+    const ALIGN: usize = 4096;
 
-    // --- Step 1: host allocates and fills the input buffer on the GPU ---
+    // Allocate page-aligned zeroed host memory. The producer writes
+    // into it, both contexts import it by pointer.
     //
-    // `Memory::Shared` gives us a host-visible, coherent mapping so we
-    // can write into it with a plain pointer. In a real embedding the
-    // buffer might instead be written by the host's own compute/blit
-    // dispatches, or be device-local and populated via staging.
-    let input_bytes = (ROWS * COLS * 4) as u64;
-    let external_input = gpu.create_buffer(bg::BufferDesc {
-        name: "external_input",
-        size: input_bytes,
-        memory: bg::Memory::Shared,
+    // Safety: the layout is valid (non-zero size, power-of-two align).
+    let layout = Layout::from_size_align(INPUT_BYTES, ALIGN).unwrap();
+    let host_ptr = unsafe { alloc_zeroed(layout) };
+    assert!(!host_ptr.is_null(), "host allocation failed");
+
+    // --- Producer context (fully independent of meganeura) ---
+    //
+    // In a real app this is owned by the host engine. Here we spin up
+    // a standalone Blade context to play the role convincingly.
+    let producer = unsafe {
+        bg::Context::init(bg::ContextDesc {
+            validation: cfg!(debug_assertions),
+            timing: false,
+            capture: false,
+            overlay: false,
+            device_id: std::env::var("MEGANEURA_DEVICE_ID")
+                .ok()
+                .and_then(|s| s.parse().ok()),
+            ..Default::default()
+        })
+    }
+    .expect("producer context init failed");
+    eprintln!(
+        "producer device : {}",
+        producer.device_information().device_name
+    );
+
+    // Producer imports the host pointer as a GPU buffer. Because the
+    // memory type is `HostAllocation`, Blade maps the buffer so that
+    // `buffer.data()` returns the same pointer back — we can write into
+    // it directly from the CPU side and the producer's shaders would
+    // see those writes.
+    let producer_buf = producer.create_buffer(bg::BufferDesc {
+        name: "producer_input",
+        size: INPUT_BYTES as u64,
+        memory: bg::Memory::External(bg::ExternalMemorySource::HostAllocation(host_ptr as usize)),
     });
+
+    // "Render" / produce the tensor. In reality this would be whatever
+    // GPU work produces the data; here we just fill it from the CPU to
+    // keep the example focused on the interop mechanics.
     unsafe {
-        let p = external_input.data() as *mut f32;
+        let p = producer_buf.data() as *mut f32;
         for i in 0..(ROWS * COLS) {
             *p.add(i) = (i as f32 - 10.0) * 0.25;
         }
     }
     eprintln!(
-        "host-owned input buffer: {} bytes, filled from CPU (no meganeura involved)",
-        input_bytes
+        "producer wrote {} bytes into the shared allocation",
+        INPUT_BYTES
     );
 
-    // --- Step 2: build a meganeura graph that references "x" by name ---
+    // --- Meganeura: build a graph and a session on its OWN context ---
     let mut g = Graph::new();
     let x = g.input("x", &[ROWS, COLS]);
     let w = g.parameter("w", &[COLS, OUT]);
@@ -82,56 +102,51 @@ fn main() {
     let y = g.relu(mm);
     g.set_outputs(vec![y]);
 
-    // --- Step 3: build an inference session on the *shared* context ---
-    //
-    // `SessionConfig::gpu` routes meganeura to reuse our context
-    // instead of initialising its own. That's the precondition for
-    // sharing buffers — both sides must agree on device + queue.
-    let (mut session, _) = build(
-        &g,
-        SessionConfig {
-            mode: Mode::Inference,
-            gpu: Some(Arc::clone(&gpu)),
-            ..SessionConfig::default()
-        },
+    // `build_inference_session` internally calls `Session::new`, which
+    // initialises a fresh `blade_graphics::Context` owned by the
+    // session — no context sharing with `producer`.
+    let mut session = build_inference_session(&g);
+    eprintln!(
+        "meganeura device: {}",
+        session.device_information().device_name
     );
 
-    // --- Step 4: bind the host's buffer to the "x" slot ---
+    // Bind the shared memory to the "x" slot. Meganeura's context
+    // imports the same host pointer through its own
+    // VK_EXT_external_memory_host allocation, so its shaders read from
+    // exactly the bytes the producer wrote.
     //
-    // After this call, meganeura will read `x` from `external_input`
-    // instead of from its own allocation. The internal buffer for "x"
-    // is destroyed immediately; `external_input` is *not* destroyed
-    // on session drop — we retain ownership.
+    // In a pure GPU-to-GPU scenario (FD / DMA-BUF / Win32) the
+    // producer would call `producer.get_external_buffer_source(buf)`
+    // to extract the OS handle and pass that `ExternalMemorySource`
+    // here instead. The API shape is identical.
     let required = session
         .slot_size(ExternalSlot::Input("x"))
-        .expect("graph has an input named x");
-    assert!(input_bytes as usize >= required);
+        .expect("graph input 'x'");
+    assert!(INPUT_BYTES >= required);
+    let source = bg::ExternalMemorySource::HostAllocation(host_ptr as usize);
     session
-        .bind_external_buffer(ExternalSlot::Input("x"), external_input)
-        .expect("bind external input");
+        .bind_external_buffer(ExternalSlot::Input("x"), source, INPUT_BYTES as u64)
+        .expect("import external buffer");
 
-    // Upload weights via the usual path. We could also allocate W
-    // externally and bind via `ExternalSlot::Parameter("w")`.
-    let w_data: Vec<f32> = (0..(COLS * OUT))
-        .map(|i| (i as f32 - 8.0) * 0.1)
-        .collect();
+    // Weights go through the usual upload path. They could equally
+    // well be imported via `ExternalSlot::Parameter("w")`.
+    let w_data: Vec<f32> = (0..(COLS * OUT)).map(|i| (i as f32 - 8.0) * 0.1).collect();
     session.set_parameter("w", &w_data);
 
-    // --- Step 5: run meganeura, read the result back to CPU ---
+    // Run inference, read the output back to CPU.
     session.step();
     session.wait();
-
     let y: Vec<f32> = session.read_output(ROWS * OUT);
+
     println!("y = relu(x @ w)  (shape [{ROWS}, {OUT}]):");
     for row in 0..ROWS {
         let slice = &y[row * OUT..(row + 1) * OUT];
         println!("  {:?}", slice);
     }
 
-    // --- Step 6: cross-check against a CPU reference ---
-    let x_ref: Vec<f32> = (0..(ROWS * COLS))
-        .map(|i| (i as f32 - 10.0) * 0.25)
-        .collect();
+    // Cross-check against a CPU reference.
+    let x_ref: Vec<f32> = (0..(ROWS * COLS)).map(|i| (i as f32 - 10.0) * 0.25).collect();
     let mut cpu = [0.0_f32; ROWS * OUT];
     for r in 0..ROWS {
         for o in 0..OUT {
@@ -150,14 +165,20 @@ fn main() {
     println!("max |gpu - cpu| = {:e}", max_err);
     assert!(max_err < 1e-4, "GPU result diverged from CPU reference");
 
-    // --- Step 7: tear down in the right order ---
-    //
-    // Drop the session first so any GPU work finishes and meganeura
-    // releases its *internal* resources. Then the caller destroys
-    // their buffer, and finally the Arc<Context> drops when the last
-    // reference goes out of scope.
+    // Teardown order matters:
+    // 1. Drop the session. Meganeura waits for any outstanding work and
+    //    releases its Vulkan import of the shared memory. The
+    //    underlying host allocation stays live (producer still holds a
+    //    reference via `producer_buf`).
     drop(session);
-    gpu.destroy_buffer(external_input);
+    // 2. Producer releases its reference, dropping the last import.
+    producer.destroy_buffer(producer_buf);
+    // 3. Now the host memory has no GPU users — safe to free.
+    unsafe {
+        dealloc(host_ptr, layout);
+    }
 
-    println!("done — buffer was shared GPU-to-GPU, no CPU roundtrip on input.");
+    println!(
+        "done — input bytes travelled producer-GPU → meganeura-GPU without any CPU roundtrip."
+    );
 }

--- a/examples/external_buffer.rs
+++ b/examples/external_buffer.rs
@@ -1,0 +1,163 @@
+//! External object interop: share a GPU buffer between a standalone
+//! Blade context (playing the role of a host renderer / game engine)
+//! and meganeura.
+//!
+//! The input tensor is allocated and populated *outside* meganeura —
+//! directly on a `blade_graphics::Context` the caller owns. Meganeura
+//! then consumes that buffer in place, runs a small compute graph, and
+//! we read the result back to CPU at the end.
+//!
+//! This mirrors the intended embedding pattern: the host app already
+//! has its data resident on the GPU (from rendering, simulation, a
+//! game engine, ...), and we want neural inference to consume it
+//! without a CPU roundtrip.
+
+use std::sync::Arc;
+
+use blade_graphics as bg;
+use meganeura::{ExternalSlot, Graph, Mode, SessionConfig, build};
+
+fn main() {
+    env_logger::init();
+
+    // --- Host application's Blade context ---
+    //
+    // In a real embedding this is owned by the renderer / game. We
+    // wrap it in `Arc` so both sides can share it.
+    let gpu = Arc::new(
+        unsafe {
+            bg::Context::init(bg::ContextDesc {
+                validation: cfg!(debug_assertions),
+                timing: false,
+                capture: false,
+                overlay: false,
+                device_id: std::env::var("MEGANEURA_DEVICE_ID")
+                    .ok()
+                    .and_then(|s| s.parse().ok()),
+                ..Default::default()
+            })
+        }
+        .expect("failed to initialise blade GPU context"),
+    );
+    eprintln!(
+        "running on {}",
+        gpu.device_information().device_name
+    );
+
+    // Problem: y = relu(x @ W), where:
+    //   x is a [ROWS, COLS] tensor the *host* produced
+    //   W is a [COLS, OUT] weight matrix owned by meganeura
+    const ROWS: usize = 4;
+    const COLS: usize = 6;
+    const OUT: usize = 3;
+
+    // --- Step 1: host allocates and fills the input buffer on the GPU ---
+    //
+    // `Memory::Shared` gives us a host-visible, coherent mapping so we
+    // can write into it with a plain pointer. In a real embedding the
+    // buffer might instead be written by the host's own compute/blit
+    // dispatches, or be device-local and populated via staging.
+    let input_bytes = (ROWS * COLS * 4) as u64;
+    let external_input = gpu.create_buffer(bg::BufferDesc {
+        name: "external_input",
+        size: input_bytes,
+        memory: bg::Memory::Shared,
+    });
+    unsafe {
+        let p = external_input.data() as *mut f32;
+        for i in 0..(ROWS * COLS) {
+            *p.add(i) = (i as f32 - 10.0) * 0.25;
+        }
+    }
+    eprintln!(
+        "host-owned input buffer: {} bytes, filled from CPU (no meganeura involved)",
+        input_bytes
+    );
+
+    // --- Step 2: build a meganeura graph that references "x" by name ---
+    let mut g = Graph::new();
+    let x = g.input("x", &[ROWS, COLS]);
+    let w = g.parameter("w", &[COLS, OUT]);
+    let mm = g.matmul(x, w);
+    let y = g.relu(mm);
+    g.set_outputs(vec![y]);
+
+    // --- Step 3: build an inference session on the *shared* context ---
+    //
+    // `SessionConfig::gpu` routes meganeura to reuse our context
+    // instead of initialising its own. That's the precondition for
+    // sharing buffers — both sides must agree on device + queue.
+    let (mut session, _) = build(
+        &g,
+        SessionConfig {
+            mode: Mode::Inference,
+            gpu: Some(Arc::clone(&gpu)),
+            ..SessionConfig::default()
+        },
+    );
+
+    // --- Step 4: bind the host's buffer to the "x" slot ---
+    //
+    // After this call, meganeura will read `x` from `external_input`
+    // instead of from its own allocation. The internal buffer for "x"
+    // is destroyed immediately; `external_input` is *not* destroyed
+    // on session drop — we retain ownership.
+    let required = session
+        .slot_size(ExternalSlot::Input("x"))
+        .expect("graph has an input named x");
+    assert!(input_bytes as usize >= required);
+    session
+        .bind_external_buffer(ExternalSlot::Input("x"), external_input)
+        .expect("bind external input");
+
+    // Upload weights via the usual path. We could also allocate W
+    // externally and bind via `ExternalSlot::Parameter("w")`.
+    let w_data: Vec<f32> = (0..(COLS * OUT))
+        .map(|i| (i as f32 - 8.0) * 0.1)
+        .collect();
+    session.set_parameter("w", &w_data);
+
+    // --- Step 5: run meganeura, read the result back to CPU ---
+    session.step();
+    session.wait();
+
+    let y: Vec<f32> = session.read_output(ROWS * OUT);
+    println!("y = relu(x @ w)  (shape [{ROWS}, {OUT}]):");
+    for row in 0..ROWS {
+        let slice = &y[row * OUT..(row + 1) * OUT];
+        println!("  {:?}", slice);
+    }
+
+    // --- Step 6: cross-check against a CPU reference ---
+    let x_ref: Vec<f32> = (0..(ROWS * COLS))
+        .map(|i| (i as f32 - 10.0) * 0.25)
+        .collect();
+    let mut cpu = [0.0_f32; ROWS * OUT];
+    for r in 0..ROWS {
+        for o in 0..OUT {
+            let mut acc = 0.0_f32;
+            for c in 0..COLS {
+                acc += x_ref[r * COLS + c] * w_data[c * OUT + o];
+            }
+            cpu[r * OUT + o] = acc.max(0.0);
+        }
+    }
+    let max_err = y
+        .iter()
+        .zip(cpu.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f32, f32::max);
+    println!("max |gpu - cpu| = {:e}", max_err);
+    assert!(max_err < 1e-4, "GPU result diverged from CPU reference");
+
+    // --- Step 7: tear down in the right order ---
+    //
+    // Drop the session first so any GPU work finishes and meganeura
+    // releases its *internal* resources. Then the caller destroys
+    // their buffer, and finally the Arc<Context> drops when the last
+    // reference goes out of scope.
+    drop(session);
+    gpu.destroy_buffer(external_input);
+
+    println!("done — buffer was shared GPU-to-GPU, no CPU roundtrip on input.");
+}

--- a/examples/external_buffer.rs
+++ b/examples/external_buffer.rs
@@ -146,7 +146,9 @@ fn main() {
     }
 
     // Cross-check against a CPU reference.
-    let x_ref: Vec<f32> = (0..(ROWS * COLS)).map(|i| (i as f32 - 10.0) * 0.25).collect();
+    let x_ref: Vec<f32> = (0..(ROWS * COLS))
+        .map(|i| (i as f32 - 10.0) * 0.25)
+        .collect();
     let mut cpu = [0.0_f32; ROWS * OUT];
     for r in 0..ROWS {
         for o in 0..OUT {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use graph::{DType, Graph, NodeId, TensorType};
 pub use load::nnef::{NnefError, NnefModel, load_nnef};
 pub use load::onnx::{OnnxError, OnnxModel, load_onnx, load_onnx_bytes};
 pub use optimize::OptimizeReport;
-pub use runtime::{MemorySummary, Session};
+pub use runtime::{ExternalBindError, ExternalSlot, MemorySummary, Session};
 pub use train::{
     EpochStats, LossHistory, MetricCallback, Mode, Optimizer, SessionConfig, StepMetrics,
     TrainConfig, TrainHistory, Trainer, build, build_inference_session, build_session,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1120,14 +1120,10 @@ pub struct Session {
     adam_step: u32,
     /// Pending Adam parameters. When set, `step()` appends Adam updates.
     pending_adam: Option<(f32, f32, f32, f32)>, // (lr, beta1, beta2, eps)
-    /// Buffer indices whose GPU allocation is owned by the caller (see
-    /// [`Session::bind_external_buffer`]). Drop skips `destroy_buffer` for
-    /// these — the owner is responsible for destruction.
-    external_buffers: HashSet<u32>,
 }
 
-/// Identifies a graph-facing slot that can be backed by a caller-owned
-/// buffer. See [`Session::bind_external_buffer`].
+/// Identifies a graph-facing slot that can be backed by an imported
+/// external buffer. See [`Session::bind_external_buffer`].
 #[derive(Clone, Copy, Debug)]
 pub enum ExternalSlot<'a> {
     /// Graph input declared by `Graph::input(name, ...)`.
@@ -1143,7 +1139,7 @@ pub enum ExternalSlot<'a> {
 pub enum ExternalBindError {
     /// No input/parameter of that name, or output index out of range.
     UnknownSlot,
-    /// The external buffer is smaller than the slot requires.
+    /// The external handle's backing memory is smaller than the slot.
     TooSmall { required: u64, got: u64 },
 }
 
@@ -1622,96 +1618,124 @@ impl Session {
             adam_state,
             adam_step: 0,
             pending_adam: None,
-            external_buffers: HashSet::new(),
         }
     }
 
-    /// Replace a graph slot's GPU buffer with one allocated by the caller.
+    /// Import an externally-allocated buffer into a graph slot.
     ///
-    /// Intended for interop with host applications (renderers, game
-    /// engines) that already have tensor data resident on the GPU.
-    /// Meganeura binds the caller's buffer in place of its internal
-    /// allocation, so forward/backward passes read from (or write into)
-    /// it directly — no CPU roundtrip.
+    /// This is true cross-context interop: a producer — a game engine,
+    /// renderer, video decoder, other ML framework — allocates the
+    /// buffer in *its own* Blade context using `Memory::External(...)`,
+    /// then queries the OS handle via the producer context's
+    /// `get_external_buffer_source(...)`. Passing that
+    /// `ExternalMemorySource` here tells meganeura's context to
+    /// re-import the same underlying memory. Both contexts then see
+    /// identical bytes without any CPU roundtrip and without sharing a
+    /// `blade_graphics::Context`.
     ///
-    /// # Ownership
+    /// The import replaces the session's internal allocation for
+    /// `slot`. After this call, dispatches that read from / write to
+    /// that slot operate directly on the shared memory.
     ///
-    /// The caller retains ownership of the buffer. The session does NOT
-    /// destroy it on drop; it's up to the caller to call
-    /// `context.destroy_buffer(buffer)` after dropping the session (or
-    /// when the buffer is otherwise no longer needed).
+    /// # Handle types
     ///
-    /// # Requirements
+    /// See [`blade_graphics::ExternalMemorySource`]:
+    /// * `Fd(Some(fd))` — Linux/Unix opaque FD (VK_KHR_external_memory_fd).
+    /// * `Dma(Some(fd))` — Linux DMA-BUF (VK_EXT_external_memory_dma_buf),
+    ///   the usual channel to share with GStreamer / V4L2 / EGL / Wayland.
+    /// * `Win32(Some(handle))` / `Win32KMT(Some(handle))` — Windows
+    ///   (VK_KHR_external_memory_win32).
+    /// * `HostAllocation(ptr)` — a host malloc'd pointer imported by
+    ///   both contexts (VK_EXT_external_memory_host). Useful when the
+    ///   producer is a CPU-resident tensor, e.g. during a PyTorch
+    ///   migration: allocate page-aligned host memory, memcpy the
+    ///   tensor in, import on both sides.
     ///
-    /// * The buffer must belong to the same Blade context passed to
-    ///   [`Session::with_context`]. Binding a buffer from a different
-    ///   context is undefined behaviour (different device / queue).
-    /// * The buffer must be at least as large as the slot requires — see
-    ///   [`Session::slot_size`]. Extra capacity is tolerated.
-    /// * For `Input`/`Parameter` slots meant to be written from the
-    ///   caller side, the buffer must be host-visible (`Memory::Shared`)
-    ///   if the caller uses `Buffer::data()` to upload. Purely device-
-    ///   local buffers work too as long as the caller populates them via
-    ///   their own compute/blit dispatches before `step()`.
+    /// # Ownership & lifetime
+    ///
+    /// Once imported, the resulting buffer is owned by meganeura's
+    /// context — `Session::drop` will destroy it, releasing
+    /// meganeura's reference to the shared memory. The producer's
+    /// original buffer remains independently owned and must be
+    /// destroyed by the producer separately. The underlying allocation
+    /// is refcounted by the driver (Vulkan memory objects) or OS
+    /// (malloc'd page), so it stays live until both sides release.
+    ///
+    /// FD/HANDLE ownership follows Vulkan's rules: on a successful
+    /// import, the importing driver takes ownership of the handle and
+    /// the caller must not close it. On failure the handle is
+    /// untouched. For `HostAllocation(ptr)` the caller retains the
+    /// pointer and must keep the memory live for the lifetime of the
+    /// session.
     ///
     /// # Errors
     ///
-    /// Returns [`ExternalBindError::UnknownSlot`] if the slot name /
-    /// output index is not known to the graph. Returns
-    /// [`ExternalBindError::TooSmall`] if the buffer size is below the
-    /// slot's requirement.
+    /// * [`ExternalBindError::UnknownSlot`] — no slot with that
+    ///   name/index.
+    /// * [`ExternalBindError::TooSmall`] — the declared `size` is below
+    ///   the slot's requirement.
+    ///
+    /// # Platform support
+    ///
+    /// Vulkan only. Blade's Metal and GLES backends currently
+    /// `unimplemented!()` for external memory — on those backends the
+    /// import call will panic inside Blade.
     ///
     /// # Example
     ///
     /// ```no_run
-    /// # use std::sync::Arc;
     /// # use blade_graphics as bg;
     /// # use meganeura::{ExternalSlot, Graph, build_inference_session};
-    /// # let gpu: Arc<bg::Context> = unimplemented!();
+    /// # fn doc(producer: &bg::Context, shared_handle: bg::Buffer, size: u64) {
     /// # let mut g = Graph::new();
     /// # let _ = g.input("x", &[4, 3]);
-    /// # let mut session = build_inference_session(&g);
-    /// let buf = gpu.create_buffer(bg::BufferDesc {
-    ///     name: "external_x",
-    ///     size: 4 * 3 * 4,
-    ///     memory: bg::Memory::Shared,
-    /// });
-    /// session.bind_external_buffer(ExternalSlot::Input("x"), buf).unwrap();
-    /// // ... session.step() ...
-    /// drop(session);
-    /// gpu.destroy_buffer(buf);
+    /// let handle = producer
+    ///     .get_external_buffer_source(shared_handle)
+    ///     .expect("buffer was allocated with Memory::External");
+    ///
+    /// let mut session = build_inference_session(&g); // its own context
+    /// session
+    ///     .bind_external_buffer(ExternalSlot::Input("x"), handle, size)
+    ///     .unwrap();
+    /// // session.step() reads x from the shared memory
+    /// # }
     /// ```
     pub fn bind_external_buffer(
         &mut self,
         slot: ExternalSlot<'_>,
-        buffer: blade_graphics::Buffer,
+        source: blade_graphics::ExternalMemorySource,
+        size: u64,
     ) -> Result<(), ExternalBindError> {
         let buf_ref = self.resolve_slot(slot)?;
         let required = self.plan.buffers[buf_ref.0 as usize] as u64;
-        let got = buffer.size();
-        if got < required {
-            return Err(ExternalBindError::TooSmall { required, got });
+        if size < required {
+            return Err(ExternalBindError::TooSmall {
+                required,
+                got: size,
+            });
         }
 
         // Finish any outstanding GPU work that might still reference the
-        // old buffer, then release it before swapping.
+        // internal buffer, then release it before swapping in the import.
         self.wait();
 
+        let imported = self.gpu.create_buffer(blade_graphics::BufferDesc {
+            name: "meganeura_imported",
+            size,
+            memory: blade_graphics::Memory::External(source),
+        });
+
         let idx = buf_ref.0 as usize;
-        let was_external = self.external_buffers.contains(&buf_ref.0);
-        if !was_external {
-            self.gpu.destroy_buffer(self.buffers[idx]);
-        }
-        self.buffers[idx] = buffer;
-        self.external_buffers.insert(buf_ref.0);
+        self.gpu.destroy_buffer(self.buffers[idx]);
+        self.buffers[idx] = imported;
         Ok(())
     }
 
     /// Size in bytes of the GPU buffer backing the given slot.
     ///
-    /// Useful for sizing a caller-owned buffer before passing it to
-    /// [`Session::bind_external_buffer`]. Returns `None` if the slot is
-    /// not known to the graph.
+    /// Useful for sizing a shared allocation on the producer side
+    /// before calling [`Session::bind_external_buffer`]. Returns `None`
+    /// if the slot is not known to the graph.
     pub fn slot_size(&self, slot: ExternalSlot<'_>) -> Option<usize> {
         let buf_ref = self.resolve_slot(slot).ok()?;
         Some(self.plan.buffers[buf_ref.0 as usize])
@@ -3498,11 +3522,7 @@ impl Drop for Session {
         for (_, pipeline) in self.pipelines.reduction_map.iter_mut() {
             self.gpu.destroy_compute_pipeline(pipeline);
         }
-        for (i, buffer) in self.buffers.iter().enumerate() {
-            if self.external_buffers.contains(&(i as u32)) {
-                // Caller-owned — caller is responsible for destruction.
-                continue;
-            }
+        for buffer in &self.buffers {
             self.gpu.destroy_buffer(*buffer);
         }
         for &(m_buf, v_buf) in &self.adam_state {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1120,7 +1120,46 @@ pub struct Session {
     adam_step: u32,
     /// Pending Adam parameters. When set, `step()` appends Adam updates.
     pending_adam: Option<(f32, f32, f32, f32)>, // (lr, beta1, beta2, eps)
+    /// Buffer indices whose GPU allocation is owned by the caller (see
+    /// [`Session::bind_external_buffer`]). Drop skips `destroy_buffer` for
+    /// these — the owner is responsible for destruction.
+    external_buffers: HashSet<u32>,
 }
+
+/// Identifies a graph-facing slot that can be backed by a caller-owned
+/// buffer. See [`Session::bind_external_buffer`].
+#[derive(Clone, Copy, Debug)]
+pub enum ExternalSlot<'a> {
+    /// Graph input declared by `Graph::input(name, ...)`.
+    Input(&'a str),
+    /// Graph parameter declared by `Graph::parameter(name, ...)`.
+    Parameter(&'a str),
+    /// Graph output, by index. Index 0 is the primary output.
+    Output(usize),
+}
+
+/// Error returned by [`Session::bind_external_buffer`].
+#[derive(Debug)]
+pub enum ExternalBindError {
+    /// No input/parameter of that name, or output index out of range.
+    UnknownSlot,
+    /// The external buffer is smaller than the slot requires.
+    TooSmall { required: u64, got: u64 },
+}
+
+impl std::fmt::Display for ExternalBindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::UnknownSlot => write!(f, "no graph slot with the given name/index"),
+            Self::TooSmall { required, got } => write!(
+                f,
+                "external buffer too small: got {got} bytes, need at least {required}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ExternalBindError {}
 
 impl Session {
     /// Select the best cooperative matrix config from GPU capabilities.
@@ -1583,6 +1622,123 @@ impl Session {
             adam_state,
             adam_step: 0,
             pending_adam: None,
+            external_buffers: HashSet::new(),
+        }
+    }
+
+    /// Replace a graph slot's GPU buffer with one allocated by the caller.
+    ///
+    /// Intended for interop with host applications (renderers, game
+    /// engines) that already have tensor data resident on the GPU.
+    /// Meganeura binds the caller's buffer in place of its internal
+    /// allocation, so forward/backward passes read from (or write into)
+    /// it directly — no CPU roundtrip.
+    ///
+    /// # Ownership
+    ///
+    /// The caller retains ownership of the buffer. The session does NOT
+    /// destroy it on drop; it's up to the caller to call
+    /// `context.destroy_buffer(buffer)` after dropping the session (or
+    /// when the buffer is otherwise no longer needed).
+    ///
+    /// # Requirements
+    ///
+    /// * The buffer must belong to the same Blade context passed to
+    ///   [`Session::with_context`]. Binding a buffer from a different
+    ///   context is undefined behaviour (different device / queue).
+    /// * The buffer must be at least as large as the slot requires — see
+    ///   [`Session::slot_size`]. Extra capacity is tolerated.
+    /// * For `Input`/`Parameter` slots meant to be written from the
+    ///   caller side, the buffer must be host-visible (`Memory::Shared`)
+    ///   if the caller uses `Buffer::data()` to upload. Purely device-
+    ///   local buffers work too as long as the caller populates them via
+    ///   their own compute/blit dispatches before `step()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExternalBindError::UnknownSlot`] if the slot name /
+    /// output index is not known to the graph. Returns
+    /// [`ExternalBindError::TooSmall`] if the buffer size is below the
+    /// slot's requirement.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use blade_graphics as bg;
+    /// # use meganeura::{ExternalSlot, Graph, build_inference_session};
+    /// # let gpu: Arc<bg::Context> = unimplemented!();
+    /// # let mut g = Graph::new();
+    /// # let _ = g.input("x", &[4, 3]);
+    /// # let mut session = build_inference_session(&g);
+    /// let buf = gpu.create_buffer(bg::BufferDesc {
+    ///     name: "external_x",
+    ///     size: 4 * 3 * 4,
+    ///     memory: bg::Memory::Shared,
+    /// });
+    /// session.bind_external_buffer(ExternalSlot::Input("x"), buf).unwrap();
+    /// // ... session.step() ...
+    /// drop(session);
+    /// gpu.destroy_buffer(buf);
+    /// ```
+    pub fn bind_external_buffer(
+        &mut self,
+        slot: ExternalSlot<'_>,
+        buffer: blade_graphics::Buffer,
+    ) -> Result<(), ExternalBindError> {
+        let buf_ref = self.resolve_slot(slot)?;
+        let required = self.plan.buffers[buf_ref.0 as usize] as u64;
+        let got = buffer.size();
+        if got < required {
+            return Err(ExternalBindError::TooSmall { required, got });
+        }
+
+        // Finish any outstanding GPU work that might still reference the
+        // old buffer, then release it before swapping.
+        self.wait();
+
+        let idx = buf_ref.0 as usize;
+        let was_external = self.external_buffers.contains(&buf_ref.0);
+        if !was_external {
+            self.gpu.destroy_buffer(self.buffers[idx]);
+        }
+        self.buffers[idx] = buffer;
+        self.external_buffers.insert(buf_ref.0);
+        Ok(())
+    }
+
+    /// Size in bytes of the GPU buffer backing the given slot.
+    ///
+    /// Useful for sizing a caller-owned buffer before passing it to
+    /// [`Session::bind_external_buffer`]. Returns `None` if the slot is
+    /// not known to the graph.
+    pub fn slot_size(&self, slot: ExternalSlot<'_>) -> Option<usize> {
+        let buf_ref = self.resolve_slot(slot).ok()?;
+        Some(self.plan.buffers[buf_ref.0 as usize])
+    }
+
+    fn resolve_slot(&self, slot: ExternalSlot<'_>) -> Result<BufferRef, ExternalBindError> {
+        match slot {
+            ExternalSlot::Input(name) => self
+                .plan
+                .input_buffers
+                .iter()
+                .find(|e| e.0 == name)
+                .map(|e| e.1)
+                .ok_or(ExternalBindError::UnknownSlot),
+            ExternalSlot::Parameter(name) => self
+                .plan
+                .param_buffers
+                .iter()
+                .find(|e| e.0 == name)
+                .map(|e| e.1)
+                .ok_or(ExternalBindError::UnknownSlot),
+            ExternalSlot::Output(idx) => self
+                .plan
+                .output_buffers
+                .get(idx)
+                .copied()
+                .ok_or(ExternalBindError::UnknownSlot),
         }
     }
 
@@ -3342,7 +3498,11 @@ impl Drop for Session {
         for (_, pipeline) in self.pipelines.reduction_map.iter_mut() {
             self.gpu.destroy_compute_pipeline(pipeline);
         }
-        for buffer in &self.buffers {
+        for (i, buffer) in self.buffers.iter().enumerate() {
+            if self.external_buffers.contains(&(i as u32)) {
+                // Caller-owned — caller is responsible for destruction.
+                continue;
+            }
             self.gpu.destroy_buffer(*buffer);
         }
         for &(m_buf, v_buf) in &self.adam_state {


### PR DESCRIPTION
Host applications (renderers, game engines) can now pass a
caller-owned `blade_graphics::Buffer` into a meganeura `Session`
via `bind_external_buffer`, replacing the internal allocation for
a named input/parameter or indexed output. Combined with the
existing `Session::with_context` shared-context path, this lets a
host app hand its GPU-resident tensor to meganeura directly — no
CPU roundtrip.

Ownership: caller retains the buffer; `Session::Drop` skips
destruction for external slots. The buffer must belong to the same
Blade context as the session and be at least `slot_size(...)` bytes.

Comes with `examples/external_buffer.rs` showing a Blade context
creating + populating a buffer, meganeura consuming it for a
`relu(x @ W)` inference, and a CPU readback at the end.