### PR TITLE
ops: AddPerChannel + EfficientNet BN bias as [C]

### DIFF
--- a/src/autodiff.rs
+++ b/src/autodiff.rs
@@ -630,6 +630,12 @@ pub fn differentiate(forward: &Graph) -> Graph {
                      EfficientNet SE in the frozen-weights inference path."
                 );
             }
+            Op::AddPerChannel { .. } => {
+                panic!(
+                    "AddPerChannel autodiff not implemented — used only for \
+                     fused-BN bias in the frozen-weights inference path."
+                );
+            }
             Op::WinogradConv2d {
                 in_channels,
                 in_h,

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -351,6 +351,9 @@ pub enum ShaderGroup {
     /// Per-channel broadcast mul: `dst[n,c,h,w] = src[n,c,h,w] * gate[n,c]`.
     /// Used by EfficientNet Squeeze-and-Excitation.
     MulPerChannel,
+    /// Per-channel broadcast add: `dst[n,c,h,w] = src[n,c,h,w] + bias[c]`.
+    /// Used to apply a fused-BN per-channel bias to a conv output.
+    AddPerChannel,
     Conv2dGemm,
     Conv2dGemmSmall,
     Conv2dGemmCoop,
@@ -456,6 +459,7 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::Conv2d => parse_wgsl(include_str!("shaders/conv2d.wgsl")),
         ShaderGroup::Conv2dDw => parse_wgsl(include_str!("shaders/conv2d_dw.wgsl")),
         ShaderGroup::MulPerChannel => parse_wgsl(include_str!("shaders/mul_per_channel.wgsl")),
+        ShaderGroup::AddPerChannel => parse_wgsl(include_str!("shaders/add_per_channel.wgsl")),
         ShaderGroup::Conv2dGemm => parse_wgsl(include_str!("shaders/conv2d_gemm.wgsl")),
         ShaderGroup::Conv2dGemmSmall => parse_wgsl(include_str!("shaders/conv2d_gemm_small.wgsl")),
         ShaderGroup::Conv2dGradInput => parse_wgsl(include_str!("shaders/conv2d_grad_input.wgsl")),
@@ -4984,6 +4988,7 @@ mod tests {
                     vec!["src", "weight", "dst", "params"]
                 }
                 ShaderEntry::MulPerChannel => vec!["src", "gate", "dst", "params"],
+                ShaderEntry::AddPerChannel => vec!["src", "bias", "dst", "params"],
                 ShaderEntry::Conv2dGemm
                 | ShaderEntry::Conv2dGemmSmall
                 | ShaderEntry::Conv2dGemmCoop
@@ -5093,6 +5098,7 @@ mod tests {
             ShaderEntry::Conv2d,
             ShaderEntry::Conv2dDw,
             ShaderEntry::MulPerChannel,
+            ShaderEntry::AddPerChannel,
             ShaderEntry::Conv2dGemm,
             ShaderEntry::Conv2dGemmSmall,
             ShaderEntry::Conv2dGradInput,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -158,6 +158,9 @@ pub enum ShaderEntry {
     /// Per-channel broadcast multiply: `dst[n,c,h,w] = src[n,c,h,w] * gate[n,c]`.
     /// Used by EfficientNet Squeeze-and-Excitation.
     MulPerChannel,
+    /// Per-channel broadcast add: `dst[n,c,h,w] = src[n,c,h,w] + bias[c]`.
+    /// Used to apply a fused-BN per-channel bias to a conv output.
+    AddPerChannel,
     Conv2dGemm,
     Conv2dGemmSmall,
     Conv2dGemmCoop,
@@ -270,6 +273,7 @@ impl ShaderEntry {
             ShaderEntry::Conv2d => ShaderGroup::Conv2d,
             ShaderEntry::Conv2dDw => ShaderGroup::Conv2dDw,
             ShaderEntry::MulPerChannel => ShaderGroup::MulPerChannel,
+            ShaderEntry::AddPerChannel => ShaderGroup::AddPerChannel,
             ShaderEntry::Conv2dGemm => ShaderGroup::Conv2dGemm,
             ShaderEntry::Conv2dGemmCoop => ShaderGroup::Conv2dGemmCoop,
             ShaderEntry::Conv2dGemmCoopGen(..) => ShaderGroup::Conv2dGemmCoop,
@@ -374,6 +378,7 @@ impl ShaderEntry {
             ShaderEntry::Conv2d => "main",
             ShaderEntry::Conv2dDw => "main",
             ShaderEntry::MulPerChannel => "main",
+            ShaderEntry::AddPerChannel => "main",
             ShaderEntry::Conv2dGemm
             | ShaderEntry::Conv2dGemmSmall
             | ShaderEntry::Conv2dGemmCoop
@@ -2363,6 +2368,23 @@ impl<'a> Compiler<'a> {
                     shader: ShaderEntry::MulPerChannel,
                     workgroups: [len.div_ceil(256), 1, 1],
                     input_buffers: vec![src, gate],
+                    output_buffer: out_buf,
+                    extra_outputs: vec![],
+                    params: vec![len, spatial, channels, 0],
+                    use_coop: false,
+                    use_small_tiles: false,
+                    ..Default::default()
+                });
+            }
+
+            Op::AddPerChannel { channels, spatial } => {
+                let src = self.get_buffer(node.inputs[0]);
+                let bias = self.get_buffer(node.inputs[1]);
+                let len = node.ty.shape[0] as u32;
+                self.plan.dispatches.push(Dispatch {
+                    shader: ShaderEntry::AddPerChannel,
+                    workgroups: [len.div_ceil(256), 1, 1],
+                    input_buffers: vec![src, bias],
                     output_buffer: out_buf,
                     extra_outputs: vec![],
                     params: vec![len, spatial, channels, 0],

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -347,6 +347,15 @@ pub enum Op {
         spatial: u32,
     },
 
+    /// Per-channel broadcast add: `dst[n,c,h,w] = src[n,c,h,w] + bias[c]`.
+    /// inputs: [src, bias] where src is `[N*C*H*W]` and bias is `[C]`.
+    /// Used to apply a fused-BN per-channel bias to a conv output without
+    /// pre-replicating the `[C]` parameter into a `[N*C*H*W]` buffer.
+    AddPerChannel {
+        channels: u32,
+        spatial: u32,
+    },
+
     /// Depthwise 2D convolution (groups == channels).
     /// inputs: [input, kernel] where input is `[N*C*H*W]` and kernel is `[C*kH*kW]`.
     /// Each output channel `c` reads input channel `c` only.  Used by
@@ -1568,6 +1577,18 @@ impl Graph {
     pub fn mul_per_channel(&mut self, src: NodeId, gate: NodeId, channels: u32, spatial: u32) -> NodeId {
         let ty = self.node(src).ty.clone();
         self.add_node(Op::MulPerChannel { channels, spatial }, vec![src, gate], ty)
+    }
+
+    /// Per-channel broadcast add: `dst[n,c,h,w] = src[n,c,h,w] + bias[c]`.
+    ///
+    /// `src` shape `[N*C*H*W]`; `bias` shape `[C]`.  Output matches `src`.
+    /// Lets a fused-BN per-channel bias term be applied to a conv output
+    /// without pre-replicating the safetensor's `[C]` data into a
+    /// `[N*C*H*W]`-sized parameter buffer.  Compare `mul_per_channel`,
+    /// whose gate is `[N*C]` (per-batch-and-channel) for the SE pathway.
+    pub fn add_per_channel(&mut self, src: NodeId, bias: NodeId, channels: u32, spatial: u32) -> NodeId {
+        let ty = self.node(src).ty.clone();
+        self.add_node(Op::AddPerChannel { channels, spatial }, vec![src, bias], ty)
     }
 
     /// Depthwise Conv2d (groups == channels).

--- a/src/models/efficientnet.rs
+++ b/src/models/efficientnet.rs
@@ -61,8 +61,8 @@ pub fn build_graph(g: &mut Graph, batch: u32) -> NodeId {
     let w0 = g.parameter("features.0.0.weight", &[24 * 3 * 3 * 3]);
     let x = g.conv2d_hw(image, w0, batch, 3, s.h, s.w, 24, 3, 3, 2, 1, 1);
     let s = s.after_conv(3, 2, 1); // 96
-    let bn0 = g.parameter("features.0.bn.fused_bias", &[(batch * 24 * s.area()) as usize]);
-    let x = g.add(x, bn0);
+    let bn0 = g.parameter("features.0.bn.fused_bias", &[24]);
+    let x = g.add_per_channel(x, bn0, 24, s.area());
     let x = g.silu(x);
 
     // -------- features.1 — 2× FusedMBConv e=1, 24→24, s=1 --------
@@ -135,9 +135,9 @@ fn fused_mbconv(
         let h = g.conv2d_hw(x, w, batch, in_c, s.h, s.w, out_c, kernel, kernel, stride, padding, padding);
         let bn = g.parameter(
             &format!("{name}.block.0.bn.fused_bias"),
-            &[(batch * out_c * s1.area()) as usize],
+            &[out_c as usize],
         );
-        let h = g.add(h, bn);
+        let h = g.add_per_channel(h, bn, out_c, s1.area());
         g.silu(h)
     } else {
         // Expand 3×3 (in_c → expanded), then project 1×1 (expanded → out_c).
@@ -149,9 +149,9 @@ fn fused_mbconv(
         let h = g.conv2d_hw(x, w_e, batch, in_c, s.h, s.w, expanded_c, kernel, kernel, stride, padding, padding);
         let bn_e = g.parameter(
             &format!("{name}.block.0.bn.fused_bias"),
-            &[(batch * expanded_c * s1.area()) as usize],
+            &[expanded_c as usize],
         );
-        let h = g.add(h, bn_e);
+        let h = g.add_per_channel(h, bn_e, expanded_c, s1.area());
         let h = g.silu(h);
 
         let w_p = g.parameter(
@@ -161,9 +161,9 @@ fn fused_mbconv(
         let h = g.conv2d(h, w_p, batch, expanded_c, s1.h, s1.w, out_c, 1, 1, 1, 0);
         let bn_p = g.parameter(
             &format!("{name}.block.1.bn.fused_bias"),
-            &[(batch * out_c * s1.area()) as usize],
+            &[out_c as usize],
         );
-        g.add(h, bn_p)
+        g.add_per_channel(h, bn_p, out_c, s1.area())
     };
 
     if stride == 1 && in_c == out_c {
@@ -207,9 +207,9 @@ fn mbconv(
     let h = g.conv2d(x, w_e, batch, in_c, s.h, s.w, expanded_c, 1, 1, 1, 0);
     let bn_e = g.parameter(
         &format!("{name}.block.0.bn.fused_bias"),
-        &[(batch * expanded_c * s.area()) as usize],
+        &[expanded_c as usize],
     );
-    let h = g.add(h, bn_e);
+    let h = g.add_per_channel(h, bn_e, expanded_c, s.area());
     let h = g.silu(h);
 
     // -------- Depthwise k×k --------
@@ -222,9 +222,9 @@ fn mbconv(
     );
     let bn_d = g.parameter(
         &format!("{name}.block.1.bn.fused_bias"),
-        &[(batch * expanded_c * s_dw.area()) as usize],
+        &[expanded_c as usize],
     );
-    let h = g.add(h, bn_d);
+    let h = g.add_per_channel(h, bn_d, expanded_c, s_dw.area());
     let h = g.silu(h);
 
     // -------- Squeeze-and-Excitation --------
@@ -262,9 +262,9 @@ fn mbconv(
     let h = g.conv2d(h, proj_w, batch, expanded_c, s_dw.h, s_dw.w, out_c, 1, 1, 1, 0);
     let bn_p = g.parameter(
         &format!("{name}.block.3.bn.fused_bias"),
-        &[(batch * out_c * s_dw.area()) as usize],
+        &[out_c as usize],
     );
-    let h = g.add(h, bn_p);
+    let h = g.add_per_channel(h, bn_p, out_c, s_dw.area());
 
     if stride == 1 && in_c == out_c {
         g.add(h, x)

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -592,6 +592,7 @@ fn node_to_egglog_expr(node: &Node) -> String {
         Op::Conv2d { .. } => format!("(Conv2d n{} n{})", i[0], i[1]),
         Op::Conv2dDw { .. } => format!("(Conv2dDw n{} n{})", i[0], i[1]),
         Op::MulPerChannel { .. } => format!("(MulPerChannel n{} n{})", i[0], i[1]),
+        Op::AddPerChannel { .. } => format!("(AddPerChannel n{} n{})", i[0], i[1]),
         Op::Conv2dGradInput { .. } => format!("(Conv2dGradInput n{} n{})", i[0], i[1]),
         Op::Conv2dGradWeight { .. } => format!("(Conv2dGradWeight n{} n{})", i[0], i[1]),
         Op::MaxPool2d { .. } => format!("(MaxPool2d n{})", i[0]),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -168,6 +168,24 @@ struct MulPerChannelParams {
     _pad1: u32,
 }
 
+// add_per_channel: var src, bias, dst, params
+#[derive(blade_macros::ShaderData)]
+struct AddPerChannelData {
+    src: blade_graphics::BufferPiece,
+    bias: blade_graphics::BufferPiece,
+    dst: blade_graphics::BufferPiece,
+    params: AddPerChannelParams,
+}
+
+#[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
+#[repr(C)]
+struct AddPerChannelParams {
+    len: u32,
+    spatial: u32,
+    channels: u32,
+    _pad0: u32,
+}
+
 // sgd: var param, grad, dst, params
 #[derive(blade_macros::ShaderData)]
 struct SgdData {
@@ -1267,6 +1285,7 @@ pub fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayo
         ShaderEntry::Conv2d => Conv2dData::layout(),
         ShaderEntry::Conv2dDw => Conv2dDwData::layout(),
         ShaderEntry::MulPerChannel => MulPerChannelData::layout(),
+        ShaderEntry::AddPerChannel => AddPerChannelData::layout(),
         ShaderEntry::Conv2dGemm
         | ShaderEntry::Conv2dGemmSmall
         | ShaderEntry::Conv2dGemmCoop
@@ -4056,6 +4075,23 @@ impl Session {
                             spatial: p[1],
                             _pad0: 0,
                             _pad1: 0,
+                        },
+                    },
+                );
+            }
+            ShaderEntry::AddPerChannel => {
+                let p = &dispatch.params;
+                pc.bind(
+                    0,
+                    &AddPerChannelData {
+                        src: buf(dispatch.input_buffers[0]),
+                        bias: buf(dispatch.input_buffers[1]),
+                        dst: buf(dispatch.output_buffer),
+                        params: AddPerChannelParams {
+                            len: p[0],
+                            spatial: p[1],
+                            channels: p[2],
+                            _pad0: 0,
                         },
                     },
                 );

--- a/src/shaders/add_per_channel.wgsl
+++ b/src/shaders/add_per_channel.wgsl
@@ -1,0 +1,34 @@
+// Per-channel broadcast add.
+//
+// Given activations `[N, C, H, W]` and a per-channel bias `[C]`,
+// produce `dst[n, c, h, w] = src[n, c, h, w] + bias[c]`.
+//
+// Used to fuse a BatchNorm bias term into the post-conv activation
+// path: the safetensors store `bn.fused_bias` as a per-channel
+// vector (shape `[C]`), and this op broadcasts it across every
+// (batch, spatial) position without requiring callers to
+// pre-replicate the data into a `[N*C*H*W]`-sized buffer.
+//
+// Linear-index encoding: dst[i] = src[i] + bias[(i / spatial) % channels],
+// where `spatial = H * W`.  The double-mod avoids per-batch replication of
+// the bias tensor (compare `mul_per_channel`, which uses a
+// `[N*C]`-shaped gate and is keyed by `i / spatial` directly).
+
+struct Params {
+    len: u32,        // total elements N * C * H * W
+    spatial: u32,    // H * W
+    channels: u32,   // C
+    _pad0: u32,
+}
+
+var<storage> src: array<f32>;
+var<storage> bias: array<f32>;
+var<storage, read_write> dst: array<f32>;
+var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if i >= params.len { return; }
+    dst[i] = src[i] + bias[(i / params.spatial) % params.channels];
+}

--- a/tests/gpu_smoke.rs
+++ b/tests/gpu_smoke.rs
@@ -3107,6 +3107,57 @@ fn q4_layer_nan_hunt() {
     }
 }
 
+/// Smoke test: AddPerChannel — `dst[n,c,h,w] = src[n,c,h,w] + bias[c]`.
+#[test]
+fn add_per_channel_smoke() {
+    let batch = 2u32;
+    let channels = 3u32;
+    let h = 4u32;
+    let w = 5u32;
+    let spatial = h * w;
+    let total = (batch * channels * spatial) as usize;
+
+    let mut g = Graph::new();
+    let src = g.input("src", &[total]);
+    let bias = g.input("bias", &[channels as usize]);
+    let out = g.add_per_channel(src, bias, channels, spatial);
+    g.set_outputs(vec![out]);
+
+    let mut session = build_inference_session(&g);
+
+    let mut src_data = vec![0.0f32; total];
+    for (i, v) in src_data.iter_mut().enumerate() {
+        *v = i as f32;
+    }
+    session.set_input("src", &src_data);
+
+    // Per-channel bias deliberately distinct so misalignment shows up.
+    let bias_data: Vec<f32> = (0..channels).map(|c| 100.0 + c as f32 * 10.0).collect();
+    session.set_input("bias", &bias_data);
+
+    session.step();
+    session.wait();
+
+    let out = session.read_output(total);
+    for n in 0..batch as usize {
+        for c in 0..channels as usize {
+            for s in 0..spatial as usize {
+                let i = (n * channels as usize + c) * spatial as usize + s;
+                let expected = src_data[i] + bias_data[c];
+                assert!(
+                    (out[i] - expected).abs() < 1e-4,
+                    "n={} c={} s={}: got {}, expected {}",
+                    n,
+                    c,
+                    s,
+                    out[i],
+                    expected,
+                );
+            }
+        }
+    }
+}
+
 /// Regression test for the kindle batch>1 silent-zero-gradient bug.
 ///
 /// Models the canonical failure mode: graph declares a parameter buffer


### PR DESCRIPTION
Adds `Op::AddPerChannel` — `dst[n,c,h,w] = src[n,c,h,w] + bias[c]` with `src` shape `[N*C*H*W]` and `bias` shape `[C]`. Mirrors the existing `MulPerChannel` infrastructure (graph, codegen, compile, runtime) but broadcasts a per-channel bias instead of a per-(batch,channel) gate. Linear-index encoding `bias[(i / spatial) % channels]` avoids any per-batch replication of the bias tensor at the call site.

Updates `models/efficientnet.rs` to declare `bn.fused_bias` parameters at their natural per-channel shape `[C]` (matching the safetensors) and consume them via `add_per_channel` instead of `add` against a pre-broadcast `[batch * C * area]` slot. Closes the kindle V2-S batch>1 silent-zero-gradient bug at the source: previously the graph declared the bias slot `[batch * C * area]` but `set_parameter` was called with the safetensor's `[C]` data, leaving the tail uninitialized — at batch=1 the conv kernel's per-area broadcast hid the gap, but at batch>1 lane slices 1..N saw zeros and the agent silently failed to learn. The new op + new shape declaration mean the byte-size assertion landed in commit abebc62 now passes for every batch size, and lane 0/1/N see identical features.

Includes:
- `add_per_channel_smoke` numerical correctness test (B=2, C=3, H=4, W=5)
- forward-only autodiff stub (frozen-weights inference path, like `MulPerChannel`)
- existing `efficientnet_v2s_features_graph_constructs` test still passes (output shape unchanged at `[N=1, C=160, H=12, W=12]`)