### PR TITLE
Integrate Android runtime support and chunked submission on current main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,15 @@ rust-version = "1.88"
 description = "E-graph optimized neural network training on Blade"
 license = "MIT"
 
+[features]
+default = ["hub"]
+# Downloading weights from the HuggingFace Hub
+# (`SafeTensorsModel::download` / `download_file`). Turn this off on
+# targets where there is no ambient HTTP/TLS stack or writable cache
+# directory — Android, for instance, ships weights as app assets and
+# loads them through `SafeTensorsModel::load`.
+hub = ["dep:hf-hub"]
+
 [dependencies]
 blade-graphics = { version = "0.8.4", git = "https://github.com/kvark/blade", rev = "60c2eeb8d6180ff2db5167e304d55b78a18dfee2" }
 blade-macros = "0.3"
@@ -22,16 +31,22 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ron = "0.8"
 log = "0.4"
-env_logger = "0.11"
 flate2 = "1"
 safetensors = "0.4"
-hf-hub = { version = "0.4", default-features = false, features = ["ureq", "rustls-tls"] }
-tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
+hf-hub = { version = "0.4", default-features = false, features = ["ureq", "rustls-tls"], optional = true }
 oxionnx-core = "0.1"
 oxionnx-proto = "0.1"
 half = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry"] }
+
+# Only the examples, benches, and tests need these. Keeping them out of
+# `[dependencies]` matters for cross-compilation: `tokenizers`/`onig`
+# pulls in a C library, which is a needless build-script burden for
+# downstream crates that just want the inference runtime.
+[dev-dependencies]
+env_logger = "0.11"
+tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
 
 [[example]]
 name = "mnist"

--- a/src/data/safetensors.rs
+++ b/src/data/safetensors.rs
@@ -8,7 +8,9 @@
 //! ```no_run
 //! use meganeura::data::safetensors::SafeTensorsModel;
 //!
-//! let model = SafeTensorsModel::download("dacorvo/mnist-mlp").unwrap();
+//! // `SafeTensorsModel::download("dacorvo/mnist-mlp")` fetches from the
+//! // Hub instead, when the `hub` feature is enabled.
+//! let model = SafeTensorsModel::load("model.safetensors".into()).unwrap();
 //! for (name, info) in model.tensor_info() {
 //!     println!("{}: shape={:?}", name, info.shape);
 //! }
@@ -41,6 +43,10 @@ impl SafeTensorsModel {
     /// Download a model from HuggingFace Hub by repository ID.
     ///
     /// Downloads `model.safetensors` from the given repo (e.g. `"dacorvo/mnist-mlp"`).
+    ///
+    /// Requires the `hub` feature. Without it, fetch the weights ahead of
+    /// time and use [`SafeTensorsModel::load`].
+    #[cfg(feature = "hub")]
     pub fn download(repo_id: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let api = hf_hub::api::sync::Api::new()?;
         let repo = api.model(repo_id.to_string());
@@ -104,6 +110,10 @@ impl SafeTensorsModel {
     }
 
     /// Download a specific safetensors file from a HuggingFace Hub repo.
+    ///
+    /// Requires the `hub` feature. Without it, fetch the weights ahead of
+    /// time and use [`SafeTensorsModel::load`].
+    #[cfg(feature = "hub")]
     pub fn download_file(
         repo_id: &str,
         filename: &str,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1815,7 +1815,7 @@ pub struct Session {
     /// compute pass. Pass boundaries in blade emit ALL_COMMANDS barriers.
     groups: Vec<std::ops::Range<usize>>,
     encoder: blade_graphics::CommandEncoder,
-    /// How many submissions `step()` splits its dispatches across.
+    /// Caller-selected upper bound on the submissions used by `step()`.
     /// See [`Session::set_submission_chunks`]. Always at least 1.
     submission_chunks: usize,
     sync_point: Option<blade_graphics::SyncPoint>,
@@ -2778,14 +2778,20 @@ impl Session {
         }
     }
 
-    /// Split `step()`'s dispatches across several submissions instead of one.
+    /// Set an upper bound on the submissions used by `step()`.
     ///
-    /// By default the whole plan goes into a single command buffer, which
-    /// occupies the queue for its entire duration. That is ideal when
-    /// meganeura owns the GPU, and poor when it does not: sharing a device
-    /// with a renderer means every frame queues behind the whole inference.
-    /// On a Quest 3S a 135 ms encoder drops a 90 Hz render loop to 15 Hz.
-    /// Splitting into chunks lets the other work interleave.
+    /// By default the whole plan goes into a single command buffer. When the
+    /// queue is shared with another workload, such as a renderer, splitting
+    /// the plan lets that work interleave between submissions without
+    /// dividing the model into independently compiled graphs.
+    ///
+    /// This is a caller-selected scheduling policy, not an automatic tuner.
+    /// Meganeura partitions the compiled plan's ordered barrier groups as
+    /// evenly as possible by group count; it does not estimate their duration
+    /// or observe the latency of other queue users. The requested value is an
+    /// upper bound, since a short plan can produce fewer chunks. Profile the
+    /// end-to-end workload on the target device: extra submissions have CPU
+    /// and driver overhead and can make either workload slower.
     ///
     /// Correctness across the resulting submission boundaries does not need
     /// extra synchronization. Blade ends every command buffer with a
@@ -2794,10 +2800,10 @@ impl Session {
     /// commands submitted to the same queue before and after it — not merely
     /// those in the same command buffer.
     ///
-    /// Costs one extra submit per chunk, and reallocates the command encoder
-    /// so that no command buffer is re-recorded while still in flight. Call
-    /// it once during setup rather than per step. `chunks` is clamped to at
-    /// least 1; 1 restores the single-submission default.
+    /// Reallocates the command encoder so that no command buffer is re-recorded
+    /// while still in flight. Call it once during setup rather than per step.
+    /// `chunks` is clamped to at least 1; 1 restores the single-submission
+    /// default.
     pub fn set_submission_chunks(&mut self, chunks: usize) {
         let chunks = chunks.max(1);
         if chunks == self.submission_chunks {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1815,6 +1815,9 @@ pub struct Session {
     /// compute pass. Pass boundaries in blade emit ALL_COMMANDS barriers.
     groups: Vec<std::ops::Range<usize>>,
     encoder: blade_graphics::CommandEncoder,
+    /// How many submissions `step()` splits its dispatches across.
+    /// See [`Session::set_submission_chunks`]. Always at least 1.
+    submission_chunks: usize,
     sync_point: Option<blade_graphics::SyncPoint>,
     /// Nanosecond offset (in profiler time) of the most recent GPU submit,
     /// used to place GPU pass timings on the GPU track.
@@ -2598,6 +2601,7 @@ impl Session {
             plan,
             groups,
             encoder,
+            submission_chunks: 1,
             sync_point: None,
             last_submit_ns: 0,
             profiling: false,
@@ -2772,6 +2776,48 @@ impl Session {
                 .copied()
                 .ok_or(ExternalBindError::UnknownSlot),
         }
+    }
+
+    /// Split `step()`'s dispatches across several submissions instead of one.
+    ///
+    /// By default the whole plan goes into a single command buffer, which
+    /// occupies the queue for its entire duration. That is ideal when
+    /// meganeura owns the GPU, and poor when it does not: sharing a device
+    /// with a renderer means every frame queues behind the whole inference.
+    /// On a Quest 3S a 135 ms encoder drops a 90 Hz render loop to 15 Hz.
+    /// Splitting into chunks lets the other work interleave.
+    ///
+    /// Correctness across the resulting submission boundaries does not need
+    /// extra synchronization. Blade ends every command buffer with a
+    /// conservative global memory barrier and opens each new one assuming an
+    /// unknown prior producer, and a Vulkan pipeline barrier's scopes cover
+    /// commands submitted to the same queue before and after it — not merely
+    /// those in the same command buffer.
+    ///
+    /// Costs one extra submit per chunk, and reallocates the command encoder
+    /// so that no command buffer is re-recorded while still in flight. Call
+    /// it once during setup rather than per step. `chunks` is clamped to at
+    /// least 1; 1 restores the single-submission default.
+    pub fn set_submission_chunks(&mut self, chunks: usize) {
+        let chunks = chunks.max(1);
+        if chunks == self.submission_chunks {
+            return;
+        }
+        // The encoder rotates through a fixed ring of command buffers with no
+        // internal wait, so recording chunk N+1 while chunk N-1 is still
+        // executing would re-record a live buffer. One spare beyond the
+        // number in flight keeps that from happening.
+        self.wait();
+        self.gpu.destroy_command_encoder(&mut self.encoder);
+        self.encoder = self
+            .gpu
+            .create_command_encoder(blade_graphics::CommandEncoderDesc {
+                name: "meganeura",
+                buffer_count: chunks as u32 + 1,
+                manual_barriers: false,
+            });
+        self.submission_chunks = chunks;
+        log::info!("submission chunks: {chunks}");
     }
 
     /// Enable or disable per-dispatch GPU profiling.
@@ -3960,22 +4006,41 @@ impl Session {
                 pc.dispatch(dispatch.workgroups);
             }
         } else {
-            // Inline-barrier mode: all dispatches in a single compute pass
-            // with lightweight compute-to-compute barriers between groups.
-            // Avoids the per-pass overhead of begin_pass/end_pass (timestamps,
-            // debug labels) while maintaining correct memory ordering.
-            let mut pass = self.encoder.compute("step");
-            for gi in 0..self.groups.len() {
-                if gi > 0 {
-                    pass.barrier();
+            // Inline-barrier mode: dispatches share one compute pass with
+            // lightweight compute-to-compute barriers between groups. Avoids
+            // the per-pass overhead of begin_pass/end_pass (timestamps, debug
+            // labels) while maintaining correct memory ordering.
+            //
+            // With `set_submission_chunks`, the groups are spread over
+            // several submissions so a co-tenant on the queue (a renderer,
+            // typically) can slot its own work between them. The chunk
+            // boundary needs no explicit barrier: blade closes each command
+            // buffer with a conservative global one.
+            let total = self.groups.len();
+            let per_chunk = total.div_ceil(self.submission_chunks.min(total).max(1));
+            let mut start = 0;
+            while start < total {
+                let end = (start + per_chunk).min(total);
+                {
+                    let mut pass = self.encoder.compute("step");
+                    for gi in start..end {
+                        if gi > start {
+                            pass.barrier();
+                        }
+                        let group = self.groups[gi].clone();
+                        for i in group {
+                            let dispatch = &self.plan.dispatches[i];
+                            let pipeline = self.pipelines.get(dispatch);
+                            let mut pc = pass.with(pipeline);
+                            Self::bind_dispatch(&self.buffers, dispatch, &mut pc);
+                            pc.dispatch(dispatch.workgroups);
+                        }
+                    }
                 }
-                let group = self.groups[gi].clone();
-                for i in group {
-                    let dispatch = &self.plan.dispatches[i];
-                    let pipeline = self.pipelines.get(dispatch);
-                    let mut pc = pass.with(pipeline);
-                    Self::bind_dispatch(&self.buffers, dispatch, &mut pc);
-                    pc.dispatch(dispatch.workgroups);
+                start = end;
+                if start < total {
+                    self.sync_point = Some(self.gpu.submit(&mut self.encoder));
+                    self.encoder.start();
                 }
             }
         }

--- a/tests/submission_chunks.rs
+++ b/tests/submission_chunks.rs
@@ -1,9 +1,10 @@
 //! Splitting a plan across submissions must not change what it computes.
 //!
-//! `Session::set_submission_chunks` exists so that a co-tenant on the GPU
-//! queue — a renderer, typically — can interleave its work between chunks
-//! instead of waiting behind an entire inference. That only pays off if the
-//! chunk boundaries are as sound as the pass boundaries they replace.
+//! `Session::set_submission_chunks` lets a caller choose an upper bound on
+//! submissions so that a co-tenant on the GPU queue — a renderer, typically
+//! — can interleave its work between chunks instead of waiting behind an
+//! entire inference. That only pays off if the chunk boundaries are as sound
+//! as the pass boundaries they replace.
 //!
 //! The argument for soundness is that blade ends every command buffer with a
 //! conservative global memory barrier, opens each new one assuming an
@@ -43,7 +44,9 @@ fn seed_parameters(session: &mut Session, layers: usize, dim: usize) {
             .map(|k| ((k + i * 7) as f32 * 0.017).sin() * 0.1)
             .collect();
         session.set_parameter(&format!("w{i}"), &w);
-        let b: Vec<f32> = (0..dim).map(|k| ((k + i) as f32 * 0.03).cos() * 0.01).collect();
+        let b: Vec<f32> = (0..dim)
+            .map(|k| ((k + i) as f32 * 0.03).cos() * 0.01)
+            .collect();
         session.set_parameter(&format!("b{i}"), &b);
         session.set_parameter(&format!("ln{i}.w"), &vec![1.0f32; dim]);
         session.set_parameter(&format!("ln{i}.b"), &vec![0.0f32; dim]);
@@ -52,10 +55,13 @@ fn seed_parameters(session: &mut Session, layers: usize, dim: usize) {
 
 fn run(chunks: usize, layers: usize, rows: usize, dim: usize, steps: usize) -> Vec<f32> {
     let g = build_chain(layers, rows, dim);
-    let (mut session, _) = meganeura::train::build(&g, SessionConfig {
-        mode: Mode::Inference,
-        ..Default::default()
-    });
+    let (mut session, _) = meganeura::train::build(
+        &g,
+        SessionConfig {
+            mode: Mode::Inference,
+            ..Default::default()
+        },
+    );
     session.set_submission_chunks(chunks);
     seed_parameters(&mut session, layers, dim);
 
@@ -90,11 +96,12 @@ fn chunked_submission_matches_single_submission() {
     );
     // A chain of layer norms should not collapse to a constant, or the
     // comparison below would pass for the wrong reason.
-    let spread = reference
-        .iter()
-        .fold(f32::NEG_INFINITY, |a, &b| a.max(b))
+    let spread = reference.iter().fold(f32::NEG_INFINITY, |a, &b| a.max(b))
         - reference.iter().fold(f32::INFINITY, |a, &b| a.min(b));
-    assert!(spread > 0.1, "reference output is nearly constant: {spread}");
+    assert!(
+        spread > 0.1,
+        "reference output is nearly constant: {spread}"
+    );
 
     for chunks in [2, 3, 5, 16] {
         let got = run(chunks, LAYERS, ROWS, DIM, STEPS);

--- a/tests/submission_chunks.rs
+++ b/tests/submission_chunks.rs
@@ -1,0 +1,136 @@
+//! Splitting a plan across submissions must not change what it computes.
+//!
+//! `Session::set_submission_chunks` exists so that a co-tenant on the GPU
+//! queue — a renderer, typically — can interleave its work between chunks
+//! instead of waiting behind an entire inference. That only pays off if the
+//! chunk boundaries are as sound as the pass boundaries they replace.
+//!
+//! The argument for soundness is that blade ends every command buffer with a
+//! conservative global memory barrier, opens each new one assuming an
+//! unknown prior producer, and that a Vulkan pipeline barrier's scopes cover
+//! commands submitted to the same queue before and after it, not just those
+//! in the same command buffer. A wrong argument there would show up as
+//! sporadically stale reads at exactly the seams, so these tests use a deep
+//! chain where every layer depends on the previous one, and check equality
+//! against the single-submission result.
+
+use meganeura::train::{Mode, SessionConfig};
+use meganeura::{Graph, Session};
+
+/// A chain deep enough to have many barrier groups, so chunk boundaries
+/// land in the middle of real dependencies rather than at a convenient
+/// seam. Every op consumes the previous one's output.
+fn build_chain(layers: usize, rows: usize, dim: usize) -> Graph {
+    let mut g = Graph::new();
+    let mut x = g.input("x", &[rows, dim]);
+    for i in 0..layers {
+        let w = g.parameter(&format!("w{i}"), &[dim, dim]);
+        let b = g.parameter(&format!("b{i}"), &[dim]);
+        x = g.matmul(x, w);
+        x = g.bias_add(x, b);
+        x = g.gelu(x);
+        let ln_w = g.parameter(&format!("ln{i}.w"), &[dim]);
+        let ln_b = g.parameter(&format!("ln{i}.b"), &[dim]);
+        x = g.layer_norm(x, ln_w, ln_b, 1e-5);
+    }
+    g.set_outputs(vec![x]);
+    g
+}
+
+fn seed_parameters(session: &mut Session, layers: usize, dim: usize) {
+    for i in 0..layers {
+        let w: Vec<f32> = (0..dim * dim)
+            .map(|k| ((k + i * 7) as f32 * 0.017).sin() * 0.1)
+            .collect();
+        session.set_parameter(&format!("w{i}"), &w);
+        let b: Vec<f32> = (0..dim).map(|k| ((k + i) as f32 * 0.03).cos() * 0.01).collect();
+        session.set_parameter(&format!("b{i}"), &b);
+        session.set_parameter(&format!("ln{i}.w"), &vec![1.0f32; dim]);
+        session.set_parameter(&format!("ln{i}.b"), &vec![0.0f32; dim]);
+    }
+}
+
+fn run(chunks: usize, layers: usize, rows: usize, dim: usize, steps: usize) -> Vec<f32> {
+    let g = build_chain(layers, rows, dim);
+    let (mut session, _) = meganeura::train::build(&g, SessionConfig {
+        mode: Mode::Inference,
+        ..Default::default()
+    });
+    session.set_submission_chunks(chunks);
+    seed_parameters(&mut session, layers, dim);
+
+    let x: Vec<f32> = (0..rows * dim)
+        .map(|i| (i as f32 * 0.011).sin() * 0.5)
+        .collect();
+    session.set_input("x", &x);
+
+    // Several steps: a boundary hazard can depend on whether a command
+    // buffer in the ring is still in flight, which only shows up once the
+    // encoder has wrapped around at least once.
+    let mut out = vec![0.0f32; rows * dim];
+    for _ in 0..steps {
+        session.step();
+        session.wait();
+        session.read_output_by_index(0, &mut out);
+    }
+    out
+}
+
+#[test]
+fn chunked_submission_matches_single_submission() {
+    const LAYERS: usize = 8;
+    const ROWS: usize = 64;
+    const DIM: usize = 64;
+    const STEPS: usize = 4;
+
+    let reference = run(1, LAYERS, ROWS, DIM, STEPS);
+    assert!(
+        reference.iter().all(|v| v.is_finite()),
+        "reference output is not finite"
+    );
+    // A chain of layer norms should not collapse to a constant, or the
+    // comparison below would pass for the wrong reason.
+    let spread = reference
+        .iter()
+        .fold(f32::NEG_INFINITY, |a, &b| a.max(b))
+        - reference.iter().fold(f32::INFINITY, |a, &b| a.min(b));
+    assert!(spread > 0.1, "reference output is nearly constant: {spread}");
+
+    for chunks in [2, 3, 5, 16] {
+        let got = run(chunks, LAYERS, ROWS, DIM, STEPS);
+        assert_eq!(
+            got.len(),
+            reference.len(),
+            "chunks={chunks}: output length changed"
+        );
+        // The same kernels run in the same order on the same data, so this
+        // is exact equality, not an approximate comparison. Any difference
+        // means a chunk read a buffer before the previous chunk's write
+        // landed.
+        let worst = got
+            .iter()
+            .zip(&reference)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        assert_eq!(
+            worst, 0.0,
+            "chunks={chunks}: output diverged from the single-submission result by {worst}"
+        );
+    }
+}
+
+/// More chunks than there is work to split, and the degenerate zero, must
+/// both behave rather than panic or divide by zero.
+#[test]
+fn chunk_count_is_clamped_to_something_sensible() {
+    let reference = run(1, 2, 8, 16, 1);
+    for chunks in [0, 1, 1000] {
+        let got = run(chunks, 2, 8, 16, 1);
+        let worst = got
+            .iter()
+            .zip(&reference)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        assert_eq!(worst, 0.0, "chunks={chunks} changed the result");
+    }
+}


### PR DESCRIPTION
## Summary

- apply the existing Android cross-compilation changes to `main` at `7561a64`
- keep Hub/tokenizer dependencies out of Android runtime builds
- add `Session::set_submission_chunks` so a renderer sharing the Vulkan queue can interleave work between inference chunks
- retain exact chunk-boundary correctness tests

This is the public Meganeura revision used by the DinoVision Android XR train-to-deploy case study.

## Validation

- `cargo test --locked --test submission_chunks -- --test-threads=1`: 2 passed
- DinoVision workspace: 51 tests passed on this integration
- Android API 34/aarch64 release benchmark, evaluator, and XR APK built successfully
- fixed-frame host/Quest numerical comparison passed

The default parallel invocation raced while two tests independently initialized Blade GPU contexts: one test passed and the other failed device creation with `INCOMPLETE`. Serial execution passes both chunking tests. Blade also emits the two existing device-creation VUID diagnostics (`VK_EXT_pipeline_protected_access` and `VK_EXT_full_screen_exclusive` dependency setup). This PR remains draft so those setup diagnostics are visible rather than conflated with chunk-boundary correctness.