### PR TITLE
Fix coop conv for K not a multiple of 4; prefer f32 coop tiles

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -4459,7 +4459,10 @@ fn emit_forward_weight_stage(
     let _ = writeln!(src, "            let gr = {row_offset};");
     src.push_str("            let tc4 = t + v4_col;\n");
     let _ = writeln!(src, "            let flat = v4_row * {tile}u + v4_col;");
-    src.push_str("            if gr < m_total && (tc4 + 4u) <= k_total {\n");
+    // Fast path: vec4 load, valid only when each weight row [Co, K] starts
+    // on a vec4 boundary, i.e. k_total % 4 == 0. The branch is on a
+    // uniform value so there is no warp divergence.
+    src.push_str("            if (k_total & 3u) == 0u && gr < m_total && (tc4 + 4u) <= k_total {\n");
     src.push_str("                let v = weight[(gr * k_total + tc4) >> 2u];\n");
     let _ = writeln!(
         src,
@@ -4478,10 +4481,22 @@ fn emit_forward_weight_stage(
         "                {shared_name}[flat + 3u] = {cast_open}v.w{cast_close};"
     );
     src.push_str("            } else {\n");
-    let _ = writeln!(src, "                {shared_name}[flat] = zero_val;");
-    let _ = writeln!(src, "                {shared_name}[flat + 1u] = zero_val;");
-    let _ = writeln!(src, "                {shared_name}[flat + 2u] = zero_val;");
-    let _ = writeln!(src, "                {shared_name}[flat + 3u] = zero_val;");
+    // Fallback for K not a multiple of 4: rows are not vec4-aligned, so
+    // `weight[(gr*k_total+tc4)>>2]` would read across the row boundary.
+    // Index each element individually (alignment-independent). Conv2d
+    // with Ci*kH*kW not divisible by 4 (e.g. Ci=14 → K=126) hits this.
+    src.push_str("                for (var i = 0u; i < 4u; i = i + 1u) {\n");
+    src.push_str("                    let kc = tc4 + i;\n");
+    src.push_str("                    if gr < m_total && kc < k_total {\n");
+    src.push_str("                        let idx = gr * k_total + kc;\n");
+    let _ = writeln!(
+        src,
+        "                        {shared_name}[flat + i] = {cast_open}weight[idx >> 2u][idx & 3u]{cast_close};"
+    );
+    src.push_str("                    } else {\n");
+    let _ = writeln!(src, "                        {shared_name}[flat + i] = zero_val;");
+    src.push_str("                    }\n");
+    src.push_str("                }\n");
     src.push_str("            }\n");
     src.push_str("        }\n\n");
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1650,17 +1650,30 @@ impl Session {
             log::warn!("MEGANEURA_DISABLE_COOP set — forcing scalar matmul");
             return None;
         }
-        if caps.f16_tile > 0 {
-            Some(CoopConfig {
-                tile_size: caps.f16_tile,
-                use_f16_input: true,
-            })
-        } else if caps.f32_tile > 0 {
-            Some(CoopConfig {
-                tile_size: caps.f32_tile,
-                use_f16_input: false,
-            })
+        log::info!(
+            "coop caps: f16_tile={}, f32_tile={}",
+            caps.f16_tile,
+            caps.f32_tile
+        );
+        // f16 coop operands (max 65504, ~3 decimal digits) silently
+        // overflow to NaN / lose precision on f32 models whose activations
+        // exceed f16 range — which the scalar f32 path handles fine. So
+        // prefer f32 coop tiles; treat f16 as opt-in (MEGANEURA_COOP_F16)
+        // for throughput when the model is known to fit f16. With only f16
+        // tiles and no opt-in, fall back to scalar f32 (correct).
+        let want_f16 = std::env::var("MEGANEURA_COOP_F16").is_ok();
+        if caps.f32_tile > 0 {
+            Some(CoopConfig { tile_size: caps.f32_tile, use_f16_input: false })
+        } else if caps.f16_tile > 0 && want_f16 {
+            Some(CoopConfig { tile_size: caps.f16_tile, use_f16_input: true })
         } else {
+            if caps.f16_tile > 0 {
+                log::warn!(
+                    "only f16 cooperative-matrix tiles available; using scalar \
+                     matmul (f16 coop overflows f32 models with large \
+                     activations). Set MEGANEURA_COOP_F16=1 to force f16 coop."
+                );
+            }
             None
         }
     }

--- a/tests/coop_conv_unaligned_k.rs
+++ b/tests/coop_conv_unaligned_k.rs
@@ -1,0 +1,80 @@
+//! Regression: Conv2dGemm cooperative-matrix kernel must be correct when
+//! K = Ci*kH*kW is not a multiple of 4. The vec4 weight staging assumed
+//! each [Co, K] row begins on a vec4 boundary; for Ci=14 (K=126) the rows
+//! are unaligned and the load read across row boundaries, corrupting the
+//! tile (max abs error ~1.9, 2M/4M elements wrong) and NaN-ing the deep
+//! van-world SR model on NVIDIA. Fixed by a per-element fallback when
+//! k_total % 4 != 0 (codegen::emit_forward_weight_stage).
+//!
+//! The coop path runs only on GPUs that advertise cooperative matrices;
+//! on f16-only GPUs it is opt-in (overflow-unsafe for large activations),
+//! so we force it with MEGANEURA_COOP_F16. With small bounded inputs f16
+//! precision is fine, isolating the K%4 *alignment* correctness. On
+//! no-coop hardware (e.g. lavapipe CI) both paths are scalar and the test
+//! trivially passes.
+
+use meganeura::{Graph, build_inference_session};
+
+fn conv_out(in_c: u32, coop: bool) -> Vec<f32> {
+    // SAFETY: tests run single-threaded (--test-threads=1 for GPU tests).
+    unsafe {
+        if coop {
+            std::env::set_var("MEGANEURA_COOP_F16", "1");
+            std::env::remove_var("MEGANEURA_DISABLE_COOP");
+        } else {
+            std::env::set_var("MEGANEURA_DISABLE_COOP", "1");
+            std::env::remove_var("MEGANEURA_COOP_F16");
+        }
+    }
+    let (batch, hw, out_c) = (32u32, 16u32, 64u32);
+    let in_size = (batch * in_c * hw * hw) as usize;
+    let k_size = (out_c * in_c * 9) as usize;
+    let mut g = Graph::new();
+    let x = g.input("x", &[in_size]);
+    let k = g.parameter("k", &[k_size]);
+    let y = g.conv2d(x, k, batch, in_c, hw, hw, out_c, 3, 3, 1, 1);
+    g.set_outputs(vec![y]);
+    let mut s = build_inference_session(&g);
+    // Small bounded values so f16 coop precision is not the issue.
+    let xd: Vec<f32> = (0..in_size).map(|i| ((i * 31 % 17) as f32 / 16.0 - 0.5) * 0.2).collect();
+    let kd: Vec<f32> = (0..k_size).map(|i| ((i * 13 % 19) as f32 / 18.0 - 0.5) * 0.2).collect();
+    s.set_parameter("k", &kd);
+    s.set_input("x", &xd);
+    s.step();
+    s.wait();
+    s.read_output((batch * out_c * hw * hw) as usize)
+}
+
+#[test]
+fn coop_conv_unaligned_k_matches_scalar() {
+    // K = 14*9 = 126, not a multiple of 4 — the failing case.
+    let scalar = conv_out(14, false);
+    let coop = conv_out(14, true);
+    let max_abs = scalar
+        .iter()
+        .zip(&coop)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    let nan = coop.iter().filter(|v| v.is_nan()).count();
+    println!("K=126 coop-vs-scalar: max_abs_diff={max_abs:.4}, coop NaNs={nan}");
+    // The bug gave max_abs ~1.9; f16 coop rounding on these bounded inputs
+    // is well under 0.05. (0 if the GPU has no coop — both scalar.)
+    assert_eq!(nan, 0, "coop conv produced NaNs at K=126");
+    assert!(
+        max_abs < 0.05,
+        "coop conv wrong at K=126 (not multiple of 4): max_abs_diff={max_abs}"
+    );
+}
+
+#[test]
+fn coop_conv_aligned_k_matches_scalar() {
+    // K = 16*9 = 144, a multiple of 4 — the already-working case (guard).
+    let scalar = conv_out(16, false);
+    let coop = conv_out(16, true);
+    let max_abs = scalar
+        .iter()
+        .zip(&coop)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    assert!(max_abs < 0.05, "coop conv wrong at K=144: max_abs_diff={max_abs}");
+}


### PR DESCRIPTION
## Summary

Two fixes surfaced by running the van-world SR diffusion model on an RTX 5070 — the first GPU exercised here that advertises cooperative matrices (the AMD 610M dev box has none; lavapipe CI has none). Both manifested as training NaN at batch 32.

### 1. `Conv2dGemm` coop kernel: K (= Ci·kH·kW) not a multiple of 4 (`21f63c0`)

The generated cooperative-matrix forward conv (`codegen::emit_forward_weight_stage`) staged weights via vec4 (128-bit) loads `weight[(gr*k_total + tc4) >> 2]`, assuming each `[Co, K]` row starts on a vec4 boundary, i.e. `k_total % 4 == 0`. When K isn't a multiple of 4 (e.g. Ci=14 → K=126), rows are unaligned, the vec4 read crosses row boundaries, corrupting the staged tile (max abs error ~1.9, ~2M/4M output elements wrong) and NaN-ing deep networks.

The van-world `conv_in` has 10 data + 4 conditioning = 14 input channels → K=126, exactly this case.

Fix: per-element component indexing (`weight[idx>>2][idx&3]`, alignment-independent) when `k_total % 4 != 0`; the vec4 fast path is kept for the aligned case (uniform branch, no regression there).

### 2. Prefer f32 coop tiles; make f16 coop opt-in for f32 models (`9b1f9d7`)

f16 coop operands (max 65504) silently overflow when an f32 model's activations exceed f16 range — which the scalar f32 path handles fine. `select_coop_config` unconditionally preferred f16 for throughput, NaN-ing f32 models with large activations on f16-only-coop GPUs (RTX 5070: `f16_tile=16, f32_tile=0`). Now: prefer f32 tiles; with only f16 available, fall back to scalar f32 unless `MEGANEURA_COOP_F16=1`.

## Test

New regression `tests/coop_conv_unaligned_k.rs`: K=126 (failing case) and K=144 (aligned guard), coop-vs-scalar, forcing coop with `MEGANEURA_COOP_F16=1`. Pre-fix max_abs ~1.9; post-fix **max_abs=0.0000, 0 NaNs**. On no-coop hardware (lavapipe CI) both paths are scalar and it passes trivially.

Verified on the 5070: gradcheck (18), coop_matmul_skinny w/ `MEGANEURA_COOP_F16=1` (22), training_correctness (8), coop_conv_unaligned_k (2) — all pass.

## Note on full tensor-core utilization

The 5070 exposes only f16 coop (no f32, no bf16 through blade). For models whose activations exceed f16 range, fix #2 means this GPU runs scalar f32 — correct, but not tensor cores. True full-HW use on such models needs **bf16 coop** (bf16 has f32's exponent range), which blade-graphics doesn't yet expose. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
