### PR TITLE
Fix Session::Drop leaking epilogue/pointwise/reduction pipelines

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3316,6 +3316,15 @@ impl Drop for Session {
         for (_, pipeline) in self.pipelines.small_map.iter_mut() {
             self.gpu.destroy_compute_pipeline(pipeline);
         }
+        for (_, pipeline) in self.pipelines.epilogue_map.iter_mut() {
+            self.gpu.destroy_compute_pipeline(pipeline);
+        }
+        for (_, pipeline) in self.pipelines.pointwise_map.iter_mut() {
+            self.gpu.destroy_compute_pipeline(pipeline);
+        }
+        for (_, pipeline) in self.pipelines.reduction_map.iter_mut() {
+            self.gpu.destroy_compute_pipeline(pipeline);
+        }
         for buffer in &self.buffers {
             self.gpu.destroy_buffer(*buffer);
         }


### PR DESCRIPTION
Session::Drop only destroyed pipelines from map, coop_map, and small_map, but the Pipelines struct has three additional maps (epilogue_map, pointwise_map, reduction_map) that were never cleaned up. This caused Vulkan validation errors on exit about undestroyed pipeline and pipeline layout objects.