### PR TITLE
AdamW: decoupled weight decay via set_weight_decay

### DIFF
--- a/examples/gpu_compare.rs
+++ b/examples/gpu_compare.rs
@@ -1,0 +1,96 @@
+//! Raw hardware ceiling microbench: large compute-bound matmuls (fp32
+//! GFLOPS) + a large elementwise pass (memory GB/s). Run on each GPU via
+//! MEGANEURA_DEVICE_ID to get the *real* hardware delta, independent of the
+//! per-dispatch launch latency that bottlenecks small graphs.
+//!
+//!   MEGANEURA_DEVICE_ID=12036 cargo run --release --example gpu_compare  # 5070
+//!   MEGANEURA_DEVICE_ID=5710  cargo run --release --example gpu_compare  # 610M
+
+use std::time::Instant;
+
+use meganeura::{Graph, build_inference_session};
+
+fn bench_matmul(n: usize, warmup: usize, iters: usize) -> (f64, &'static str) {
+    // Square n×n×n matmul: 2 n^3 flops, O(n^2) memory — compute-bound for
+    // n >= ~1024, so it saturates the shader cores.
+    let mut g = Graph::new();
+    let a = g.input("a", &[n, n]);
+    let b = g.parameter("b", &[n, n]);
+    let c = g.matmul(a, b);
+    g.set_outputs(vec![c]);
+    let mut s = build_inference_session(&g);
+
+    let kernel = s
+        .plan()
+        .dispatches
+        .iter()
+        .find(|d| matches!(d.shader, meganeura::compile::ShaderEntry::MatMul))
+        .map(|d| if d.use_coop { "coop" } else if d.use_small_tiles { "small" } else { "tile" })
+        .unwrap_or("?");
+
+    s.set_input("a", &vec![0.01_f32; n * n]);
+    s.set_parameter("b", &vec![0.01_f32; n * n]);
+    for _ in 0..warmup {
+        s.step();
+    }
+    s.wait();
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        s.step();
+    }
+    s.wait();
+    (t0.elapsed().as_secs_f64() / iters as f64, kernel)
+}
+
+fn bench_bandwidth(n: usize, warmup: usize, iters: usize) -> f64 {
+    // Elementwise c = a + b over n floats: reads 2n, writes n => 12n bytes
+    // of traffic, ~0 arithmetic intensity => memory-bandwidth bound.
+    let mut g = Graph::new();
+    let a = g.input("a", &[n]);
+    let b = g.parameter("b", &[n]);
+    let c = g.add(a, b);
+    g.set_outputs(vec![c]);
+    let mut s = build_inference_session(&g);
+    s.set_input("a", &vec![1.0_f32; n]);
+    s.set_parameter("b", &vec![2.0_f32; n]);
+    for _ in 0..warmup {
+        s.step();
+    }
+    s.wait();
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        s.step();
+    }
+    s.wait();
+    t0.elapsed().as_secs_f64() / iters as f64
+}
+
+fn main() {
+    env_logger::init();
+    let device_name = {
+        let mut g = Graph::new();
+        let x = g.input("x", &[4, 4]);
+        let w = g.parameter("w", &[4, 4]);
+        let y = g.matmul(x, w);
+        g.set_outputs(vec![y]);
+        build_inference_session(&g).device_information().device_name.clone()
+    };
+    println!("device: {device_name}\n");
+
+    println!("== compute: square fp32 matmul ==");
+    println!("{:>6} {:>10} {:>9} {:>7}", "N", "ms", "GFLOP/s", "kernel");
+    for &n in &[512usize, 1024, 2048, 4096] {
+        let iters = if n >= 2048 { 30 } else { 100 };
+        let (per_call, kernel) = bench_matmul(n, 10, iters);
+        let gflops = 2.0 * (n as f64).powi(3) / per_call / 1e9;
+        println!("{n:>6} {:>10.3} {gflops:>9.0} {kernel:>7}", per_call * 1000.0);
+    }
+
+    println!("\n== memory: elementwise add (12 bytes/elem) ==");
+    println!("{:>10} {:>10} {:>9}", "Melem", "ms", "GB/s");
+    for &n in &[1usize << 22, 1 << 24, 1 << 26] {
+        let per_call = bench_bandwidth(n, 10, 100);
+        let gbs = 12.0 * n as f64 / per_call / 1e9;
+        println!("{:>10} {:>10.3} {gbs:>9.0}", n / (1 << 20), per_call * 1000.0);
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -234,7 +234,7 @@ struct AdamParams {
     beta2: f32,
     eps: f32,
     step: f32,
-    _pad0: u32,
+    wd: f32,
     _pad1: u32,
 }
 
@@ -1579,6 +1579,8 @@ pub struct Session {
     /// `step()` calls until overridden by another `set_adam` /
     /// `set_learning_rate` call or cleared via `clear_optimizer()`.
     pending_adam: Option<(f32, f32, f32, f32)>, // (lr, beta1, beta2, eps)
+    /// Decoupled weight-decay coefficient (AdamW). 0.0 = plain Adam.
+    adam_wd: f32,
     /// Maximum L2 norm of the per-step concatenated gradient. When set,
     /// `step()` splits its submission so it can read all gradient buffers
     /// to CPU between backward and optimizer, scale them by
@@ -2292,6 +2294,7 @@ impl Session {
             adam_state,
             adam_step: 0,
             pending_adam: None,
+            adam_wd: 0.0,
             weight_staging: HashMap::new(),
         }
     }
@@ -3759,6 +3762,7 @@ impl Session {
                 }
             } else if let Some((lr, beta1, beta2, eps)) = self.pending_adam {
                 self.adam_step += 1;
+                let wd = self.adam_wd;
                 let pipeline = &self.pipelines.map[&ShaderEntry::AdamUpdate];
                 let mut pass = self.encoder.compute("adam_update");
                 for (idx, &(param_buf, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
@@ -3791,7 +3795,7 @@ impl Session {
                                 beta2,
                                 eps,
                                 step: self.adam_step as f32,
-                                _pad0: 0,
+                                wd,
                                 _pad1: 0,
                             },
                         },
@@ -5180,7 +5184,7 @@ impl Session {
                         beta2,
                         eps,
                         step: self.adam_step as f32,
-                        _pad0: 0,
+                        wd: self.adam_wd,
                         _pad1: 0,
                     },
                 },
@@ -5204,6 +5208,14 @@ impl Session {
         self.pending_adam = Some((lr, beta1, beta2, eps));
         // Switching optimizers: Adam wins, SGD stops applying.
         self.pending_lr = None;
+    }
+
+    /// Set the decoupled weight-decay coefficient for the Adam update,
+    /// turning it into AdamW: each step also applies `param -= lr * wd * param`,
+    /// independent of the gradient. 0.0 (the default) is plain Adam. Persists
+    /// across steps until changed; unaffected by [`set_adam`].
+    pub fn set_weight_decay(&mut self, wd: f32) {
+        self.adam_wd = wd;
     }
 
     /// Stop running optimizer updates after `step()`.

--- a/src/shaders/adam.wgsl
+++ b/src/shaders/adam.wgsl
@@ -5,7 +5,7 @@ struct Params {
     beta2: f32,
     eps: f32,
     step: f32,
-    _pad0: u32,
+    wd: f32,
     _pad1: u32,
 }
 
@@ -34,6 +34,8 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let m_hat = m_new / (1.0 - pow(params.beta1, params.step));
     let v_hat = v_new / (1.0 - pow(params.beta2, params.step));
 
-    // Update parameter
-    param[i] = param[i] - params.lr * m_hat / (sqrt(v_hat) + params.eps);
+    // Update parameter. Decoupled weight decay (AdamW): the wd*param term is
+    // applied directly to the weight, NOT routed through the Adam moments, so
+    // it is independent of the gradient's adaptive scaling.
+    param[i] = param[i] - params.lr * (m_hat / (sqrt(v_hat) + params.eps) + params.wd * param[i]);
 }


### PR DESCRIPTION
## Summary

Adds **AdamW** (decoupled weight decay) to the Adam optimizer, which previously had no weight-decay term.

- `adam.wgsl`: each step now also applies `param -= lr * wd * param`, applied directly to the weight (not routed through the Adam moments, so it is independent of the gradient's adaptive scaling). Reuses the existing `_pad0` slot in the Adam uniform — no buffer-size change.
- `runtime.rs`: `Session::set_weight_decay(wd)` setter; `adam_wd` state persists across steps, threaded into both Adam dispatch sites. Defaults to 0.0, so the update is **bit-identical to plain Adam** unless set (the uniform slot that was `_pad0 = 0` now carries `wd = 0` — same bytes).

Also includes a small `examples/gpu_compare.rs` hardware-ceiling microbench (large compute-bound matmul GFLOP/s + elementwise bandwidth GB/s, honoring `MEGANEURA_DEVICE_ID`) — drop the second commit if unwanted.

## Validation

- `wd = 0` path is bit-identical to the prior Adam update.
- `wd = 0.05` exercised live on a real training run (van-world SR): weight decay measurably bounded/shrank parameters as expected.
- Builds + clippy clean on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
