### PR TITLE
Native temporal gradient accumulation: zero_grad + persistent accumulators

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -382,6 +382,7 @@ pub enum ShaderGroup {
     GradClipZero,
     GradClipNormSq,
     GradClipScale,
+    GradAccum,
 }
 
 /// Generate a `naga::Module` for a shader group.
@@ -509,6 +510,7 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::GradClipZero => parse_wgsl(include_str!("shaders/grad_clip_zero.wgsl")),
         ShaderGroup::GradClipNormSq => parse_wgsl(include_str!("shaders/grad_clip_norm_sq.wgsl")),
         ShaderGroup::GradClipScale => parse_wgsl(include_str!("shaders/grad_clip_scale.wgsl")),
+        ShaderGroup::GradAccum => parse_wgsl(include_str!("shaders/grad_accum.wgsl")),
     }
 }
 
@@ -5122,6 +5124,7 @@ mod tests {
                 ShaderEntry::GradClipZero => vec!["acc"],
                 ShaderEntry::GradClipNormSq => vec!["grad", "acc", "params"],
                 ShaderEntry::GradClipScale => vec!["grad", "acc", "params"],
+                ShaderEntry::GradAccum => vec!["grad", "acc", "params"],
             }
         }
 
@@ -5149,6 +5152,7 @@ mod tests {
             ShaderEntry::GradClipZero,
             ShaderEntry::GradClipNormSq,
             ShaderEntry::GradClipScale,
+            ShaderEntry::GradAccum,
             ShaderEntry::SumAll,
             ShaderEntry::MeanAll,
             ShaderEntry::Softmax,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -201,6 +201,10 @@ pub enum ShaderEntry {
     /// where `norm = sqrt(bitcast<f32>(acc[0]))` from the accumulator
     /// produced by `GradClipNormSq`.
     GradClipScale,
+    /// Temporal gradient accumulation: `acc[i] += grad[i] * scale`. Adds
+    /// each step's fresh (overwritten) grad into a persistent accumulator
+    /// so gradients sum across `step()` calls. Cleared by `zero_grad`.
+    GradAccum,
 }
 
 impl ShaderEntry {
@@ -305,6 +309,7 @@ impl ShaderEntry {
             ShaderEntry::GradClipZero => ShaderGroup::GradClipZero,
             ShaderEntry::GradClipNormSq => ShaderGroup::GradClipNormSq,
             ShaderEntry::GradClipScale => ShaderGroup::GradClipScale,
+            ShaderEntry::GradAccum => ShaderGroup::GradAccum,
         }
     }
 
@@ -411,7 +416,8 @@ impl ShaderEntry {
             | ShaderEntry::WinogradWeightTransform => "main",
             ShaderEntry::GradClipZero
             | ShaderEntry::GradClipNormSq
-            | ShaderEntry::GradClipScale => "main",
+            | ShaderEntry::GradClipScale
+            | ShaderEntry::GradAccum => "main",
         }
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -279,6 +279,23 @@ struct GradClipScaleParams {
     _pad1: u32,
 }
 
+// Temporal grad accumulation: acc[i] += grad[i] * scale.
+#[derive(blade_macros::ShaderData)]
+struct GradAccumData {
+    grad: blade_graphics::BufferPiece,
+    acc: blade_graphics::BufferPiece,
+    params: GradAccumParams,
+}
+
+#[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
+#[repr(C)]
+struct GradAccumParams {
+    len: u32,
+    scale: f32,
+    _pad0: u32,
+    _pad1: u32,
+}
+
 // reduce: var src, dst, params (same layout as UnaryData)
 
 // Schedule-template reduction params: { outer, inner, _pad0, _pad1 }.
@@ -846,6 +863,13 @@ impl Pipelines {
                 .entry(ShaderGroup::GradClipScale)
                 .or_default()
                 .insert(ShaderEntry::GradClipScale);
+            // Temporal grad accumulator pass, compiled unconditionally so
+            // `set_grad_accumulate` works without a session rebuild.
+            needed.insert(ShaderGroup::GradAccum);
+            entries_for_group
+                .entry(ShaderGroup::GradAccum)
+                .or_default()
+                .insert(ShaderEntry::GradAccum);
         }
 
         let mut map = HashMap::new();
@@ -1424,6 +1448,7 @@ pub fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayo
         ShaderEntry::GradClipZero => GradClipZeroData::layout(),
         ShaderEntry::GradClipNormSq => GradClipNormSqData::layout(),
         ShaderEntry::GradClipScale => GradClipScaleData::layout(),
+        ShaderEntry::GradAccum => GradAccumData::layout(),
     }
 }
 
@@ -1535,6 +1560,17 @@ pub struct Session {
     /// GradClipScale, zeroed by GradClipZero. `None` when the plan
     /// has no trainable parameters.
     grad_clip_acc: Option<blade_graphics::Buffer>,
+    /// Persistent per-parameter gradient accumulators (parallel to
+    /// `plan.param_grad_pairs`). When `grad_accum_scale` is `Some`, each
+    /// `step()` adds `grad * scale` into these instead of letting the
+    /// optimizer read the single-step grad — giving PyTorch-style
+    /// temporal accumulation. Allocated lazily on first
+    /// `set_grad_accumulate`; cleared by `zero_grad`.
+    grad_accum_bufs: Vec<blade_graphics::Buffer>,
+    /// `Some(scale)` enables temporal accumulation (`scale` = 1/micro so
+    /// the accumulator holds the mean grad); `None` = direct optimizer
+    /// reads of the per-step grad (default).
+    grad_accum_scale: Option<f32>,
     /// Adam step counter.
     adam_step: u32,
     /// Active Adam parameters. When set, every `step()` appends Adam updates
@@ -2234,6 +2270,8 @@ impl Session {
             grad_clip_every: 1,
             grad_clip_tick: 0,
             grad_clip_acc,
+            grad_accum_bufs: Vec::new(),
+            grad_accum_scale: None,
             lr_multipliers: Vec::new(),
             adam_state,
             adam_step: 0,
@@ -3518,6 +3556,37 @@ impl Session {
             }
         }
 
+        // Temporal grad accumulation: add this step's (overwritten) grads
+        // into the persistent accumulators that the clip/optimizer below
+        // will read. Runs in its own pass after backward (it reads grad
+        // buffers the backward just wrote).
+        if let Some(scale) = self.grad_accum_scale {
+            {
+                let pipeline = &self.pipelines.map[&ShaderEntry::GradAccum];
+                let mut pass = self.encoder.compute("grad_accum");
+                for (idx, &(_, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
+                    let len = (self.plan.buffers[grad_buf.0 as usize] / 4) as u32;
+                    let mut pc = pass.with(pipeline);
+                    pc.bind(
+                        0,
+                        &GradAccumData {
+                            grad: self.buffers[grad_buf.0 as usize].at(0),
+                            acc: self.grad_accum_bufs[idx].at(0),
+                            params: GradAccumParams { len, scale, _pad0: 0, _pad1: 0 },
+                        },
+                    );
+                    pc.dispatch([len.div_ceil(256), 1, 1]);
+                }
+            }
+            // Submit + wait so the accumulator this pass wrote is fully
+            // durable before the optimizer's separate passes read it.
+            // Sharing one submission left a write/read hazard that
+            // corrupted the accumulator on the apply step.
+            self.sync_point = Some(self.gpu.submit(&mut self.encoder));
+            self.wait();
+            self.encoder.start();
+        }
+
         // Gradient clipping (if requested) needs to happen between
         // backward and optimizer. We split the submission: submit the
         // forward+backward pass we just encoded, wait, do CPU readback
@@ -3565,16 +3634,23 @@ impl Session {
                 pc.dispatch([1, 1, 1]);
             }
             // Pass 2: sum of squares per gradient buffer.
+            let accumulating = self.grad_accum_scale.is_some();
             {
                 let pipeline = &self.pipelines.map[&ShaderEntry::GradClipNormSq];
                 let mut pass = self.encoder.compute("grad_clip_norm_sq");
-                for &(param_buf, grad_buf) in &self.plan.param_grad_pairs {
+                for (idx, &(param_buf, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
                     let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
                     let mut pc = pass.with(pipeline);
                     pc.bind(
                         0,
                         &GradClipNormSqData {
-                            grad: self.buffers[grad_buf.0 as usize].at(0),
+                            grad: Self::grad_source(
+                                &self.buffers,
+                                &self.grad_accum_bufs,
+                                accumulating,
+                                idx,
+                                grad_buf,
+                            ),
                             acc: acc_buf.at(0),
                             params: GradClipNormSqParams {
                                 len,
@@ -3594,13 +3670,19 @@ impl Session {
             {
                 let pipeline = &self.pipelines.map[&ShaderEntry::GradClipScale];
                 let mut pass = self.encoder.compute("grad_clip_scale");
-                for &(param_buf, grad_buf) in &self.plan.param_grad_pairs {
+                for (idx, &(param_buf, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
                     let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
                     let mut pc = pass.with(pipeline);
                     pc.bind(
                         0,
                         &GradClipScaleData {
-                            grad: self.buffers[grad_buf.0 as usize].at(0),
+                            grad: Self::grad_source(
+                                &self.buffers,
+                                &self.grad_accum_bufs,
+                                accumulating,
+                                idx,
+                                grad_buf,
+                            ),
                             acc: acc_buf.at(0),
                             params: GradClipScaleParams {
                                 len,
@@ -3622,11 +3704,12 @@ impl Session {
         // (default 1.0). Param-name lookup uses the plan's param_buffers
         // table; the cost is negligible (small N at session-build time).
         if !self.plan.param_grad_pairs.is_empty() {
+            let accumulating = self.grad_accum_scale.is_some();
             let lr = self.pending_lr;
             if let Some(learning_rate) = lr {
                 let pipeline = &self.pipelines.map[&ShaderEntry::SgdUpdate];
                 let mut pass = self.encoder.compute("sgd_update");
-                for &(param_buf, grad_buf) in &self.plan.param_grad_pairs {
+                for (idx, &(param_buf, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
                     let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
                     let effective_lr = learning_rate
                         * Self::lr_multiplier_for_buf(
@@ -3639,7 +3722,13 @@ impl Session {
                         0,
                         &SgdData {
                             param: self.buffers[param_buf.0 as usize].at(0),
-                            grad: self.buffers[grad_buf.0 as usize].at(0),
+                            grad: Self::grad_source(
+                                &self.buffers,
+                                &self.grad_accum_bufs,
+                                accumulating,
+                                idx,
+                                grad_buf,
+                            ),
                             dst: self.buffers[param_buf.0 as usize].at(0),
                             params: SgdParams {
                                 len,
@@ -3669,7 +3758,13 @@ impl Session {
                         0,
                         &AdamData {
                             param: self.buffers[param_buf.0 as usize].at(0),
-                            grad: self.buffers[grad_buf.0 as usize].at(0),
+                            grad: Self::grad_source(
+                                &self.buffers,
+                                &self.grad_accum_bufs,
+                                accumulating,
+                                idx,
+                                grad_buf,
+                            ),
                             m: m_buf.at(0),
                             v: v_buf.at(0),
                             params: AdamParams {
@@ -3691,6 +3786,23 @@ impl Session {
 
         self.last_submit_ns = crate::profiler::now_ns();
         self.sync_point = Some(self.gpu.submit(&mut self.encoder));
+    }
+
+    /// The buffer the optimizer/clip should read for param `idx`'s
+    /// gradient: the persistent accumulator when temporal accumulation is
+    /// active, else the per-step grad buffer the backward just wrote.
+    fn grad_source(
+        buffers: &[blade_graphics::Buffer],
+        accum_bufs: &[blade_graphics::Buffer],
+        accumulating: bool,
+        idx: usize,
+        grad_buf: BufferRef,
+    ) -> blade_graphics::BufferPiece {
+        if accumulating {
+            accum_bufs[idx].at(0)
+        } else {
+            buffers[grad_buf.0 as usize].at(0)
+        }
     }
 
     fn bind_dispatch(
@@ -4365,10 +4477,11 @@ impl Session {
             }
             ShaderEntry::GradClipZero
             | ShaderEntry::GradClipNormSq
-            | ShaderEntry::GradClipScale => {
+            | ShaderEntry::GradClipScale
+            | ShaderEntry::GradAccum => {
                 unreachable!(
-                    "Grad-clip shaders are dispatched directly from step() when \
-                     `pending_grad_clip` is set, not via bind_dispatch"
+                    "Grad-clip/accum shaders are dispatched directly from step(), \
+                     not via bind_dispatch"
                 );
             }
             ShaderEntry::ScatterAdd => {
@@ -5084,6 +5197,68 @@ impl Session {
     pub fn clear_optimizer(&mut self) {
         self.pending_lr = None;
         self.pending_adam = None;
+    }
+
+    /// Enable temporal gradient accumulation over `micro_batches` steps.
+    ///
+    /// meganeura's static-graph backward *overwrites* each param's grad
+    /// buffer every `step()` (it sums contributions within one backward,
+    /// not across calls). With accumulation enabled, each `step()`
+    /// instead adds `grad / micro_batches` into a persistent accumulator,
+    /// and the optimizer (clip + Adam/SGD) reads that accumulator — so
+    /// `step()` K times then one optimizer-bearing step trains on the
+    /// mean gradient of K micro-batches at single-batch GPU memory.
+    ///
+    /// Call [`Session::zero_grad`] before each K-step window. Pass
+    /// `micro_batches = 1` (or [`Session::clear_grad_accumulate`]) to
+    /// restore direct single-step optimizer reads.
+    pub fn set_grad_accumulate(&mut self, micro_batches: u32) {
+        assert!(micro_batches >= 1);
+        if micro_batches == 1 {
+            self.grad_accum_scale = None;
+            return;
+        }
+        if self.grad_accum_bufs.is_empty() {
+            self.grad_accum_bufs = self
+                .plan
+                .param_grad_pairs
+                .iter()
+                .enumerate()
+                .map(|(i, &(_, grad_buf))| {
+                    let size = (self.plan.buffers[grad_buf.0 as usize] as u64).max(4);
+                    let buf = self.gpu.create_buffer(blade_graphics::BufferDesc {
+                        name: &format!("grad_accum_{i}"),
+                        size,
+                        memory: blade_graphics::Memory::Shared,
+                    });
+                    unsafe {
+                        std::ptr::write_bytes(buf.data(), 0, size as usize);
+                    }
+                    buf
+                })
+                .collect();
+        }
+        self.grad_accum_scale = Some(1.0 / micro_batches as f32);
+    }
+
+    pub fn clear_grad_accumulate(&mut self) {
+        self.grad_accum_scale = None;
+    }
+
+    /// Zero the gradient accumulators (PyTorch `optimizer.zero_grad()`).
+    /// No-op unless [`Session::set_grad_accumulate`] is active.
+    pub fn zero_grad(&mut self) {
+        if self.grad_accum_bufs.is_empty() {
+            return;
+        }
+        self.wait();
+        // Accumulators are host-visible (Shared); zero in place.
+        for (buf, &(_, grad_buf)) in self.grad_accum_bufs.iter().zip(&self.plan.param_grad_pairs) {
+            let size = self.plan.buffers[grad_buf.0 as usize].max(4);
+            unsafe {
+                std::ptr::write_bytes(buf.data(), 0, size);
+            }
+        }
     }
 
     pub fn memory_summary(&self) -> MemorySummary {

--- a/src/shaders/grad_accum.wgsl
+++ b/src/shaders/grad_accum.wgsl
@@ -1,0 +1,25 @@
+// Temporal gradient accumulation: acc[i] += grad[i] * scale.
+//
+// backward overwrites each param's grad buffer every step(); this pass
+// adds that fresh grad into a persistent accumulator so gradients sum
+// ACROSS step() calls (the PyTorch `.grad +=` semantics meganeura's
+// static-graph backward lacks). `scale` is 1/micro_batches so the
+// accumulator holds the mean gradient. Cleared by `zero_grad()`.
+
+struct Params {
+    len: u32,
+    scale: f32,
+    _pad0: u32,
+    _pad1: u32,
+}
+
+var<storage> grad: array<f32>;
+var<storage, read_write> acc: array<f32>;
+var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if i >= params.len { return; }
+    acc[i] = acc[i] + grad[i] * params.scale;
+}

--- a/tests/grad_accumulate.rs
+++ b/tests/grad_accumulate.rs
@@ -1,0 +1,115 @@
+//! Native temporal gradient accumulation: K backward passes summed into
+//! the persistent accumulator, then one optimizer step, must match a
+//! single optimizer step on the mean of those K gradients.
+
+use meganeura::{Graph, build_session};
+
+fn build() -> Graph {
+    // Simple linear regression: loss = mse(x @ w, target).
+    let mut g = Graph::new();
+    let x = g.input("x", &[2, 3]);
+    let w = g.parameter("w", &[3, 2]);
+    let y = g.matmul(x, w);
+    let t = g.input("t", &[2, 2]);
+    let loss = g.mse_loss(y, t);
+    g.set_outputs(vec![loss]);
+    g
+}
+
+const W_INIT: [f32; 6] = [0.1, -0.2, 0.3, 0.05, 0.4, -0.1];
+
+/// Two micro-batches A and B. Accumulating A then B (scale 1/2) then one
+/// SGD step must equal one SGD step whose grad is mean(gradA, gradB).
+#[test]
+fn accumulate_two_micro_equals_mean_grad_step() {
+    let a_x = vec![1.0f32, 0.5, -0.3, 0.2, 0.8, 0.1];
+    let a_t = vec![0.4f32, -0.1, 0.6, 0.2];
+    let b_x = vec![-0.5f32, 0.9, 0.4, -0.2, 0.3, 0.7];
+    let b_t = vec![0.1f32, 0.5, -0.4, 0.3];
+
+    // --- Reference: read gradA and gradB separately, mean, manual SGD ---
+    let g = build();
+    let mut s = build_session(&g);
+    s.set_parameter("w", &W_INIT);
+    s.clear_optimizer();
+    s.set_input("x", &a_x);
+    s.set_input("t", &a_t);
+    s.step();
+    s.wait();
+    let mut ga = [0.0f32; 6];
+    s.read_param_grad("w", &mut ga);
+    s.set_input("x", &b_x);
+    s.set_input("t", &b_t);
+    s.step();
+    s.wait();
+    let mut gb = [0.0f32; 6];
+    s.read_param_grad("w", &mut gb);
+    let lr = 0.1f32;
+    let mut want = W_INIT;
+    for i in 0..6 {
+        want[i] -= lr * 0.5 * (ga[i] + gb[i]);
+    }
+
+    // --- Native accumulation: zero_grad, A, B (scale 1/2), then SGD ---
+    let mut s = build_session(&g);
+    s.set_parameter("w", &W_INIT);
+    s.set_grad_accumulate(2);
+    s.zero_grad();
+    s.clear_optimizer(); // micro-batch A: accumulate only
+    s.set_input("x", &a_x);
+    s.set_input("t", &a_t);
+    s.step();
+    s.set_learning_rate(lr); // micro-batch B: accumulate + apply
+    s.set_input("x", &b_x);
+    s.set_input("t", &b_t);
+    s.step();
+    s.wait();
+    let mut got = [0.0f32; 6];
+    s.read_param("w", &mut got);
+
+    let max = want
+        .iter()
+        .zip(&got)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    println!("want={want:?}\ngot ={got:?}\nmax diff={max:.3e}");
+    assert!(max < 1e-5, "native accumulation != mean-grad step: {max}");
+}
+
+/// zero_grad must actually clear: a second accumulate window starting
+/// with zero_grad reproduces the first (no carryover).
+#[test]
+fn zero_grad_clears_accumulator() {
+    let x = vec![1.0f32, 0.5, -0.3, 0.2, 0.8, 0.1];
+    let t = vec![0.4f32, -0.1, 0.6, 0.2];
+    let g = build();
+    let mut s = build_session(&g);
+    s.set_parameter("w", &W_INIT);
+    s.set_grad_accumulate(1.max(1)); // enable accumulator buffers
+    s.set_grad_accumulate(2);
+
+    let mut step_once = |s: &mut meganeura::Session| -> [f32; 6] {
+        s.set_parameter("w", &W_INIT);
+        s.zero_grad();
+        s.clear_optimizer();
+        s.set_input("x", &x);
+        s.set_input("t", &t);
+        s.step();
+        s.set_learning_rate(0.1);
+        s.set_input("x", &x);
+        s.set_input("t", &t);
+        s.step();
+        s.wait();
+        let mut p = [0.0f32; 6];
+        s.read_param("w", &mut p);
+        p
+    };
+    let first = step_once(&mut s);
+    let second = step_once(&mut s);
+    let max = first
+        .iter()
+        .zip(&second)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    assert!(max < 1e-6, "zero_grad failed to clear; carryover {max}");
+}


### PR DESCRIPTION
meganeura's static-graph backward sums gradients **spatially** (within one backward, via `accumulate_grad`) but **overwrites** each param grad buffer every `step()` — no temporal accumulation across backward passes, no `zero_grad`. This adds PyTorch-style temporal accumulation:

- persistent per-param accumulator buffers (lazy via `set_grad_accumulate(K)`); a `GradAccum` shader does `acc += grad * (1/K)` after each backward.
- `zero_grad()` clears the accumulators.
- optimizer (Adam/SGD) and grad-clip read the accumulator instead of the per-step grad when active.
- usage: `zero_grad`; K-1 accumulate-only steps (optimizer disarmed); one apply step. Effective batch K*batch at single-batch GPU memory.

The accumulate pass submits+waits before the optimizer reads the accumulator: sharing one submission left a write/read hazard that corrupted it on the apply step (the new test catches it — two distinct micro-batches must equal a mean-grad step).

Off by default. Tests: `tests/grad_accumulate.rs`; core training suites + clippy -D warnings green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)