### PR TITLE
Nvidia whisper optimizations

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1483,18 +1483,39 @@ fn gen_matmul_coop_wgsl_prologue(
         a_stage_1 = gen_vec4_a("shared_b1", &format!("(tile_row + {}u)", tile));
     } else if vec4_a_transposed {
         // AT: A[K,M], load vec4 along M (consecutive in memory), write
-        // transposed to shared.
+        // transposed to shared. The packed vec4 load is valid only when M is
+        // divisible by four: otherwise successive K rows start at different
+        // lanes of the storage vec4. Partial rows and unaligned row strides
+        // use scalar lane extraction, mirroring the Normal/BT staging paths.
         let gen_vec4_at = |shared: &str, row_offset: &str| -> String {
             format!(
                 "{{\
                \n            let tc = t + v4_row;\
                \n            let gr4 = {row} + v4_col;\
-               \n            if tc < k && (gr4 + 4u) <= m {{\
+               \n            if tc < k && (gr4 + 4u) <= m && (m & 3u) == 0u {{\
                \n                let v = matrix_a[(tc * m + gr4) >> 2u];\
                \n                {s}[v4_col * {t}u + v4_row] = {co}v.x{cc};\
                \n                {s}[(v4_col + 1u) * {t}u + v4_row] = {co}v.y{cc};\
                \n                {s}[(v4_col + 2u) * {t}u + v4_row] = {co}v.z{cc};\
                \n                {s}[(v4_col + 3u) * {t}u + v4_row] = {co}v.w{cc};\
+               \n            }} else if tc < k {{\
+               \n                let m0 = (gr4 + 0u) < m;\
+               \n                let m1 = (gr4 + 1u) < m;\
+               \n                let m2 = (gr4 + 2u) < m;\
+               \n                let m3 = (gr4 + 3u) < m;\
+               \n                let last = m - 1u;\
+               \n                let a0 = tc * m + min(gr4 + 0u, last);\
+               \n                let a1 = tc * m + min(gr4 + 1u, last);\
+               \n                let a2 = tc * m + min(gr4 + 2u, last);\
+               \n                let a3 = tc * m + min(gr4 + 3u, last);\
+               \n                let v0 = matrix_a[a0 >> 2u][a0 & 3u];\
+               \n                let v1 = matrix_a[a1 >> 2u][a1 & 3u];\
+               \n                let v2 = matrix_a[a2 >> 2u][a2 & 3u];\
+               \n                let v3 = matrix_a[a3 >> 2u][a3 & 3u];\
+               \n                {s}[v4_col * {t}u + v4_row] = select({z}, {co}v0{cc}, m0);\
+               \n                {s}[(v4_col + 1u) * {t}u + v4_row] = select({z}, {co}v1{cc}, m1);\
+               \n                {s}[(v4_col + 2u) * {t}u + v4_row] = select({z}, {co}v2{cc}, m2);\
+               \n                {s}[(v4_col + 3u) * {t}u + v4_row] = select({z}, {co}v3{cc}, m3);\
                \n            }} else {{\
                \n                let z = {z};\
                \n                {s}[v4_col * {t}u + v4_row] = z;\
@@ -2840,6 +2861,10 @@ pub fn generate_flash_grad_kv_coop_module(head_dim: u32) -> ShaderModule {
     let _ = writeln!(src, "var<workgroup> shared_p: array<f32, {}>;", bkv * bq);
     let _ = writeln!(src, "var<workgroup> shared_ds: array<f32, {}>;", bkv * bq);
     let _ = writeln!(src, "var<workgroup> wg_row_sum: array<f32, {bq}>;");
+    let _ = writeln!(
+        src,
+        "var<workgroup> wg_row_sum_partial: array<f32, {wg_size}>;"
+    );
     let _ = writeln!(src, "var<workgroup> wg_lse_max: array<f32, {bq}>;");
     let _ = writeln!(src, "var<workgroup> wg_lse_log: array<f32, {bq}>;");
     src.push('\n');
@@ -2953,27 +2978,37 @@ pub fn generate_flash_grad_kv_coop_module(head_dim: u32) -> ShaderModule {
     src.push_str("            }\n");
     src.push_str("            workgroupBarrier();\n\n");
 
-    // Precompute row_sum[qi] and lse cache (16 threads).
-    let _ = writeln!(src, "            if lid.x < {bq}u {{");
-    src.push_str("                let qi = lid.x;\n");
-    src.push_str("                let qp = t + qi;\n");
-    src.push_str("                if qp < q_seq && q_head < num_heads {\n");
-    src.push_str("                    var s = 0.0;\n");
-    src.push_str("                    let q_base = qp * q_dim + q_head * head_dim;\n");
+    // Precompute row_sum[qi] = dot(dO[qi], O[qi]). Map four threads to
+    // contiguous chunks of each Q row, matching the workgroup's existing
+    // (row, chunk) layout. The old one-thread-per-row loop left 48/64
+    // threads idle and issued strided loads across 16 distant Q rows.
+    src.push_str("            let row_qp = t + kv_row;\n");
+    src.push_str("            var row_part = 0.0;\n");
+    src.push_str("            if row_qp < q_seq && q_head < num_heads {\n");
+    src.push_str("                let q_base = row_qp * q_dim + q_head * head_dim + d_off;\n");
     let _ = writeln!(
         src,
-        "                    for (var d = 0u; d < {hd}u; d = d + 1u) {{"
+        "                for (var e = 0u; e < {chunk_hd}u; e = e + 1u) {{"
     );
-    src.push_str("                        s = s + d_out[q_base + d] * fwd_dst[q_base + d];\n");
-    src.push_str("                    }\n");
-    src.push_str("                    wg_row_sum[qi] = s;\n");
+    let _ = writeln!(
+        src,
+        "                    row_part = row_part + f32(shared_do[kv_row * {hd}u + d_off + e]) * fwd_dst[q_base + e];"
+    );
+    src.push_str("                }\n");
+    src.push_str("            }\n");
+    src.push_str("            wg_row_sum_partial[lid.x] = row_part;\n");
+    src.push_str("            workgroupBarrier();\n");
+    let _ = writeln!(src, "            if lid.x < {bq}u {{");
+    let _ = writeln!(src, "                let base = lid.x * {chunks_per_row}u;");
+    src.push_str("                wg_row_sum[lid.x] = wg_row_sum_partial[base] + wg_row_sum_partial[base + 1u] + wg_row_sum_partial[base + 2u] + wg_row_sum_partial[base + 3u];\n");
+    src.push_str("                let qp = t + lid.x;\n");
+    src.push_str("                if qp < q_seq && q_head < num_heads {\n");
     src.push_str("                    let li = (qp * num_heads + q_head) * 2u;\n");
-    src.push_str("                    wg_lse_max[qi] = lse[li];\n");
-    src.push_str("                    wg_lse_log[qi] = lse[li + 1u];\n");
+    src.push_str("                    wg_lse_max[lid.x] = lse[li];\n");
+    src.push_str("                    wg_lse_log[lid.x] = lse[li + 1u];\n");
     src.push_str("                } else {\n");
-    src.push_str("                    wg_row_sum[qi] = 0.0;\n");
-    src.push_str("                    wg_lse_max[qi] = 0.0;\n");
-    src.push_str("                    wg_lse_log[qi] = 0.0;\n");
+    src.push_str("                    wg_lse_max[lid.x] = 0.0;\n");
+    src.push_str("                    wg_lse_log[lid.x] = 0.0;\n");
     src.push_str("                }\n");
     src.push_str("            }\n");
     src.push_str("            workgroupBarrier();\n\n");

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -2679,7 +2679,8 @@ impl<'a> Compiler<'a> {
                     // Use implicit GEMM: output = weight @ im2col(input)^T
                     // M=Co, N=oH*oW, K=Ci*kH*kW, batched in z dimension
                     // Use small (32×32) tiles when workgroup count per batch is low.
-                    let wgs_64 = out_h * out_w.div_ceil(64) * out_channels.div_ceil(64);
+                    let spatial = out_h * out_w;
+                    let wgs_64 = spatial.div_ceil(64) * out_channels.div_ceil(64);
                     let use_small = wgs_64 < 16;
                     let tile = if use_small { 32 } else { 64 };
                     self.plan.dispatches.push(Dispatch {
@@ -2688,11 +2689,7 @@ impl<'a> Compiler<'a> {
                         } else {
                             ShaderEntry::Conv2dGemm
                         },
-                        workgroups: [
-                            out_h * out_w.div_ceil(tile),
-                            out_channels.div_ceil(tile),
-                            batch,
-                        ],
+                        workgroups: [spatial.div_ceil(tile), out_channels.div_ceil(tile), batch],
                         input_buffers: vec![input, kernel],
                         output_buffer: out_buf,
                         extra_outputs: vec![],
@@ -2905,7 +2902,8 @@ impl<'a> Compiler<'a> {
                     // Use implicit GEMM: grad_input = weight_T @ im2col(grad_out)^T
                     // M=Ci, N=H*W, K=Co*kH*kW, batched in z dimension.
                     {
-                        let wgs_64 = in_h * in_w.div_ceil(64) * in_channels.div_ceil(64);
+                        let spatial = in_h * in_w;
+                        let wgs_64 = spatial.div_ceil(64) * in_channels.div_ceil(64);
                         let use_small = wgs_64 < 16;
                         let tile = if use_small { 32 } else { 64 };
                         self.plan.dispatches.push(Dispatch {
@@ -2914,11 +2912,7 @@ impl<'a> Compiler<'a> {
                             } else {
                                 ShaderEntry::Conv2dGradInputGemm
                             },
-                            workgroups: [
-                                in_h * in_w.div_ceil(tile),
-                                in_channels.div_ceil(tile),
-                                batch,
-                            ],
+                            workgroups: [spatial.div_ceil(tile), in_channels.div_ceil(tile), batch],
                             input_buffers: vec![grad_out, kernel],
                             output_buffer: out_buf,
                             extra_outputs: vec![],
@@ -3341,7 +3335,6 @@ impl<'a> Compiler<'a> {
                 let bwd_coop_disabled =
                     std::env::var("MEGANEURA_FLASH_BWD_COOP").as_deref() == Ok("0");
                 let bwd_coop_enabled = !bwd_coop_disabled
-                    && grad_kv_shader == ShaderEntry::FlashAttention
                     && self.coop_caps.supports_16x16_f16()
                     && head_dim >= 16
                     && head_dim.is_multiple_of(16)
@@ -4073,6 +4066,35 @@ mod tests {
     }
 
     #[test]
+    fn conv1d_emulation_dispatches_flat_spatial_tiles() {
+        // Whisper represents its temporal convolutions as H×1 Conv2d. The
+        // spatial workgroup axis tiles H*W, rather than tiling W once per H.
+        let mut g = Graph::new();
+        let x = g.parameter("x", &[80 * 3000]);
+        let w = g.parameter("w", &[512 * 80 * 3]);
+        let y = g.conv2d_hw(x, w, 1, 80, 3000, 1, 512, 3, 1, 1, 1, 0);
+        let loss = g.sum_all(y);
+        g.set_outputs(vec![loss]);
+
+        let plan = compile(&g);
+        let forward = plan
+            .dispatches
+            .iter()
+            .find(|dispatch| dispatch.shader == ShaderEntry::Conv2dGemm)
+            .unwrap();
+        assert_eq!(forward.workgroups, [3000u32.div_ceil(64), 8, 1]);
+
+        let differentiated = crate::autodiff::differentiate(&g);
+        let training = compile(&differentiated);
+        let grad_input = training
+            .dispatches
+            .iter()
+            .find(|dispatch| dispatch.shader == ShaderEntry::Conv2dGradInputGemm)
+            .unwrap();
+        assert_eq!(grad_input.workgroups, [3000u32.div_ceil(64), 2, 1]);
+    }
+
+    #[test]
     fn test_compile_loss_buffer() {
         let mut g = Graph::new();
         let x = g.input("x", &[4, 8]);
@@ -4246,5 +4268,41 @@ mod tests {
                 | ShaderEntry::FlashGradQCoop
                 | ShaderEntry::FlashGradKVCoop
         )));
+    }
+
+    #[test]
+    fn short_cross_attention_selects_coop_grad_kv() {
+        // The scalar flash heuristic uses BQ=128 at head_dim=64, so a
+        // SmolVLA-shaped 16-position KV span selects MultiHeadAttn. The
+        // cooperative GradKV kernel has its own BKV=16 geometry and must not
+        // inherit that unrelated scalar decision.
+        let mut g = Graph::new();
+        let q = g.parameter("q", &[50, 15 * 64]);
+        let k = g.parameter("k", &[16, 5 * 64]);
+        let v = g.parameter("v", &[16, 5 * 64]);
+        let attention = g.multi_head_attn(q, k, v, 15, 5, 64, true);
+        let loss = g.sum_all(attention);
+        g.set_outputs(vec![loss]);
+        let differentiated = crate::autodiff::differentiate(&g);
+
+        let plan = compile_with_caps(
+            &differentiated,
+            &CompileOptions::default(),
+            crate::codegen::CoopCaps {
+                f16_tile: 16,
+                f32_tile: 0,
+            },
+        );
+
+        assert!(
+            plan.dispatches
+                .iter()
+                .any(|dispatch| dispatch.shader == ShaderEntry::FlashGradKVCoop)
+        );
+        assert!(
+            plan.dispatches
+                .iter()
+                .all(|dispatch| { dispatch.shader != ShaderEntry::MultiHeadAttnGradKV })
+        );
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1969,6 +1969,14 @@ impl Session {
                 let is_conv_bwd = matches!(group, ShaderGroup::Conv2dGradInputGemm);
                 let min_wgs = if is_conv_bwd {
                     MIN_COOP_WORKGROUPS_CONV_BWD
+                } else if config.use_f16_input {
+                    // On discrete NVIDIA GPUs the f16 cooperative kernel's
+                    // shared-memory staging costs more than the scalar tile
+                    // kernel at low occupancy. Representative transformer
+                    // projections with 20--72 output workgroups regress,
+                    // while the wider backward/MLP shapes win once there are
+                    // enough independent tiles to fill the device.
+                    128
                 } else {
                     16 // enables coop for attention K/V projections (N=320, 20 WGs)
                 };
@@ -1993,16 +2001,18 @@ impl Session {
                 //
                 //   * The OUTPUT STORE uses `coopStoreT(acc, &c[row*n+col],
                 //     n)` which writes a 16×16 sub-tile with row stride
-                //     `n`. When N (or M for the analogous AT/BT cases) is
-                //     not a multiple of 16, the right-edge / bottom-edge
-                //     sub-tile straddles the matrix boundary and the store
-                //     corrupts the next row's leading columns. Refuse coop
-                //     unless both output dimensions are multiples of 16.
+                //     `n`. A right-edge tile with N not divisible by 16
+                //     straddles logical rows, so it remains unsupported. A
+                //     bottom-edge tile is safe: session construction pads the
+                //     allocation to `ceil(M/16) * N`, and consumers retain the
+                //     logical M extent, so the extra rows are never observed.
+                //     Allowing partial M tiles is important for sequence
+                //     lengths such as 50, which dominate transformer training.
                 //
                 // (Conv2d / FusedRmsNormMatMul also store via coopStoreT
                 // and need the same check; their `m`/`n` come from the
                 // params destructure above.)
-                let store_ok = m.is_multiple_of(16) && n.is_multiple_of(16);
+                let store_ok = n.is_multiple_of(16);
                 let vec4_ok = match group {
                     ShaderGroup::MatMulBT => store_ok,
                     ShaderGroup::MatMulAT => store_ok,

--- a/src/train.rs
+++ b/src/train.rs
@@ -420,13 +420,19 @@ pub fn build_session_unoptimized(forward_graph: &Graph) -> Session {
     .0
 }
 
-/// Run the compile pipeline (autodiff → optimize → compile) without
-/// creating a GPU session. Useful for testing compilation in
-/// environments without GPU access.
+/// Run the training compile pipeline without creating a GPU session.
+///
+/// This deliberately mirrors [`build`]: optimize and topologically sort the
+/// forward graph before autodiff, then optimize the combined forward/backward
+/// graph. Optimizing only after autodiff can pack two source parameters into
+/// one derived parameter while leaving the original two gradient outputs in
+/// place, breaking the positional parameter/gradient contract in the plan.
+/// Useful for testing compilation in environments without GPU access.
 pub fn compile_training_graph(
     forward_graph: &Graph,
 ) -> (crate::compile::ExecutionPlan, OptimizeReport) {
-    let full_graph = autodiff::differentiate(forward_graph);
+    let optimized_forward = optimize::optimize(forward_graph).toposort();
+    let full_graph = autodiff::differentiate(&optimized_forward);
     let (optimized, report) = optimize::optimize_with_report(&full_graph);
     let plan = compile::compile(&optimized);
     (plan, report)
@@ -482,6 +488,30 @@ mod tests {
             report.fusions_applied.is_empty(),
             "unexpected fusions: {:?}",
             report.fusions_applied
+        );
+    }
+
+    #[test]
+    fn compile_training_graph_packs_swiglu_before_autodiff() {
+        let mut g = Graph::new();
+        let x = g.input("x", &[16, 32]);
+        let gate = g.parameter("gate", &[32, 64]);
+        let up = g.parameter("up", &[32, 64]);
+        let down = g.parameter("down", &[64, 32]);
+        let gate_proj = g.matmul(x, gate);
+        let up_proj = g.matmul(x, up);
+        let hidden = g.swiglu(gate_proj, up_proj);
+        let output = g.matmul(hidden, down);
+        let loss = g.mean_all(output);
+        g.set_outputs(vec![loss]);
+
+        let (plan, _) = compile_training_graph(&g);
+
+        assert_eq!(plan.param_buffers.len(), plan.param_grad_pairs.len());
+        assert!(
+            plan.param_buffers
+                .iter()
+                .any(|&(ref name, _)| name == "gate+up")
         );
     }
 

--- a/tests/coop_matmul_skinny.rs
+++ b/tests/coop_matmul_skinny.rs
@@ -268,8 +268,29 @@ fn matmul_bt_n33_non_aligned() {
     run_matmul_bt(4096, 32, 33);
 }
 
-// ---------- M direction (vec4_a_transposed + output store) ----------
-// MatMulAT with M small / non-aligned.
+// ---------- M direction (vec4_a_transposed + padded output store) ----------
+// A partial final row tile is safe when N is tile-aligned: the runtime pads
+// the output allocation through the next complete M tile, and consumers keep
+// using the logical M extent. These exercise enough workgroups to ensure the
+// f16 cooperative path is selected on supported hardware.
+
+#[test]
+fn matmul_m50_n256() {
+    run_matmul(50, 128, 256);
+}
+
+#[test]
+fn matmul_bt_m50_n256() {
+    run_matmul_bt(50, 128, 256);
+}
+
+#[test]
+fn matmul_at_m50_n256() {
+    run_matmul_at(50, 128, 256);
+}
+
+// Smaller MatMulAT shapes remain useful coverage for transposed staging,
+// although they may stay below the cooperative workgroup threshold.
 
 #[test]
 fn matmul_at_m1() {

--- a/tests/flash_grad_kv_short.rs
+++ b/tests/flash_grad_kv_short.rs
@@ -1,0 +1,102 @@
+//! Short-sequence cooperative dK/dV parity on GPUs with 16x16 f16 tiles.
+//!
+//! SmolVLA uses Q=50 with both KV=16 (cross attention) and KV=50 (self
+//! attention). These shapes must not inherit the scalar flash kernel's much
+//! larger BQ heuristic when selecting the independent BKV=16 coop kernel.
+
+use std::sync::Arc;
+
+use meganeura::{Graph, Mode, SessionConfig, build, compile::ShaderEntry};
+
+fn run(
+    gpu: Arc<blade_graphics::Context>,
+    q_seq: usize,
+    kv_seq: usize,
+    cooperative: bool,
+) -> (Vec<f32>, Vec<f32>, bool) {
+    unsafe {
+        std::env::set_var("MEGANEURA_FLASH_FWD_COOP", "0");
+        std::env::set_var(
+            "MEGANEURA_FLASH_BWD_COOP",
+            if cooperative { "1" } else { "0" },
+        );
+    }
+
+    let (num_heads, num_kv_heads, head_dim) = (3, 1, 64);
+    let mut graph = Graph::new();
+    let q = graph.parameter("q", &[q_seq, num_heads as usize * head_dim as usize]);
+    let k = graph.parameter("k", &[kv_seq, num_kv_heads as usize * head_dim as usize]);
+    let v = graph.parameter("v", &[kv_seq, num_kv_heads as usize * head_dim as usize]);
+    let attention =
+        graph.multi_head_attn(q, k, v, num_heads, num_kv_heads, head_dim, q_seq != kv_seq);
+    let loss = graph.mean_all(attention);
+    graph.set_outputs(vec![loss]);
+
+    let (mut session, _) = build(
+        &graph,
+        SessionConfig {
+            mode: Mode::Training,
+            gpu: Some(gpu),
+            ..Default::default()
+        },
+    );
+    let uses_coop = session
+        .plan()
+        .dispatches
+        .iter()
+        .any(|dispatch| dispatch.shader == ShaderEntry::FlashGradKVCoop);
+
+    let q_data: Vec<f32> = (0..q_seq * num_heads as usize * head_dim as usize)
+        .map(|i| ((i as f32 * 0.017) + 0.3).sin() * 0.1)
+        .collect();
+    let k_data: Vec<f32> = (0..kv_seq * num_kv_heads as usize * head_dim as usize)
+        .map(|i| ((i as f32 * 0.019) + 0.7).sin() * 0.1)
+        .collect();
+    let v_data: Vec<f32> = (0..kv_seq * num_kv_heads as usize * head_dim as usize)
+        .map(|i| ((i as f32 * 0.023) + 1.1).sin() * 0.1)
+        .collect();
+    session.set_parameter("q", &q_data);
+    session.set_parameter("k", &k_data);
+    session.set_parameter("v", &v_data);
+    session.step();
+    session.wait();
+
+    let mut dk = vec![0.0; k_data.len()];
+    let mut dv = vec![0.0; v_data.len()];
+    session.read_param_grad("k", &mut dk);
+    session.read_param_grad("v", &mut dv);
+    (dk, dv, uses_coop)
+}
+
+fn assert_close(label: &str, scalar: &[f32], cooperative: &[f32]) {
+    let max_abs = scalar
+        .iter()
+        .zip(cooperative)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f32, f32::max);
+    let scale = scalar
+        .iter()
+        .map(|value| value.abs())
+        .fold(0.0_f32, f32::max)
+        .max(1e-6);
+    assert!(
+        max_abs / scale < 0.02,
+        "{label}: cooperative dK/dV differs from scalar by {:.3}% (max abs {max_abs:.3e})",
+        max_abs / scale * 100.0,
+    );
+}
+
+#[test]
+fn short_cross_and_self_attention_grad_kv_match_scalar() {
+    let gpu = Arc::new(meganeura::runtime::init_gpu_context().expect("GPU context"));
+    let has_coop = gpu.capabilities().cooperative_matrix.f16_tile == 16;
+
+    for (label, q_seq, kv_seq) in [("cross", 50, 16), ("self", 50, 50)] {
+        let (scalar_k, scalar_v, scalar_used_coop) = run(gpu.clone(), q_seq, kv_seq, false);
+        let (coop_k, coop_v, coop_used_coop) = run(gpu.clone(), q_seq, kv_seq, true);
+        assert!(!scalar_used_coop);
+        assert_eq!(coop_used_coop, has_coop);
+        assert_close(&format!("{label} dK"), &scalar_k, &coop_k);
+        assert_close(&format!("{label} dV"), &scalar_v, &coop_v);
+    }
+}

--- a/tests/inference_parity_large.rs
+++ b/tests/inference_parity_large.rs
@@ -181,3 +181,60 @@ fn conv1x1_layout_parity() {
         &want[..6]
     );
 }
+
+/// Whisper's Conv1d emulation uses H×1 tensors. Cover a spatial length
+/// larger than one GEMM tile so reducing the dispatch from H workgroups to
+/// ceil(H/tile) cannot accidentally drop valid output rows.
+#[test]
+fn conv3x1_flat_spatial_dispatch_parity() {
+    let (c_in, c_out, h) = (3usize, 5usize, 129usize);
+    let in_size = c_in * h;
+    let out_size = c_out * h;
+
+    let mut g = Graph::new();
+    let x = g.input("x", &[in_size]);
+    let k = g.parameter("k", &[c_out * c_in * 3]);
+    let y = g.conv2d_hw(
+        x,
+        k,
+        1,
+        c_in as u32,
+        h as u32,
+        1,
+        c_out as u32,
+        3,
+        1,
+        1,
+        1,
+        0,
+    );
+    g.set_outputs(vec![y]);
+
+    let mut session = build_inference_session(&g);
+    let x_data = ramp(in_size, 0.7, 0.1);
+    let k_data = ramp(c_out * c_in * 3, 0.2, 0.0);
+    session.set_parameter("k", &k_data);
+    session.set_input("x", &x_data);
+    session.step();
+    session.wait();
+    let got = session.read_output(out_size);
+
+    let mut want = vec![0.0; out_size];
+    for co in 0..c_out {
+        for oh in 0..h {
+            let mut sum = 0.0;
+            for ci in 0..c_in {
+                for kh in 0..3 {
+                    let ih = oh as isize + kh as isize - 1;
+                    if (0..h as isize).contains(&ih) {
+                        sum += x_data[ci * h + ih as usize] * k_data[(co * c_in + ci) * 3 + kh];
+                    }
+                }
+            }
+            want[co * h + oh] = sum;
+        }
+    }
+
+    let d = max_diff(&got, &want);
+    assert!(d < 1e-3, "conv3x1 H×1 parity mismatch: max_diff={d:.4}");
+}


### PR DESCRIPTION
  - Fixed Whisper’s H×1 convolution dispatch geometry, eliminating up to 64× over-dispatch in src/compile.rs:2682.
  - Enabled cooperative dK/dV independently for SmolVLA’s short KV sequences in src/compile.rs:3332.
  - Parallelized and coalesced the dK/dV row-dot reduction across all 64 threads in src/codegen.rs:2981.
  - Hardened partial-row cooperative matmuls and transposed-A staging in src/runtime.rs:2002 and src/codegen.rs:1484.
  - Fixed the training-only compilation helper’s parameter/gradient packing order in src/train.rs:423.
  - Added GPU parity coverage for short cooperative gradients and Whisper-style convolution in tests/flash_grad_kv_short.rs:1 and tests/ inference_parity_large.rs:185.