### PR TITLE
Env-free core: typed config everywhere, registry + from_env opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Unreleased
 
+- The library core is now environment-free: `compile`, `runtime`,
+  `codegen`, and `optimize` accept strongly typed options and never read
+  `MEGANEURA_*` variables. New typed surface: `CoopPolicy`
+  (Auto/Disabled/AllowF16) and the diagnostic switches on
+  `SessionOptions`, flash coop toggles on `CompileOptions`,
+  `SessionConfig::{optimize, runtime}`, and `GpuOptions` +
+  `init_gpu_context_with` for adapter selection/timestamps.
+  `TuningKnobs::default()` is pure platform defaults. Env-driven behavior
+  is an explicit opt-in via the `from_env` constructors in
+  `meganeura::config` (`SessionConfig::from_env()` resolves everything,
+  including WGSL dump-dir installation and env-selected GPU contexts);
+  the repo's examples, benches, and tests opt in, so external
+  `MEGANEURA_*` workflows keep working — embedders that never call
+  `from_env` get a fully hermetic library.
+
 - Central environment-variable registry (`meganeura::config`): every
   `MEGANEURA_*` variable is declared once with type, class, and docs.
   Session build logs active overrides and warns on unrecognized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Unreleased
 
+- Central environment-variable registry (`meganeura::config`): every
+  `MEGANEURA_*` variable is declared once with type, class, and docs.
+  Session build logs active overrides and warns on unrecognized
+  `MEGANEURA_*` names (typos no longer fail silently); a test pins the
+  README table against the registry. Boolean semantics are now uniform —
+  unset = default, `0` = off, anything else = on. Two behavior
+  normalizations: `MEGANEURA_DISABLE_COOP=0` (and other diagnostic
+  flags set to `0`) no longer *enable* the switch, and
+  `MEGANEURA_FLASH_BWD_COOP` accepts any non-zero value instead of
+  exactly `1`. Precedence is per class: diagnostic switches override
+  code configuration; tuning variables only feed defaults, so
+  explicitly set `TuningKnobs`/`SessionConfig` fields win.
+
 - Eager evaluation (`meganeura::eager::Eager`): inspect any node of a graph
   while building it — `e.eval(&g, node)` executes the same builder-produced
   graph through the same generated kernels (no rewrites, no dispatch

--- a/README.md
+++ b/README.md
@@ -125,14 +125,41 @@ device ID (on Vulkan this is normally the PCI device ID, not an adapter ordinal)
 MEGANEURA_DEVICE_ID=0x744c cargo run --release --example mnist
 ```
 
-Decimal IDs are accepted too. `MEGANEURA_DISABLE_COOP=1` forces the portable
-scalar path for regression diagnosis; `MEGANEURA_FLASH_FWD_COOP=0` and
-`MEGANEURA_FLASH_BWD_COOP=0` disable only cooperative flash attention.
-Device-local intermediate storage and lifetime aliasing are default-on, with
-`MEGANEURA_NO_DEVICE_LOCAL=1` and `MEGANEURA_NO_ALIAS=1` as diagnostic escape
-hatches. `MEGANEURA_TUNE=1` (or `SessionConfig { tune: true }`) measures each
-flippable kernel family both ways on real `step()` wall-clock at session
-build and keeps the faster variant on this device.
+Decimal IDs are accepted too.
+
+## Environment variables
+
+Every `MEGANEURA_*` variable is declared in `meganeura::config::REGISTRY`
+(a test pins this table against it). Semantics are uniform: boolean
+variables treat unset as their default, `0` as off, and anything else as
+on; active overrides are logged at session build, and unrecognized
+`MEGANEURA_*` names produce a warning instead of silently doing nothing.
+Diagnostic switches override code-level configuration; tuning variables
+only provide the *defaults* for `TuningKnobs` / `SessionConfig`, so
+explicitly set options win.
+
+| Variable | Effect |
+|---|---|
+| `MEGANEURA_DISABLE_COOP` | Force the portable scalar matmul path (regression diagnosis). |
+| `MEGANEURA_COOP_F16` | Opt in to f16-input cooperative tiles when no f32 tile is advertised. |
+| `MEGANEURA_FLASH_FWD_COOP=0` | Disable only cooperative flash-attention forward. |
+| `MEGANEURA_FLASH_BWD_COOP` | Enable the experimental reduced-precision flash backward. |
+| `MEGANEURA_NO_ALIAS` | Disable buffer lifetime aliasing (every value gets its own allocation). |
+| `MEGANEURA_NO_DEVICE_LOCAL` | Keep all buffers host-visible. |
+| `MEGANEURA_SERIAL_DISPATCH` | One compute pass per dispatch — serial execution for bisection. |
+| `MEGANEURA_PIN_BUFS=3,25-40` | Force-pin logical buffers to bisect aliasing corruption. |
+| `MEGANEURA_DUMP_PLAN` | Dump dispatch order, provenance, and the alias map at build. |
+| `MEGANEURA_DUMP_WGSL=<dir>` | Write every generated shader into `<dir>`. |
+| `MEGANEURA_OPTIMIZER` | Rewrite mode: `off` \| `greedy` \| `egglog-windowed` \| `egglog-outlined` \| `egglog-whole`. |
+| `MEGANEURA_EGRAPH_COST` | Extraction objective: `ast-size` \| `tensor-traffic`. |
+| `MEGANEURA_EGRAPH_CUTOFF=<n>` | Saturation segment-size ceiling (default 300). |
+| `MEGANEURA_TUNE` | Measure coop vs scalar per kernel family at session build; keep the faster (`SessionConfig { tune: true }` equivalent). |
+| `MEGANEURA_FLASH_EPT_CAP=<n>` | Flash forward elements-per-thread cap (power of two ≥ 2). |
+| `MEGANEURA_FLASH_GRAD_Q_EPT_CAP=<n>` | EPT cap for flash dQ backward. |
+| `MEGANEURA_FLASH_GRAD_KV_EPT_CAP=<n>` | EPT cap for fused flash dK/dV backward. |
+| `MEGANEURA_FLASH_BWD_EPT_CAP=<n>` | Shared fallback cap for both flash backward kernels. |
+| `MEGANEURA_DEVICE_ID=0x744c` | Adapter selection by numeric device id. |
+| `MEGANEURA_GPU_TIMING` | Enable hardware timestamp pools (set before context creation). |
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -129,14 +129,19 @@ Decimal IDs are accepted too.
 
 ## Environment variables
 
-Every `MEGANEURA_*` variable is declared in `meganeura::config::REGISTRY`
-(a test pins this table against it). Semantics are uniform: boolean
-variables treat unset as their default, `0` as off, and anything else as
-on; active overrides are logged at session build, and unrecognized
-`MEGANEURA_*` names produce a warning instead of silently doing nothing.
-Diagnostic switches override code-level configuration; tuning variables
-only provide the *defaults* for `TuningKnobs` / `SessionConfig`, so
-explicitly set options win.
+The library core never reads the environment: `compile`, `runtime`,
+`codegen`, and `optimize` accept strongly typed options only. Env-driven
+behavior is an explicit client opt-in through the `from_env` constructors
+in `meganeura::config` — `SessionConfig::from_env()` is the one-liner
+that resolves everything below (the repo's own examples, benches, and
+tests use it; embedders that want a hermetic library simply never call
+it). Every `MEGANEURA_*` variable is declared in
+`meganeura::config::REGISTRY` (a test pins this table against it).
+Semantics are uniform: boolean variables treat unset as their default,
+`0` as off, and anything else as on; `from_env` logs the active
+overrides, and unrecognized `MEGANEURA_*` names produce a warning
+instead of silently doing nothing. Fields assigned after `from_env`
+win, so explicit code always has the last word.
 
 | Variable | Effect |
 |---|---|

--- a/bench/bench_ci_latency.rs
+++ b/bench/bench_ci_latency.rs
@@ -8,7 +8,7 @@
 ///   cargo run --release --example bench_ci_latency
 use std::time::Instant;
 
-use meganeura::{Graph, build_inference_session, build_session};
+use meganeura::Graph;
 
 fn main() {
     env_logger::init();
@@ -38,7 +38,7 @@ fn main() {
     let out = g.matmul(h2, w3);
     let loss = g.cross_entropy_loss(out, labels);
     g.set_outputs(vec![loss]);
-    let mut train_session = build_session(&g);
+    let mut train_session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     // Inference graph (forward only, logits output)
     let mut g_inf = Graph::new();
@@ -56,7 +56,8 @@ fn main() {
     let w3i = g_inf.parameter("w3", &[hidden, classes]);
     let logits = g_inf.matmul(h2i, w3i);
     g_inf.set_outputs(vec![logits]);
-    let mut inf_session = build_inference_session(&g_inf);
+    let mut inf_session =
+        meganeura::build(&g_inf, meganeura::SessionConfig::inference_from_env()).0;
 
     // Load weights (not timed)
     let w1_data = vec![0.01_f32; input_dim * hidden];

--- a/bench/bench_meganeura.rs
+++ b/bench/bench_meganeura.rs
@@ -9,7 +9,7 @@
 use std::time::Instant;
 
 use meganeura::{
-    Graph, build_inference_session,
+    Graph,
     data::safetensors::SafeTensorsModel,
     models::smollm2::{self, SmolLM2Config},
 };
@@ -164,7 +164,8 @@ fn main() {
         pg.set_outputs(prefill_outputs);
 
         eprintln!("compiling prefill...");
-        let mut prefill_session = build_inference_session(&pg);
+        let mut prefill_session =
+            meganeura::build(&pg, meganeura::SessionConfig::inference_from_env()).0;
         eprintln!(
             "prefill: {} buffers, {} dispatches, {} barrier groups",
             prefill_session.plan().buffers.len(),
@@ -180,7 +181,7 @@ fn main() {
         dg.set_outputs(vec![decode_logits]);
 
         eprintln!("compiling decode...");
-        session = build_inference_session(&dg);
+        session = meganeura::build(&dg, meganeura::SessionConfig::inference_from_env()).0;
         eprintln!(
             "decode: {} buffers, {} dispatches, {} barrier groups",
             session.plan().buffers.len(),
@@ -282,7 +283,7 @@ fn main() {
         g.set_outputs(vec![logits]);
 
         eprintln!("compiling...");
-        session = build_inference_session(&g);
+        session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
         eprintln!(
             "ready: {} buffers, {} dispatches",
             session.plan().buffers.len(),

--- a/bench/bench_sd_unet_train.rs
+++ b/bench/bench_sd_unet_train.rs
@@ -1,3 +1,4 @@
+use meganeura::Graph;
 /// SD U-Net training benchmark for meganeura.
 ///
 /// Architecture: Conv2d + GroupNorm + SiLU ResBlocks with skip connections,
@@ -5,7 +6,6 @@
 ///
 /// Outputs JSON to stdout (for compare.sh), human-readable to stderr.
 use meganeura::models::sd_unet::{self, SDUNetConfig};
-use meganeura::{Graph, build_session};
 use std::time::Instant;
 
 fn main() {
@@ -57,7 +57,7 @@ fn main() {
     // --- Compile ---
     eprintln!("compiling (autodiff + egglog + codegen)...");
     let t0 = Instant::now();
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let compile_time = t0.elapsed();
     let device_info = session.device_information().clone();
     let device_name = &device_info.device_name;

--- a/bench/bench_smolvla_meganeura.rs
+++ b/bench/bench_smolvla_meganeura.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 use std::time::Instant;
 
 use meganeura::{
-    Graph, build_inference_session,
+    Graph,
     data::safetensors::SafeTensorsModel,
     models::smolvla::{self, SmolVLAConfig},
 };
@@ -235,7 +235,7 @@ fn main() {
     g.set_outputs(vec![action_out]);
 
     eprintln!("compiling...");
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     eprintln!(
         "ready: {} buffers, {} dispatches",
         session.plan().buffers.len(),

--- a/bench/bench_smolvla_train.rs
+++ b/bench/bench_smolvla_train.rs
@@ -11,7 +11,7 @@
 use std::time::Instant;
 
 use meganeura::{
-    build_inference_session, build_session, compile_training_graph,
+    compile_training_graph,
     models::smolvla::{self, SmolVLAConfig},
 };
 
@@ -161,7 +161,8 @@ fn main() {
 
     // --- Build sessions ---
     eprintln!("compiling inference session (forward only)...");
-    let mut infer_session = build_inference_session(&training_g);
+    let mut infer_session =
+        meganeura::build(&training_g, meganeura::SessionConfig::inference_from_env()).0;
     eprintln!(
         "  infer: {} buffers, {} dispatches, {} barrier groups",
         infer_session.plan().buffers.len(),
@@ -170,7 +171,7 @@ fn main() {
     );
 
     eprintln!("compiling training session (fwd + bwd + SGD)...");
-    let mut train_session = build_session(&training_g);
+    let mut train_session = meganeura::build(&training_g, meganeura::SessionConfig::from_env()).0;
     eprintln!(
         "  train: {} buffers, {} dispatches, {} barrier groups",
         train_session.plan().buffers.len(),

--- a/bench/grad_check.rs
+++ b/bench/grad_check.rs
@@ -16,7 +16,6 @@
 use std::collections::HashMap;
 
 use meganeura::{
-    build_session,
     graph::Op,
     models::smolvla::{self, SmolVLAConfig},
 };
@@ -74,7 +73,7 @@ fn main() {
     }
 
     eprintln!("compiling session...");
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     // Fill shapes for derived params (e.g. SwiGLU concat "gate+up") from buffer sizes.
     // These aren't in the original graph, so param_shapes doesn't have them.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -372,36 +372,67 @@ updated with the new data.
 
 ---
 
-## Track F — Session-build autotuning (in-memory only)
+## Track F — The representation menu: empirical kernel selection
 
-*First cut landed:* `Session::tune` (opt-in via
-`SessionConfig { tune: true }` / `MEGANEURA_TUNE=1`) measures real
-`step()` wall-clock per flippable kernel family — plain coop matmuls
-and generated coop conv kernels vs their recorded scalar fallbacks —
-and keeps the faster variant. Both variants' pipelines are compiled up
-front, so flips need no recompilation. Default-off until the bench
-fleet validates it on coop-capable adapters. *Still open:* knobs that
-require recompilation (EPT caps, tile sizes — now plumbed as
-`TuningKnobs` plan data, so a search over them is a plan-rebuild loop),
-and the workgroup-size sweep for generated kernels.
+**End state.** No hand-maintained performance heuristics for kernel
+variants. Instead, a per-device **menu of legal representations** and a
+measured choice among them:
 
-**Problem.** Tile sizes (64/32), `flash_ept_cap` (32), coop workgroup
-thresholds (16/32), GEMV switchover — all fixed heuristics, tuned
-mostly on one GPU, applied to Apple/RDNA/Intel/NVIDIA alike.
+1. **Legality** — the menu is derived from capabilities: the tile
+   shapes/dtypes the driver advertises, subgroup support, f16. Facts,
+   registered once per device, never guessed.
+2. **Validity** — declarative numeric constraints filter the menu per
+   value: `requires_full_precision` (autodiff-marked) × the format each
+   representation stages through. This stage can never be empirical —
+   the canonical cautionary tale is the coop-threshold experiment that
+   went 44 ms → 29 ms *and failed gradcheck*
+   (`rejected-optimizations.md`): a purely measured selector picks the
+   fast wrong kernel every time. Validity is checked by parity/gradcheck
+   tests, not by timing.
+3. **Speed** — whatever survives 1–2 is chosen by measured
+   `step()`-context wall-clock, per (archetype, shape-class), applied to
+   every instance of that class. The remaining hard-coded thresholds
+   (coop workgroup minimums, the Apple >1024 veto, small-tile cutoff,
+   GEMV switchover) demote from *deciders* to *search priors* — the
+   starting configuration when tuning is off or budget-limited.
 
-**Plan.** At session build, for the handful of distinct
-(archetype, shape-class) pairs in the plan, run a micro-search over
-the small knob set (2–4 values each), measuring real `step()`-context
-wall-clock, and pick winners. **No on-disk cache** — the tune budget
-must simply be small relative to a training run (target: < 2 s for a
-SmolLM2-class plan; the archetype design keeps the space tiny).
-In-memory only, per session; inference sessions can opt out
-(`SessionConfig`) to protect TTFT.
+**Landed.** The enabling structure: variant decisions have one owner
+(`select_variants`), every promoted dispatch records its
+`scalar_fallback`, codegen knobs travel as `TuningKnobs` plan data, and
+`Session::tune` (opt-in via `SessionConfig { tune: true }` /
+`MEGANEURA_TUNE=1`) measures coop↔scalar per family on real `step()`
+wall-clock with both pipelines pre-compiled — flips need no
+recompilation. Default-off until the bench fleet validates the flip
+path on coop-capable adapters.
 
-**Lessons honored.** This is wall-clock tuning, not register-stats
-tuning (that was tried and removed); per-kernel × per-cap
-combinatorial tuning is what made the old `auto_tune_flash_ept` take
-30 s — bounding the space per shape-class is the fix.
+**Remaining plan.**
+1. *Fleet validation*, then default-on for the family-level flips.
+2. *Shape-class granularity:* group dispatches by
+   (archetype, m/n/k-class) and measure per class instead of per
+   family. Transformer plans have a handful of classes repeated across
+   layers, so the space stays tiny.
+3. *Recompiling knobs:* EPT caps / tile sizes / generated-kernel
+   workgroup sizes are plan data now, so a candidate is a plan rebuild
+   (~seconds). Bound the space per shape-class (2–4 values per knob).
+4. *Persist measured winners* in the semantic plan cache: it already
+   fingerprints device caps and every knob (A-002), so invalidation is
+   solved and the search becomes a first-run-only cost. This revises
+   the earlier "in-memory only" stance — that call predates the
+   semantic cache; with invalidation free, refusing persistence just
+   re-pays the tune budget every process.
+
+**Non-goals.** Representation choice stays *out of the e-graph*: the
+e-graph is semantic and device-free, and `coop(x) ≡ scalar(x)` is not a
+true congruence when staging dtypes differ. The e-graph picks *what* to
+compute (extraction by bytes-moved, validated offline by benches); the
+plan/runtime layer picks *how* (measured per device). Coupling them is
+how the register-cost experiment failed — `optimize` runs before a GPU
+exists in many paths.
+
+**Lessons honored.** Wall-clock only, never per-dispatch GPU time
+(<~50 µs is submission-dominated) and never register stats; the old
+`auto_tune_flash_ept` took 30 s because it tuned per-kernel × per-cap —
+shape-class bounding is the fix.
 
 ---
 

--- a/examples/analyze_shaders.rs
+++ b/examples/analyze_shaders.rs
@@ -331,7 +331,7 @@ fn main() {
     {
         let sm = meganeura::codegen::generate_flash_attention_module(
             64,
-            meganeura::codegen::flash_ept_cap(),
+            meganeura::TuningKnobs::from_env().flash_ept_cap,
         );
         analyze(
             "flash_attention_hd64",
@@ -343,7 +343,7 @@ fn main() {
 
         let sm_gq = meganeura::codegen::generate_flash_grad_q_module(
             64,
-            meganeura::codegen::flash_grad_q_ept_cap(),
+            meganeura::TuningKnobs::from_env().flash_grad_q_ept_cap,
         );
         analyze(
             "flash_grad_q_hd64",
@@ -355,7 +355,7 @@ fn main() {
 
         let sm_gkv = meganeura::codegen::generate_flash_grad_kv_module(
             64,
-            meganeura::codegen::flash_grad_kv_ept_cap(),
+            meganeura::TuningKnobs::from_env().flash_grad_kv_ept_cap,
         );
         analyze(
             "flash_grad_kv_hd64",

--- a/examples/diffusion.rs
+++ b/examples/diffusion.rs
@@ -12,7 +12,7 @@
 ///
 /// MSE loss is built from primitives: `mean_all(mul(diff, diff))`
 /// where `diff = add(pred, neg(target))`.
-use meganeura::{DataLoader, Graph, TrainConfig, Trainer, build_session};
+use meganeura::{DataLoader, Graph, TrainConfig, Trainer};
 use std::time::Instant;
 
 fn main() {
@@ -96,7 +96,7 @@ fn main() {
     // --- Build session ---
     println!("building session (autodiff + egglog + compile)...");
     let t0 = Instant::now();
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let compile_time = t0.elapsed();
     println!(
         "session ready in {:.2}s: {} buffers, {} dispatches",

--- a/examples/dispatch_overhead.rs
+++ b/examples/dispatch_overhead.rs
@@ -30,7 +30,7 @@ fn infer_raw(g: &Graph) -> Session {
         SessionConfig {
             mode: Mode::Inference,
             options: raw_opts(),
-            ..SessionConfig::default()
+            ..SessionConfig::from_env()
         },
     )
     .0

--- a/examples/external_buffer.rs
+++ b/examples/external_buffer.rs
@@ -24,7 +24,7 @@
 use std::alloc::{Layout, alloc_zeroed, dealloc};
 
 use blade_graphics as bg;
-use meganeura::{ExternalSlot, Graph, build_inference_session};
+use meganeura::{ExternalSlot, Graph};
 
 fn main() {
     env_logger::init();
@@ -105,7 +105,7 @@ fn main() {
     // `build_inference_session` internally calls `Session::new`, which
     // initialises a fresh `blade_graphics::Context` owned by the
     // session — no context sharing with `producer`.
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     eprintln!(
         "meganeura device: {}",
         session.device_information().device_name

--- a/examples/gpu_compare.rs
+++ b/examples/gpu_compare.rs
@@ -8,7 +8,7 @@
 
 use std::time::Instant;
 
-use meganeura::{Graph, build_inference_session};
+use meganeura::Graph;
 
 fn bench_matmul(n: usize, warmup: usize, iters: usize) -> (f64, &'static str) {
     // Square n×n×n matmul: 2 n^3 flops, O(n^2) memory — compute-bound for
@@ -18,7 +18,7 @@ fn bench_matmul(n: usize, warmup: usize, iters: usize) -> (f64, &'static str) {
     let b = g.parameter("b", &[n, n]);
     let c = g.matmul(a, b);
     g.set_outputs(vec![c]);
-    let mut s = build_inference_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     let kernel = s
         .plan()
@@ -58,7 +58,7 @@ fn bench_bandwidth(n: usize, warmup: usize, iters: usize) -> f64 {
     let b = g.parameter("b", &[n]);
     let c = g.add(a, b);
     g.set_outputs(vec![c]);
-    let mut s = build_inference_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     s.set_input("a", &vec![1.0_f32; n]);
     s.set_parameter("b", &vec![2.0_f32; n]);
     for _ in 0..warmup {
@@ -81,7 +81,8 @@ fn main() {
         let w = g.parameter("w", &[4, 4]);
         let y = g.matmul(x, w);
         g.set_outputs(vec![y]);
-        build_inference_session(&g)
+        meganeura::build(&g, meganeura::SessionConfig::inference_from_env())
+            .0
             .device_information()
             .device_name
             .clone()

--- a/examples/huggingface.rs
+++ b/examples/huggingface.rs
@@ -13,9 +13,7 @@
 /// MNIST test data is expected in `data/` (gzipped or raw):
 ///   data/t10k-images-idx3-ubyte.gz
 ///   data/t10k-labels-idx1-ubyte.gz
-use meganeura::{
-    Graph, MnistDataset, build_inference_session, data::safetensors::SafeTensorsModel,
-};
+use meganeura::{Graph, MnistDataset, data::safetensors::SafeTensorsModel};
 use std::path::{Path, PathBuf};
 
 fn main() {
@@ -81,7 +79,7 @@ fn main() {
 
     // --- Build inference session ---
     println!("compiling inference session...");
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     println!(
         "session ready: {} buffers, {} dispatches",
         session.plan().buffers.len(),

--- a/examples/matmul_throughput.rs
+++ b/examples/matmul_throughput.rs
@@ -10,7 +10,7 @@
 
 use std::time::Instant;
 
-use meganeura::{Graph, build_inference_session};
+use meganeura::Graph;
 
 /// Theoretical fp32 peak for a few GPUs (TFLOPS). Rough; used only for
 /// percentage reporting.
@@ -77,7 +77,7 @@ fn bench_shape(
     let c = g.matmul(a, b);
     g.set_outputs(vec![c]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let a_data = vec![0.01_f32; m * k];
     let b_data = vec![0.01_f32; k * n];
     session.set_input("a", &a_data);
@@ -139,7 +139,7 @@ fn main() {
         let w = g.parameter("w", &[4, 4]);
         let y = g.matmul(x, w);
         g.set_outputs(vec![y]);
-        let s = build_inference_session(&g);
+        let s = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
         s.device_information().device_name.clone()
     };
     let peak_fp32 = approximate_peak_tflops(&device_name);

--- a/examples/mnist.rs
+++ b/examples/mnist.rs
@@ -10,7 +10,7 @@
 /// Expected files (gzipped or raw):
 ///   data/train-images-idx3-ubyte.gz  (or without .gz)
 ///   data/train-labels-idx1-ubyte.gz  (or without .gz)
-use meganeura::{DataLoader, Graph, MnistDataset, TrainConfig, Trainer, build_session};
+use meganeura::{DataLoader, Graph, MnistDataset, TrainConfig, Trainer};
 use std::path::Path;
 
 fn main() {
@@ -67,7 +67,7 @@ fn main() {
     // --- Build training session ---
     // This runs: autodiff → egglog optimize → compile → GPU init
     println!("building session (autodiff + egglog + compile)...");
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     println!(
         "session ready: {} buffers, {} dispatches",
         session.plan().buffers.len(),

--- a/examples/onnx_compare.rs
+++ b/examples/onnx_compare.rs
@@ -17,9 +17,7 @@
 /// Expects:
 ///   - models/onnx/mnist-mlp.onnx  (from the export script)
 ///   - data/t10k-images-idx3-ubyte.gz  (MNIST test set, optional for accuracy test)
-use meganeura::{
-    Graph, build_inference_session, data::safetensors::SafeTensorsModel, load::onnx::load_onnx,
-};
+use meganeura::{Graph, data::safetensors::SafeTensorsModel, load::onnx::load_onnx};
 use std::path::Path;
 
 fn main() {
@@ -54,7 +52,11 @@ fn main() {
 
     // ─── Compile both ───
     println!("compiling ONNX session...");
-    let mut onnx_session = build_inference_session(&onnx_model.graph);
+    let mut onnx_session = meganeura::build(
+        &onnx_model.graph,
+        meganeura::SessionConfig::inference_from_env(),
+    )
+    .0;
     println!(
         "  {} buffers, {} dispatches",
         onnx_session.plan().buffers.len(),
@@ -62,7 +64,11 @@ fn main() {
     );
 
     println!("compiling native session...");
-    let mut native_session = build_inference_session(&native_graph);
+    let mut native_session = meganeura::build(
+        &native_graph,
+        meganeura::SessionConfig::inference_from_env(),
+    )
+    .0;
     println!(
         "  {} buffers, {} dispatches",
         native_session.plan().buffers.len(),

--- a/examples/profile_resnet50_train.rs
+++ b/examples/profile_resnet50_train.rs
@@ -4,7 +4,7 @@
 //! Usage:
 //!   MEGANEURA_DEVICE_ID=<id> cargo run --release --example profile_resnet50_train
 
-use meganeura::{build_session, models::resnet};
+use meganeura::models::resnet;
 
 fn main() {
     env_logger::init();
@@ -13,7 +13,7 @@ fn main() {
     // stride-1 backward dispatches to the generated conv coop kernels.
     // Without this the scalar Conv2dGradInputGemm runs (34% of training
     // time on RTX 5080).
-    let gpu = meganeura::runtime::init_gpu_context().expect("gpu");
+    let gpu = meganeura::init_gpu_context_with(meganeura::GpuOptions::from_env()).expect("gpu");
     let result = meganeura::runtime::auto_tune(&gpu, 64);
     eprintln!("coop_matrix_available={}", result.coop_caps.is_supported());
     meganeura::runtime::install_auto_tune(result);
@@ -22,7 +22,7 @@ fn main() {
     let batch = 1u32;
     let g = resnet::build_resnet50_training(batch);
 
-    let mut sess = build_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     eprintln!(
         "ResNet-50 training: {} dispatches, {} buffers",
         sess.plan().dispatches.len(),

--- a/examples/profile_session.rs
+++ b/examples/profile_session.rs
@@ -4,7 +4,7 @@
 //! `MEGANEURA_GPU_TIMING=1 cargo run --release --example profile_session -- gap-profile.json`
 
 use meganeura::{
-    Graph, build_inference_session,
+    Graph,
     profiler::{CaptureOptions, capture_session_profile, save_session_profile_json},
 };
 use std::time::Instant;
@@ -34,7 +34,7 @@ fn main() {
     let probabilities = graph.softmax(activated);
     graph.set_outputs(vec![probabilities]);
 
-    let mut session = build_inference_session(&graph);
+    let mut session = meganeura::build(&graph, meganeura::SessionConfig::inference_from_env()).0;
     let input_data: Vec<f32> = (0..ROWS * WIDTH)
         .map(|index| (index as f32 * 0.001).sin())
         .collect();

--- a/examples/profile_smollm2_decode.rs
+++ b/examples/profile_smollm2_decode.rs
@@ -11,7 +11,7 @@
 
 use std::time::Instant;
 
-use meganeura::{Graph, build_inference_session, models::smollm2};
+use meganeura::{Graph, models::smollm2};
 
 fn main() {
     env_logger::init();
@@ -28,7 +28,7 @@ fn main() {
     g.set_outputs(vec![logits]);
 
     eprintln!("compiling...");
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     eprintln!(
         "decode: {} buffers, {} dispatches, {} barrier groups",
         session.plan().buffers.len(),

--- a/examples/profile_whisper_inference.rs
+++ b/examples/profile_whisper_inference.rs
@@ -9,7 +9,7 @@
 //!   MEGANEURA_DEVICE_ID=<id> cargo run --release --example profile_whisper_inference
 
 use meganeura::{
-    Graph, build_inference_session,
+    Graph,
     models::whisper::{self, WhisperConfig},
 };
 
@@ -19,7 +19,7 @@ fn main() {
     // Install coop_matrix_available global so the FlashAttentionCoop
     // dispatch (gated additionally by MEGANEURA_FLASH_FWD_COOP=1) can
     // fire on capable GPUs.
-    let gpu = meganeura::runtime::init_gpu_context().expect("gpu");
+    let gpu = meganeura::init_gpu_context_with(meganeura::GpuOptions::from_env()).expect("gpu");
     let result = meganeura::runtime::auto_tune(&gpu, 64);
     eprintln!("coop_matrix_available={}", result.coop_caps.is_supported());
     meganeura::runtime::install_auto_tune(result);
@@ -34,7 +34,7 @@ fn main() {
     let hidden = whisper::build_encoder(&mut g, &config, batch, mel_len);
     g.set_outputs(vec![hidden]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     eprintln!(
         "Whisper-tiny encoder: {} dispatches, {} buffers, seq_len={}",
         session.plan().dispatches.len(),

--- a/examples/profile_whisper_train.rs
+++ b/examples/profile_whisper_train.rs
@@ -2,15 +2,12 @@
 //! LayerNorm forward rewrite. Mirrors profile_whisper_inference but
 //! builds the training graph (encoder + projection + MSE loss).
 
-use meganeura::{
-    build_session,
-    models::whisper::{self, WhisperConfig},
-};
+use meganeura::models::whisper::{self, WhisperConfig};
 
 fn main() {
     env_logger::init();
 
-    let gpu = meganeura::runtime::init_gpu_context().expect("gpu");
+    let gpu = meganeura::init_gpu_context_with(meganeura::GpuOptions::from_env()).expect("gpu");
     let result = meganeura::runtime::auto_tune(&gpu, 64);
     eprintln!("coop_matrix_available={}", result.coop_caps.is_supported());
     meganeura::runtime::install_auto_tune(result);
@@ -21,7 +18,7 @@ fn main() {
     let mel_len = 3000u32;
     let g = whisper::build_training_graph(&config, batch, mel_len);
 
-    let mut sess = build_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     eprintln!(
         "Whisper-tiny training: {} dispatches, {} buffers",
         sess.plan().dispatches.len(),

--- a/examples/qwen3.rs
+++ b/examples/qwen3.rs
@@ -15,7 +15,7 @@
 ///   cargo run --release --example qwen3 -- --tokens 128           # generate 128 tokens
 ///   cargo run --release --example qwen3 -- --f16                  # half-precision weights
 ///   cargo run --release --example qwen3 -- --q4                   # 4-bit quantized weights
-use meganeura::{Graph, build_inference_session, data::safetensors::SafeTensorsModel};
+use meganeura::{Graph, data::safetensors::SafeTensorsModel};
 
 struct Qwen3Config {
     repo_id: &'static str,
@@ -325,7 +325,7 @@ fn main() {
 
     // --- Compile ---
     println!("compiling inference session...");
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let total_vram: usize = session.plan().buffers.iter().sum();
     println!(
         "session ready: {} buffers, {} dispatches, {:.1} MB VRAM",

--- a/examples/resnet.rs
+++ b/examples/resnet.rs
@@ -6,9 +6,7 @@
 ///
 /// Usage:
 ///   cargo run --release --example resnet
-use meganeura::{
-    Graph, build_inference_session, data::safetensors::SafeTensorsModel, models::resnet,
-};
+use meganeura::{Graph, data::safetensors::SafeTensorsModel, models::resnet};
 
 const REPO_ID: &str = "microsoft/resnet-18";
 
@@ -25,7 +23,7 @@ fn main() {
 
     // --- Compile ---
     println!("compiling...");
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     println!(
         "  {} buffers, {} dispatches",
         session.plan().buffers.len(),

--- a/examples/sd_unet_train.rs
+++ b/examples/sd_unet_train.rs
@@ -1,3 +1,4 @@
+use meganeura::Graph;
 /// Stable Diffusion U-Net training benchmark for Meganeura.
 ///
 /// Trains a U-Net denoiser on synthetic latent data via score matching:
@@ -12,7 +13,6 @@
 /// This is structurally equivalent to the Stable Diffusion 1.5 U-Net, scaled
 /// down to fit in GPU memory and run quickly for benchmarking.
 use meganeura::models::sd_unet::{self, SDUNetConfig};
-use meganeura::{Graph, build_session};
 use std::time::Instant;
 
 fn main() {
@@ -64,7 +64,7 @@ fn main() {
     // --- Compile (autodiff + optimize + GPU init) ---
     println!("compiling (autodiff + egglog + codegen)...");
     let t0 = Instant::now();
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let compile_time = t0.elapsed();
     println!(
         "compiled in {:.2}s: {} buffers, {} dispatches",

--- a/examples/smollm2.rs
+++ b/examples/smollm2.rs
@@ -6,7 +6,7 @@
 /// Usage:
 ///   cargo run --release --example smollm2 [-- "Your prompt here"]
 use meganeura::{
-    Graph, build_inference_session,
+    Graph,
     data::safetensors::SafeTensorsModel,
     models::smollm2::{self, SmolLM2Config},
 };
@@ -76,7 +76,7 @@ fn main() {
 
     // --- Compile ---
     println!("compiling inference session...");
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     println!(
         "session ready: {} buffers, {} dispatches",
         session.plan().buffers.len(),

--- a/examples/smollm2_train_bench.rs
+++ b/examples/smollm2_train_bench.rs
@@ -11,7 +11,7 @@ fn main() {
     eprintln!("SmolLM2-135M training benchmark (seq={})", seq_len);
     let g = meganeura::models::smollm2::build_training_graph(&config, seq_len);
 
-    let mut sess = meganeura::build_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     eprintln!(
         "  {} dispatches, {} groups",
         sess.plan().dispatches.len(),

--- a/examples/smolvlm2.rs
+++ b/examples/smolvlm2.rs
@@ -7,7 +7,7 @@
 /// Usage:
 ///   cargo run --release --example smolvlm2
 use meganeura::{
-    Graph, build_inference_session,
+    Graph,
     data::safetensors::SafeTensorsModel,
     models::smolvlm2::{self, SmolVLM2Config},
 };
@@ -96,7 +96,7 @@ fn main() {
         "compiling vision encoder ({} patches, {} hidden)...",
         test_num_patches, hidden
     );
-    let mut vision_session = build_inference_session(&g);
+    let mut vision_session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     println!(
         "  {} buffers, {} dispatches",
         vision_session.plan().buffers.len(),
@@ -230,7 +230,7 @@ fn main() {
         "compiling text decoder (seq_len={}, vocab={})...",
         total_seq_len, config.text.vocab_size
     );
-    let mut text_session = build_inference_session(&g);
+    let mut text_session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     println!(
         "  {} buffers, {} dispatches",
         text_session.plan().buffers.len(),

--- a/examples/test_flash_coop_fwd.rs
+++ b/examples/test_flash_coop_fwd.rs
@@ -6,7 +6,7 @@
 //! scalar one — and asserts the outputs match within f16-input
 //! tolerance.
 
-use meganeura::{Graph, build_inference_session};
+use meganeura::Graph;
 
 fn build_and_run(label: &str, seq: usize, num_heads: u32, head_dim: u32, causal: bool) -> Vec<f32> {
     let d = (num_heads * head_dim) as usize;
@@ -20,7 +20,7 @@ fn build_and_run(label: &str, seq: usize, num_heads: u32, head_dim: u32, causal:
         g.full_attention(q, k, v, num_heads, num_heads, head_dim)
     };
     g.set_outputs(vec![out]);
-    let mut sess = build_inference_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     let total = seq * d;
     let qd: Vec<f32> = (0..total).map(|i| ((i % 17) as f32 - 8.0) * 0.05).collect();

--- a/examples/test_flash_grad_q_coop.rs
+++ b/examples/test_flash_grad_q_coop.rs
@@ -2,7 +2,7 @@
 //! scalar version. Builds a small attention forward + sum_all loss,
 //! reads the dQ output, compares scalar vs coop.
 
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 fn build_and_run(seq: usize, num_heads: u32, head_dim: u32, causal: bool) -> Vec<f32> {
     let d = (num_heads * head_dim) as usize;
@@ -19,7 +19,7 @@ fn build_and_run(seq: usize, num_heads: u32, head_dim: u32, causal: bool) -> Vec
     g.set_outputs(vec![loss]);
 
     // build_session differentiates internally (training session).
-    let mut sess = build_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     let total = seq * d;
     let qd: Vec<f32> = (0..total).map(|i| ((i % 17) as f32 - 8.0) * 0.05).collect();

--- a/examples/v2s_lane_bisect.rs
+++ b/examples/v2s_lane_bisect.rs
@@ -13,7 +13,6 @@
 
 use meganeura::Graph;
 use meganeura::NodeId;
-use meganeura::build_inference_session;
 use meganeura::data::safetensors::SafeTensorsModel;
 use meganeura::models::efficientnet;
 use meganeura::models::efficientnet::{Spatial, fused_mbconv, mbconv};
@@ -168,7 +167,7 @@ fn main() {
         };
     g.set_outputs(vec![out_node]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     println!("loading weights from {weights_path}...");
     let weights = SafeTensorsModel::load(weights_path.clone().into()).expect("safetensors load");

--- a/examples/whisper.rs
+++ b/examples/whisper.rs
@@ -6,7 +6,7 @@
 /// Usage:
 ///   cargo run --release --example whisper
 use meganeura::{
-    Graph, build_inference_session,
+    Graph,
     data::safetensors::SafeTensorsModel,
     models::whisper::{self, WhisperConfig},
 };
@@ -28,7 +28,7 @@ fn main() {
 
     // --- Compile ---
     println!("compiling...");
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     println!(
         "  {} buffers, {} dispatches",
         session.plan().buffers.len(),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -125,8 +125,6 @@ pub(crate) fn hash_build_config(
         mode_tag: u8,
         skip_full_optimize: bool,
         coop_caps: CoopCaps,
-        flash_forward_coop: bool,
-        flash_backward_coop: bool,
     }
 
     let fingerprint = BuildFingerprint {
@@ -135,9 +133,7 @@ pub(crate) fn hash_build_config(
         mode_tag,
         skip_full_optimize,
         coop_caps,
-        flash_forward_coop: crate::config::FLASH_FWD_COOP.bool_or(true),
-        flash_backward_coop: crate::config::FLASH_BWD_COOP.bool_or(false),
-        // The flash EPT caps now live in `options.knobs`, hashed above.
+        // Flash coop flags and EPT caps live in `options`, hashed above.
     };
     hash_serializable(&fingerprint)
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -135,8 +135,8 @@ pub(crate) fn hash_build_config(
         mode_tag,
         skip_full_optimize,
         coop_caps,
-        flash_forward_coop: std::env::var("MEGANEURA_FLASH_FWD_COOP").as_deref() != Ok("0"),
-        flash_backward_coop: std::env::var("MEGANEURA_FLASH_BWD_COOP").as_deref() == Ok("1"),
+        flash_forward_coop: crate::config::FLASH_FWD_COOP.bool_or(true),
+        flash_backward_coop: crate::config::FLASH_BWD_COOP.bool_or(false),
         // The flash EPT caps now live in `options.knobs`, hashed above.
     };
     hash_serializable(&fingerprint)

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -45,10 +45,19 @@ pub struct ShaderModule {
     pub source: String,
 }
 
-/// Dump WGSL source to `$MEGANEURA_DUMP_WGSL` if set (for debugging/inspection).
+static WGSL_DUMP_DIR: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Route every generated/parsed WGSL shader into `dir` (debug hook; the
+/// `MEGANEURA_DUMP_WGSL` mapping in `crate::config` calls this). First
+/// call wins for the process lifetime.
+pub fn set_wgsl_dump_dir(dir: impl Into<String>) {
+    let _ = WGSL_DUMP_DIR.set(dir.into());
+}
+
+/// Dump WGSL source to the configured dump dir, if any.
 fn maybe_dump_wgsl(source: &str, hint: &str) {
-    if let Some(dir) = crate::config::DUMP_WGSL.text() {
-        let _ = std::fs::create_dir_all(&dir);
+    if let Some(dir) = WGSL_DUMP_DIR.get() {
+        let _ = std::fs::create_dir_all(dir);
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         std::hash::Hash::hash(source, &mut hasher);
         let h = std::hash::Hasher::finish(&hasher);
@@ -473,15 +482,24 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::FlashAttention => {
             // Default head_dim=64 fallback; runtime calls
             // generate_flash_attention_module(head_dim) directly.
-            generate_flash_attention_module(64, flash_ept_cap())
+            generate_flash_attention_module(
+                64,
+                crate::compile::TuningKnobs::default().flash_ept_cap,
+            )
         }
         ShaderGroup::FlashAttentionCoop => generate_flash_attention_coop_module(64),
         ShaderGroup::FlashGradQCoop => generate_flash_grad_q_coop_module(64),
         ShaderGroup::FlashGradKVCoop => generate_flash_grad_kv_coop_module(64),
         ShaderGroup::MultiHeadAttnGradQ => parse_wgsl(include_str!("shaders/mha_grad_q.wgsl")),
-        ShaderGroup::FlashGradQ => generate_flash_grad_q_module(64, flash_grad_q_ept_cap()),
+        ShaderGroup::FlashGradQ => generate_flash_grad_q_module(
+            64,
+            crate::compile::TuningKnobs::default().flash_grad_q_ept_cap,
+        ),
         ShaderGroup::MultiHeadAttnGradKV => parse_wgsl(include_str!("shaders/mha_grad_kv.wgsl")),
-        ShaderGroup::FlashGradKV => generate_flash_grad_kv_module(64, flash_grad_kv_ept_cap()),
+        ShaderGroup::FlashGradKV => generate_flash_grad_kv_module(
+            64,
+            crate::compile::TuningKnobs::default().flash_grad_kv_ept_cap,
+        ),
         ShaderGroup::SwiGLUGrad => parse_wgsl(include_str!("shaders/swiglu_grad.wgsl")),
         ShaderGroup::SwiGLUConcat => parse_wgsl(include_str!("shaders/swiglu_concat.wgsl")),
         ShaderGroup::SumRows => parse_wgsl(include_str!("shaders/sum_rows.wgsl")),
@@ -2164,52 +2182,6 @@ pub fn set_coop_caps(caps: CoopCaps) {
 
 pub fn coop_caps() -> CoopCaps {
     *COOP_CAPS.get().unwrap_or(&CoopCaps::default())
-}
-
-/// Single tunable cap on elements-per-thread for flash codegen.
-/// Apple Silicon benefits from the extra parallelism at 16, while 32 keeps
-/// register count below the spilling cliff on Ampere/Blackwell.
-/// `MEGANEURA_FLASH_EPT_CAP` overrides either default for benchmarking sweeps.
-/// Codegen and dispatch both read this so they agree on tile size.
-pub fn flash_ept_cap() -> u32 {
-    flash_ept_override(&crate::config::FLASH_EPT_CAP).unwrap_or(
-        if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
-            16
-        } else {
-            32
-        },
-    )
-}
-
-fn flash_ept_override(var: &crate::config::VarSpec) -> Option<u32> {
-    var.u32_value().filter(|v| {
-        let ok = v.is_power_of_two() && *v >= 2;
-        if !ok {
-            log::warn!("{}={v} must be a power of two >= 2; ignoring", var.name);
-        }
-        ok
-    })
-}
-
-/// dQ has fewer live accumulators than fused dK/dV and follows the forward
-/// cap by default. The shared backward override remains useful for sweeps.
-pub fn flash_grad_q_ept_cap() -> u32 {
-    flash_ept_override(&crate::config::FLASH_GRAD_Q_EPT_CAP)
-        .or_else(|| flash_ept_override(&crate::config::FLASH_BWD_EPT_CAP))
-        .unwrap_or_else(flash_ept_cap)
-}
-
-/// Fused dK/dV benefits from more threads on Apple Silicon, where reducing
-/// its register-heavy per-thread slice outweighs the extra reductions.
-pub fn flash_grad_kv_ept_cap() -> u32 {
-    flash_ept_override(&crate::config::FLASH_GRAD_KV_EPT_CAP)
-        .or_else(|| flash_ept_override(&crate::config::FLASH_BWD_EPT_CAP))
-        .or_else(|| flash_ept_override(&crate::config::FLASH_EPT_CAP))
-        .unwrap_or(if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
-            8
-        } else {
-            32
-        })
 }
 
 pub fn generate_flash_attention_module(head_dim: u32, ept_cap: u32) -> ShaderModule {
@@ -5067,11 +5039,23 @@ mod tests {
     #[test]
     fn test_flash_attention_wgsl() {
         // BQ=4 for hd=64, BQ=8 for hd=32, BQ=2 for hd=128
-        let _ = generate_flash_attention_module(64, flash_ept_cap());
-        let _ = generate_flash_attention_module(32, flash_ept_cap());
-        let _ = generate_flash_attention_module(128, flash_ept_cap());
+        let _ = generate_flash_attention_module(
+            64,
+            crate::compile::TuningKnobs::default().flash_ept_cap,
+        );
+        let _ = generate_flash_attention_module(
+            32,
+            crate::compile::TuningKnobs::default().flash_ept_cap,
+        );
+        let _ = generate_flash_attention_module(
+            128,
+            crate::compile::TuningKnobs::default().flash_ept_cap,
+        );
         // hd=256 should fall back to BQ=1 (regular attention)
-        let _ = generate_flash_attention_module(256, flash_ept_cap());
+        let _ = generate_flash_attention_module(
+            256,
+            crate::compile::TuningKnobs::default().flash_ept_cap,
+        );
     }
 
     #[test]

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -47,7 +47,7 @@ pub struct ShaderModule {
 
 /// Dump WGSL source to `$MEGANEURA_DUMP_WGSL` if set (for debugging/inspection).
 fn maybe_dump_wgsl(source: &str, hint: &str) {
-    if let Ok(dir) = std::env::var("MEGANEURA_DUMP_WGSL") {
+    if let Some(dir) = crate::config::DUMP_WGSL.text() {
         let _ = std::fs::create_dir_all(&dir);
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         std::hash::Hash::hash(source, &mut hasher);
@@ -2172,7 +2172,7 @@ pub fn coop_caps() -> CoopCaps {
 /// `MEGANEURA_FLASH_EPT_CAP` overrides either default for benchmarking sweeps.
 /// Codegen and dispatch both read this so they agree on tile size.
 pub fn flash_ept_cap() -> u32 {
-    flash_ept_override("MEGANEURA_FLASH_EPT_CAP").unwrap_or(
+    flash_ept_override(&crate::config::FLASH_EPT_CAP).unwrap_or(
         if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
             16
         } else {
@@ -2181,27 +2181,30 @@ pub fn flash_ept_cap() -> u32 {
     )
 }
 
-fn flash_ept_override(name: &str) -> Option<u32> {
-    std::env::var(name)
-        .ok()
-        .and_then(|s| s.parse::<u32>().ok())
-        .filter(|v| v.is_power_of_two() && *v >= 2)
+fn flash_ept_override(var: &crate::config::VarSpec) -> Option<u32> {
+    var.u32_value().filter(|v| {
+        let ok = v.is_power_of_two() && *v >= 2;
+        if !ok {
+            log::warn!("{}={v} must be a power of two >= 2; ignoring", var.name);
+        }
+        ok
+    })
 }
 
 /// dQ has fewer live accumulators than fused dK/dV and follows the forward
 /// cap by default. The shared backward override remains useful for sweeps.
 pub fn flash_grad_q_ept_cap() -> u32 {
-    flash_ept_override("MEGANEURA_FLASH_GRAD_Q_EPT_CAP")
-        .or_else(|| flash_ept_override("MEGANEURA_FLASH_BWD_EPT_CAP"))
+    flash_ept_override(&crate::config::FLASH_GRAD_Q_EPT_CAP)
+        .or_else(|| flash_ept_override(&crate::config::FLASH_BWD_EPT_CAP))
         .unwrap_or_else(flash_ept_cap)
 }
 
 /// Fused dK/dV benefits from more threads on Apple Silicon, where reducing
 /// its register-heavy per-thread slice outweighs the extra reductions.
 pub fn flash_grad_kv_ept_cap() -> u32 {
-    flash_ept_override("MEGANEURA_FLASH_GRAD_KV_EPT_CAP")
-        .or_else(|| flash_ept_override("MEGANEURA_FLASH_BWD_EPT_CAP"))
-        .or_else(|| flash_ept_override("MEGANEURA_FLASH_EPT_CAP"))
+    flash_ept_override(&crate::config::FLASH_GRAD_KV_EPT_CAP)
+        .or_else(|| flash_ept_override(&crate::config::FLASH_BWD_EPT_CAP))
+        .or_else(|| flash_ept_override(&crate::config::FLASH_EPT_CAP))
         .unwrap_or(if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
             8
         } else {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -53,21 +53,20 @@ pub struct TuningKnobs {
     pub flash_grad_kv_ept_cap: u32,
 }
 
-impl TuningKnobs {
-    /// Current-platform defaults with `MEGANEURA_FLASH_*_EPT_CAP` overrides —
-    /// the historical behavior of the global cap readers.
-    pub fn from_env() -> Self {
-        Self {
-            flash_ept_cap: crate::codegen::flash_ept_cap(),
-            flash_grad_q_ept_cap: crate::codegen::flash_grad_q_ept_cap(),
-            flash_grad_kv_ept_cap: crate::codegen::flash_grad_kv_ept_cap(),
-        }
-    }
-}
-
 impl Default for TuningKnobs {
+    /// Pure per-platform defaults. Apple Silicon benefits from the extra
+    /// parallelism of smaller EPT; 32 keeps register count below the
+    /// spilling cliff on Ampere/Blackwell. `MEGANEURA_FLASH_*_EPT_CAP`
+    /// overrides are applied only by [`TuningKnobs::from_env`] (in
+    /// `crate::config`) — the library itself never reads the environment.
     fn default() -> Self {
-        Self::from_env()
+        let apple = cfg!(all(target_os = "macos", target_arch = "aarch64"));
+        let fwd = if apple { 16 } else { 32 };
+        Self {
+            flash_ept_cap: fwd,
+            flash_grad_q_ept_cap: fwd,
+            flash_grad_kv_ept_cap: if apple { 8 } else { 32 },
+        }
     }
 }
 
@@ -96,6 +95,12 @@ pub struct CompileOptions {
     pub fuse_dispatches: bool,
     /// Tuning knobs stamped into the compiled plan.
     pub knobs: TuningKnobs,
+    /// Use the cooperative flash-attention forward kernel when the device
+    /// supports it.
+    pub flash_forward_coop: bool,
+    /// Enable the experimental reduced-precision cooperative flash
+    /// backward kernels.
+    pub flash_backward_coop: bool,
 }
 
 impl Default for CompileOptions {
@@ -105,6 +110,8 @@ impl Default for CompileOptions {
             use_schedule_reduction: true,
             fuse_dispatches: true,
             knobs: TuningKnobs::default(),
+            flash_forward_coop: true,
+            flash_backward_coop: false,
         }
     }
 }
@@ -825,7 +832,7 @@ pub(crate) fn compile_with_caps(
     options: &CompileOptions,
     coop_caps: crate::codegen::CoopCaps,
 ) -> ExecutionPlan {
-    let allow_reduced_precision_attention_backward = crate::config::FLASH_BWD_COOP.bool_or(false);
+    let allow_reduced_precision_attention_backward = options.flash_backward_coop;
     compile_with_caps_policy(
         graph,
         options,
@@ -837,12 +844,9 @@ pub(crate) fn compile_with_caps(
 fn compile_with_caps_policy(
     graph: &Graph,
     options: &CompileOptions,
-    mut coop_caps: crate::codegen::CoopCaps,
+    coop_caps: crate::codegen::CoopCaps,
     allow_reduced_precision_attention_backward: bool,
 ) -> ExecutionPlan {
-    if crate::config::DISABLE_COOP.bool_or(false) {
-        coop_caps = crate::codegen::CoopCaps::default();
-    }
     let mut compiler = Compiler::new_with_options(
         graph,
         options.clone(),
@@ -1744,7 +1748,7 @@ impl<'a> Compiler<'a> {
         // the scalar kernel on Blackwell. The env var
         // `MEGANEURA_FLASH_FWD_COOP=0` opts back to scalar (regression
         // escape hatch).
-        let coop_disabled = !crate::config::FLASH_FWD_COOP.bool_or(true);
+        let coop_disabled = !self.options.flash_forward_coop;
         if !coop_disabled
             && self.coop_caps.supports_16x16_f16()
             && head_dim >= 16
@@ -4653,13 +4657,13 @@ mod tests {
         );
         for hd_log2 in 1..=8 {
             let hd: u32 = 1 << hd_log2;
-            let fwd_ept = hd.min(crate::codegen::flash_ept_cap());
+            let fwd_ept = hd.min(TuningKnobs::default().flash_ept_cap);
             let fwd_tpq = hd / fwd_ept;
             let fwd_bq: u32 = (256 / fwd_tpq).max(1);
-            let grad_q_ept = hd.min(crate::codegen::flash_grad_q_ept_cap());
+            let grad_q_ept = hd.min(TuningKnobs::default().flash_grad_q_ept_cap);
             let grad_q_tpq = hd / grad_q_ept;
             let grad_q_bq: u32 = (256 / grad_q_tpq).max(1);
-            let grad_kv_ept = hd.min(crate::codegen::flash_grad_kv_ept_cap());
+            let grad_kv_ept = hd.min(TuningKnobs::default().flash_grad_kv_ept_cap);
             let grad_kv_tpq = hd / grad_kv_ept;
             let grad_kv_bq: u32 = (256 / grad_kv_tpq).max(1);
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -825,8 +825,7 @@ pub(crate) fn compile_with_caps(
     options: &CompileOptions,
     coop_caps: crate::codegen::CoopCaps,
 ) -> ExecutionPlan {
-    let allow_reduced_precision_attention_backward =
-        std::env::var("MEGANEURA_FLASH_BWD_COOP").as_deref() == Ok("1");
+    let allow_reduced_precision_attention_backward = crate::config::FLASH_BWD_COOP.bool_or(false);
     compile_with_caps_policy(
         graph,
         options,
@@ -841,7 +840,7 @@ fn compile_with_caps_policy(
     mut coop_caps: crate::codegen::CoopCaps,
     allow_reduced_precision_attention_backward: bool,
 ) -> ExecutionPlan {
-    if std::env::var("MEGANEURA_DISABLE_COOP").is_ok() {
+    if crate::config::DISABLE_COOP.bool_or(false) {
         coop_caps = crate::codegen::CoopCaps::default();
     }
     let mut compiler = Compiler::new_with_options(
@@ -1745,7 +1744,7 @@ impl<'a> Compiler<'a> {
         // the scalar kernel on Blackwell. The env var
         // `MEGANEURA_FLASH_FWD_COOP=0` opts back to scalar (regression
         // escape hatch).
-        let coop_disabled = std::env::var("MEGANEURA_FLASH_FWD_COOP").as_deref() == Ok("0");
+        let coop_disabled = !crate::config::FLASH_FWD_COOP.bool_or(true);
         if !coop_disabled
             && self.coop_caps.supports_16x16_f16()
             && head_dim >= 16

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,255 @@
+//! Central registry of every `MEGANEURA_*` environment variable.
+//!
+//! Every variable the library reads is declared here — its type, its
+//! class, its documentation, and nothing else reads `std::env` for
+//! `MEGANEURA_*` names. That buys three things the old scattered
+//! `env::var` calls couldn't provide:
+//!
+//! * **Discoverability** — [`describe`] renders the full table, and a
+//!   test pins the README against the registry so docs can't drift.
+//! * **Visibility** — [`log_overrides`] (called once at session build)
+//!   logs every variable that is actually set, and warns about
+//!   `MEGANEURA_*` names it doesn't recognize, so a typo like
+//!   `MEGANEURA_DISBLE_COOP=1` fails loudly instead of silently doing
+//!   nothing.
+//! * **Uniform semantics** — every boolean variable parses the same
+//!   way: unset → its default, `0` → off, anything else → on.
+//!   (Historically some flags treated *any* value, including `0`, as
+//!   on.)
+//!
+//! Precedence is per class:
+//!
+//! * [`VarClass::Diagnostic`] switches **override everything** — they
+//!   exist to change the behavior of a binary you can't edit.
+//! * [`VarClass::Tuning`] variables feed **defaults** — an explicitly
+//!   constructed [`TuningKnobs`](crate::compile::TuningKnobs) or
+//!   `SessionConfig` field wins over the environment.
+//! * [`VarClass::Selection`] variables choose external resources
+//!   (device, output paths) and have no in-code counterpart.
+//! * [`VarClass::External`] names are read by tests/examples, not the
+//!   library; they're registered so the unknown-variable warning
+//!   doesn't fire on them.
+
+use std::sync::OnceLock;
+
+/// How a variable's value is interpreted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VarKind {
+    /// Boolean: unset → default, `"0"` → false, anything else → true.
+    Bool,
+    /// Unsigned integer.
+    U32,
+    /// Free-form text (device ids, paths, mode names, ranges).
+    Text,
+}
+
+/// What kind of decision the variable participates in (see module docs
+/// for the precedence rules per class).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VarClass {
+    /// Debugging escape hatch; overrides code-level configuration.
+    Diagnostic,
+    /// Performance knob; provides the *default* for a typed option.
+    Tuning,
+    /// Selects an external resource (adapter, dump path, mode).
+    Selection,
+    /// Read by tests/examples only; registered for typo detection.
+    External,
+}
+
+/// One registered environment variable.
+pub struct VarSpec {
+    pub name: &'static str,
+    pub kind: VarKind,
+    pub class: VarClass,
+    pub doc: &'static str,
+}
+
+impl VarSpec {
+    fn raw(&self) -> Option<String> {
+        std::env::var(self.name).ok()
+    }
+
+    /// Boolean read: unset → `default`, `"0"` → `false`, else `true`.
+    pub fn bool_or(&self, default: bool) -> bool {
+        debug_assert_eq!(self.kind, VarKind::Bool, "{} is not boolean", self.name);
+        match self.raw() {
+            None => default,
+            Some(v) => v != "0",
+        }
+    }
+
+    /// `u32` read; unparsable values are ignored with a warning.
+    pub fn u32_value(&self) -> Option<u32> {
+        debug_assert_eq!(self.kind, VarKind::U32, "{} is not u32", self.name);
+        let raw = self.raw()?;
+        match raw.parse::<u32>() {
+            Ok(v) => Some(v),
+            Err(_) => {
+                log::warn!("{}={raw:?} is not a u32; ignoring", self.name);
+                None
+            }
+        }
+    }
+
+    /// Text read.
+    pub fn text(&self) -> Option<String> {
+        debug_assert_eq!(self.kind, VarKind::Text, "{} is not text", self.name);
+        self.raw()
+    }
+}
+
+macro_rules! registry {
+    ($($ident:ident: $name:literal, $kind:ident, $class:ident, $doc:literal;)*) => {
+        $(pub static $ident: VarSpec = VarSpec {
+            name: $name,
+            kind: VarKind::$kind,
+            class: VarClass::$class,
+            doc: $doc,
+        };)*
+        /// Every registered variable.
+        pub static REGISTRY: &[&VarSpec] = &[$(&$ident),*];
+    };
+}
+
+registry! {
+    // --- Diagnostic escape hatches (override code configuration) ---
+    DISABLE_COOP: "MEGANEURA_DISABLE_COOP", Bool, Diagnostic,
+        "Force the portable scalar matmul path; disables cooperative-matrix selection entirely.";
+    COOP_F16: "MEGANEURA_COOP_F16", Bool, Diagnostic,
+        "Opt in to f16-input cooperative tiles on devices that advertise no f32 tile.";
+    FLASH_FWD_COOP: "MEGANEURA_FLASH_FWD_COOP", Bool, Diagnostic,
+        "Set to 0 to disable only cooperative flash-attention forward.";
+    FLASH_BWD_COOP: "MEGANEURA_FLASH_BWD_COOP", Bool, Diagnostic,
+        "Enable the experimental reduced-precision cooperative flash backward.";
+    NO_ALIAS: "MEGANEURA_NO_ALIAS", Bool, Diagnostic,
+        "Disable buffer lifetime aliasing; every logical buffer gets its own allocation.";
+    NO_DEVICE_LOCAL: "MEGANEURA_NO_DEVICE_LOCAL", Bool, Diagnostic,
+        "Keep all buffers host-visible instead of device-local.";
+    SERIAL_DISPATCH: "MEGANEURA_SERIAL_DISPATCH", Bool, Diagnostic,
+        "One compute pass per dispatch — guarantees serial execution for bisection.";
+    PIN_BUFS: "MEGANEURA_PIN_BUFS", Text, Diagnostic,
+        "Force-pin logical buffers by id/range (e.g. \"3,17,25-40\") to bisect aliasing bugs.";
+    DUMP_PLAN: "MEGANEURA_DUMP_PLAN", Bool, Diagnostic,
+        "Dump dispatch order, provenance, accesses, and the alias map at session build.";
+    DUMP_WGSL: "MEGANEURA_DUMP_WGSL", Text, Diagnostic,
+        "Directory to write every generated/parsed WGSL shader into.";
+    OPTIMIZER: "MEGANEURA_OPTIMIZER", Text, Diagnostic,
+        "Rewrite mode: off | greedy | egglog-windowed | egglog-outlined | egglog-whole.";
+    EGRAPH_COST: "MEGANEURA_EGRAPH_COST", Text, Diagnostic,
+        "Extraction objective: ast-size | tensor-traffic.";
+    EGRAPH_CUTOFF: "MEGANEURA_EGRAPH_CUTOFF", U32, Diagnostic,
+        "Saturation segment-size ceiling (default 300).";
+
+    // --- Tuning defaults (explicit code-level options win) ---
+    TUNE: "MEGANEURA_TUNE", Bool, Tuning,
+        "Run Session::tune at build: measure coop vs scalar per kernel family and keep the winner.";
+    FLASH_EPT_CAP: "MEGANEURA_FLASH_EPT_CAP", U32, Tuning,
+        "Elements-per-thread cap for flash-attention forward codegen (power of two ≥ 2).";
+    FLASH_GRAD_Q_EPT_CAP: "MEGANEURA_FLASH_GRAD_Q_EPT_CAP", U32, Tuning,
+        "EPT cap for the flash dQ backward kernel.";
+    FLASH_GRAD_KV_EPT_CAP: "MEGANEURA_FLASH_GRAD_KV_EPT_CAP", U32, Tuning,
+        "EPT cap for the fused flash dK/dV backward kernel.";
+    FLASH_BWD_EPT_CAP: "MEGANEURA_FLASH_BWD_EPT_CAP", U32, Tuning,
+        "Shared fallback EPT cap for both flash backward kernels.";
+
+    // --- Resource / mode selection ---
+    DEVICE_ID: "MEGANEURA_DEVICE_ID", Text, Selection,
+        "Adapter selection by backend-reported numeric device id (decimal or 0x-hex).";
+    GPU_TIMING: "MEGANEURA_GPU_TIMING", Bool, Selection,
+        "Enable hardware timestamp query pools (must be set before the GPU context is created).";
+
+    // --- Read by tests/examples, not the library ---
+    TRACE: "MEGANEURA_TRACE", Text, External,
+        "Examples convention: write a Perfetto trace to this path.";
+    SKIP_BACKPROP: "MEGANEURA_SKIP_BACKPROP", Bool, External,
+        "Tests convention: skip MHA-backward tests on software drivers with broken wg reductions.";
+}
+
+/// Render the registry as an aligned plain-text table.
+pub fn describe() -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let width = REGISTRY.iter().map(|v| v.name.len()).max().unwrap_or(0);
+    for var in REGISTRY {
+        let _ = writeln!(
+            out,
+            "{:width$}  {:4?}  {:10?}  {}",
+            var.name, var.kind, var.class, var.doc
+        );
+    }
+    out
+}
+
+/// Log every `MEGANEURA_*` variable that is set (once per process), and
+/// warn about set variables the registry doesn't know — almost always a
+/// typo. Called from session construction; cheap and idempotent.
+pub fn log_overrides() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        let mut active = Vec::new();
+        for (name, value) in std::env::vars() {
+            if !name.starts_with("MEGANEURA_") {
+                continue;
+            }
+            match REGISTRY.iter().find(|v| v.name == name) {
+                Some(var) => {
+                    if var.class != VarClass::External {
+                        active.push(format!("{name}={value}"));
+                    }
+                }
+                None => log::warn!(
+                    "unrecognized environment variable {name}={value} — \
+                     not a registered MEGANEURA_* name (typo?); it has no effect"
+                ),
+            }
+        }
+        if !active.is_empty() {
+            log::info!("environment overrides active: {}", active.join(", "));
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_names_are_unique_and_prefixed() {
+        let mut seen = std::collections::HashSet::new();
+        for var in REGISTRY {
+            assert!(var.name.starts_with("MEGANEURA_"), "{}", var.name);
+            assert!(seen.insert(var.name), "duplicate: {}", var.name);
+        }
+    }
+
+    /// Every user-facing variable must be documented in the README, so
+    /// the docs can't drift from the code. External (tests/examples)
+    /// names are exempt.
+    #[test]
+    fn readme_documents_every_variable() {
+        let readme = include_str!("../README.md");
+        let mut missing = Vec::new();
+        for var in REGISTRY {
+            if var.class == VarClass::External {
+                continue;
+            }
+            if !readme.contains(var.name) {
+                missing.push(var.name);
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "README.md does not mention: {missing:?} — document them \
+             in the environment-variable table"
+        );
+    }
+
+    #[test]
+    fn describe_lists_everything() {
+        let d = describe();
+        for var in REGISTRY {
+            assert!(d.contains(var.name));
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,16 @@
-//! Central registry of every `MEGANEURA_*` environment variable.
+//! Central registry of every `MEGANEURA_*` environment variable — and the
+//! ONLY place that reads them.
+//!
+//! The library core is environment-free: `compile`, `runtime`, `codegen`,
+//! and `optimize` accept strongly typed options and never touch
+//! `std::env`. Clients that want env-driven behavior (the repo's own
+//! examples, benches, and tests; external harnesses like Inferena) opt in
+//! explicitly through the `from_env` constructors below, typically:
+//!
+//! ```no_run
+//! # let graph = meganeura::Graph::new();
+//! let session = meganeura::build(&graph, meganeura::SessionConfig::from_env()).0;
+//! ```
 //!
 //! Every variable the library reads is declared here — its type, its
 //! class, its documentation, and nothing else reads `std::env` for
@@ -7,8 +19,8 @@
 //!
 //! * **Discoverability** — [`describe`] renders the full table, and a
 //!   test pins the README against the registry so docs can't drift.
-//! * **Visibility** — [`log_overrides`] (called once at session build)
-//!   logs every variable that is actually set, and warns about
+//! * **Visibility** — [`log_overrides`] (called by every `from_env`
+//!   constructor) logs every variable that is actually set, and warns about
 //!   `MEGANEURA_*` names it doesn't recognize, so a typo like
 //!   `MEGANEURA_DISBLE_COOP=1` fails loudly instead of silently doing
 //!   nothing.
@@ -17,19 +29,26 @@
 //!   (Historically some flags treated *any* value, including `0`, as
 //!   on.)
 //!
-//! Precedence is per class:
+//! Precedence is simple: `from_env` resolves the environment into a
+//! value, and any field the caller assigns afterwards wins. A binary
+//! that never calls `from_env` is completely environment-independent.
+//! The classes below describe intent:
 //!
-//! * [`VarClass::Diagnostic`] switches **override everything** — they
-//!   exist to change the behavior of a binary you can't edit.
-//! * [`VarClass::Tuning`] variables feed **defaults** — an explicitly
-//!   constructed [`TuningKnobs`](crate::compile::TuningKnobs) or
-//!   `SessionConfig` field wins over the environment.
+//! * [`VarClass::Diagnostic`] switches exist to change the behavior of
+//!   a binary you can't edit — harnesses should honor them by building
+//!   their configs through `from_env`.
+//! * [`VarClass::Tuning`] variables feed the defaults of
+//!   [`TuningKnobs`] / `SessionConfig` knobs.
 //! * [`VarClass::Selection`] variables choose external resources
 //!   (device, output paths) and have no in-code counterpart.
 //! * [`VarClass::External`] names are read by tests/examples, not the
 //!   library; they're registered so the unknown-variable warning
 //!   doesn't fire on them.
 
+use crate::compile::{CompileOptions, TuningKnobs};
+use crate::optimize::{ExtractionCost, OptimizeConfig, OptimizeMode};
+use crate::runtime::{CoopPolicy, GpuOptions, SessionOptions};
+use crate::train::SessionConfig;
 use std::sync::OnceLock;
 
 /// How a variable's value is interpreted.
@@ -164,6 +183,194 @@ registry! {
         "Examples convention: write a Perfetto trace to this path.";
     SKIP_BACKPROP: "MEGANEURA_SKIP_BACKPROP", Bool, External,
         "Tests convention: skip MHA-backward tests on software drivers with broken wg reductions.";
+}
+
+impl OptimizeConfig {
+    /// Read benchmark-oriented overrides while retaining production defaults.
+    ///
+    /// - `MEGANEURA_OPTIMIZER=off|greedy|egglog-windowed|egglog-outlined|egglog-whole`
+    /// - `MEGANEURA_EGRAPH_COST=ast-size|tensor-traffic`
+    /// - `MEGANEURA_EGRAPH_CUTOFF=<positive integer>`
+    pub fn from_env() -> Self {
+        log_overrides();
+        let mut config = Self::default();
+        if let Some(value) = OPTIMIZER.text() {
+            config.mode = match value.as_str() {
+                "off" => OptimizeMode::Off,
+                "greedy" => OptimizeMode::Greedy,
+                "egglog-windowed" | "windowed" => OptimizeMode::EgglogWindowed,
+                "egglog-outlined" | "outlined" => OptimizeMode::EgglogOutlined,
+                "egglog-whole" | "whole" => OptimizeMode::EgglogWhole,
+                _ => {
+                    log::warn!("unknown MEGANEURA_OPTIMIZER={value:?}; using greedy");
+                    OptimizeMode::Greedy
+                }
+            };
+        }
+        if let Some(value) = EGRAPH_COST.text() {
+            config.extraction_cost = match value.as_str() {
+                "ast-size" | "ast" | "unit" => ExtractionCost::AstSize,
+                "tensor-traffic" | "traffic" => ExtractionCost::TensorTraffic,
+                _ => {
+                    log::warn!("unknown MEGANEURA_EGRAPH_COST={value:?}; using tensor-traffic");
+                    ExtractionCost::TensorTraffic
+                }
+            };
+        }
+        if let Some(value) = EGRAPH_CUTOFF.u32_value() {
+            if value > 0 {
+                config.saturation_cutoff = value as usize;
+            } else {
+                log::warn!("MEGANEURA_EGRAPH_CUTOFF must be > 0; using the default");
+            }
+        }
+        config
+    }
+}
+
+impl TuningKnobs {
+    /// Platform defaults with `MEGANEURA_FLASH_*_EPT_CAP` overrides.
+    /// Caps must be powers of two ≥ 2; invalid values warn and are ignored.
+    pub fn from_env() -> Self {
+        log_overrides();
+        fn cap(var: &VarSpec) -> Option<u32> {
+            var.u32_value().filter(|v| {
+                let ok = v.is_power_of_two() && *v >= 2;
+                if !ok {
+                    log::warn!("{}={v} must be a power of two >= 2; ignoring", var.name);
+                }
+                ok
+            })
+        }
+        let d = Self::default();
+        let bwd = cap(&FLASH_BWD_EPT_CAP);
+        let fwd = cap(&FLASH_EPT_CAP);
+        Self {
+            flash_ept_cap: fwd.unwrap_or(d.flash_ept_cap),
+            flash_grad_q_ept_cap: cap(&FLASH_GRAD_Q_EPT_CAP)
+                .or(bwd)
+                .or(fwd)
+                .unwrap_or(d.flash_grad_q_ept_cap),
+            flash_grad_kv_ept_cap: cap(&FLASH_GRAD_KV_EPT_CAP)
+                .or(bwd)
+                .or(fwd)
+                .unwrap_or(d.flash_grad_kv_ept_cap),
+        }
+    }
+}
+
+impl CompileOptions {
+    /// Defaults with the flash-coop switches and EPT caps read from the
+    /// environment.
+    pub fn from_env() -> Self {
+        log_overrides();
+        Self {
+            knobs: TuningKnobs::from_env(),
+            flash_forward_coop: FLASH_FWD_COOP.bool_or(true),
+            flash_backward_coop: FLASH_BWD_COOP.bool_or(false),
+            ..Self::default()
+        }
+    }
+}
+
+impl SessionOptions {
+    /// Defaults with the diagnostic switches and cooperative-matrix policy
+    /// read from the environment.
+    pub fn from_env() -> Self {
+        log_overrides();
+        let coop = if DISABLE_COOP.bool_or(false) {
+            CoopPolicy::Disabled
+        } else if COOP_F16.bool_or(false) {
+            CoopPolicy::AllowF16
+        } else {
+            CoopPolicy::Auto
+        };
+        Self {
+            debug: false,
+            coop,
+            no_alias: NO_ALIAS.bool_or(false),
+            no_device_local: NO_DEVICE_LOCAL.bool_or(false),
+            serial_dispatch: SERIAL_DISPATCH.bool_or(false),
+            dump_plan: DUMP_PLAN.bool_or(false),
+            pin_buffers: PIN_BUFS.text(),
+        }
+    }
+}
+
+impl GpuOptions {
+    /// Adapter selection and timestamp collection from the environment.
+    pub fn from_env() -> Self {
+        log_overrides();
+        let device_id = DEVICE_ID.text().and_then(|value| {
+            let parsed = crate::runtime::parse_device_id(&value);
+            if parsed.is_none() {
+                log::warn!(
+                    "ignoring invalid MEGANEURA_DEVICE_ID={value:?}; \
+                     expected decimal or 0x-prefixed u32"
+                );
+            }
+            parsed
+        });
+        Self {
+            device_id,
+            timing: GPU_TIMING.bool_or(false),
+        }
+    }
+}
+
+impl SessionConfig<'_> {
+    /// A [`SessionConfig`] with every environment override applied — the
+    /// one-liner for harnesses, examples, and env-driven test runs:
+    /// compile options, tuning knobs, optimizer mode, diagnostic switches,
+    /// coop policy, `MEGANEURA_TUNE`, and (only when `MEGANEURA_DEVICE_ID`
+    /// or `MEGANEURA_GPU_TIMING` is set) a GPU context created with those
+    /// options. Also installs the WGSL dump directory when
+    /// `MEGANEURA_DUMP_WGSL` is set.
+    ///
+    /// Fields assigned *after* this call win — precedence is simply
+    /// "explicit code runs last".
+    pub fn from_env() -> Self {
+        log_overrides();
+        if let Some(dir) = DUMP_WGSL.text() {
+            crate::codegen::set_wgsl_dump_dir(dir);
+        }
+        let gpu_opts = GpuOptions::from_env();
+        let gpu = if gpu_opts.device_id.is_some() || gpu_opts.timing {
+            match crate::runtime::init_gpu_context_with(gpu_opts) {
+                Ok(context) => Some(std::sync::Arc::new(context)),
+                Err(e) => {
+                    log::warn!("env-selected GPU init failed ({e:?}); using default adapter");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        Self {
+            gpu,
+            options: CompileOptions::from_env(),
+            optimize: OptimizeConfig::from_env(),
+            runtime: SessionOptions::from_env(),
+            tune: TUNE.bool_or(false),
+            ..Self::default()
+        }
+    }
+
+    /// [`SessionConfig::from_env`] with `mode: Inference`.
+    pub fn inference_from_env() -> Self {
+        Self {
+            mode: crate::train::Mode::Inference,
+            ..Self::from_env()
+        }
+    }
+
+    /// [`SessionConfig::from_env`] with `skip_full_optimize: true`.
+    pub fn unoptimized_from_env() -> Self {
+        Self {
+            skip_full_optimize: true,
+            ..Self::from_env()
+        }
+    }
 }
 
 /// Render the registry as an aligned plain-text table.

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -180,7 +180,14 @@ impl Eager {
                 ..CompileOptions::default()
             },
         );
-        Session::with_context_opts(plan, self.gpu.clone(), SessionOptions { debug: true })
+        Session::with_context_opts(
+            plan,
+            self.gpu.clone(),
+            SessionOptions {
+                debug: true,
+                ..Default::default()
+            },
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,9 @@ pub use load::nnef::{NnefError, NnefModel, load_nnef};
 pub use load::onnx::{OnnxError, OnnxModel, load_onnx, load_onnx_bytes};
 pub use optimize::{ExtractionCost, OptimizeConfig, OptimizeMode, OptimizeReport};
 pub use runtime::{
-    DebugStepReport, DeviceMemoryStats, DispatchAnomaly, ExternalBindError, ExternalSlot,
-    MemorySummary, ReadNodeError, Session, SessionOptions, TuneOutcome, init_gpu_context,
+    CoopPolicy, DebugStepReport, DeviceMemoryStats, DispatchAnomaly, ExternalBindError,
+    ExternalSlot, GpuOptions, MemorySummary, ReadNodeError, Session, SessionOptions, TuneOutcome,
+    init_gpu_context, init_gpu_context_with,
 };
 pub use train::{
     EpochStats, LossHistory, MetricCallback, Mode, Optimizer, SessionConfig, StepMetrics,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod autodiff;
 pub mod cache;
 pub mod codegen;
 pub mod compile;
+pub mod config;
 pub mod data;
 pub mod eager;
 pub mod graph;

--- a/src/memplan.rs
+++ b/src/memplan.rs
@@ -102,8 +102,12 @@ impl BufferUse {
 /// - `ScatterAdd` outputs — read-modify-write;
 /// - any buffer whose first use is a read (live-in from a prior step),
 ///   and any buffer no dispatch touches.
-pub fn plan_buffer_aliasing(plan: &ExecutionPlan, groups: &[Range<usize>]) -> AliasPlan {
-    let (pinned, uses) = compute_pinned(plan, groups);
+pub fn plan_buffer_aliasing(
+    plan: &ExecutionPlan,
+    groups: &[Range<usize>],
+    pin_spec: Option<&str>,
+) -> AliasPlan {
+    let (pinned, uses) = compute_pinned(plan, groups, pin_spec);
     let n = plan.buffers.len();
 
     let mut map = vec![usize::MAX; n];
@@ -179,8 +183,12 @@ pub fn plan_buffer_aliasing(plan: &ExecutionPlan, groups: &[Range<usize>]) -> Al
 /// — step-local intermediates are still marked for `Memory::Device`.
 /// Used when `MEGANEURA_NO_ALIAS` disables reuse, so the aliasing and
 /// device-local decisions can be toggled independently.
-pub fn plan_no_alias(plan: &ExecutionPlan, groups: &[Range<usize>]) -> AliasPlan {
-    let (pinned, _) = compute_pinned(plan, groups);
+pub fn plan_no_alias(
+    plan: &ExecutionPlan,
+    groups: &[Range<usize>],
+    pin_spec: Option<&str>,
+) -> AliasPlan {
+    let (pinned, _) = compute_pinned(plan, groups, pin_spec);
     AliasPlan {
         map: (0..plan.buffers.len()).collect(),
         sizes: plan.buffers.clone(),
@@ -192,7 +200,11 @@ pub fn plan_no_alias(plan: &ExecutionPlan, groups: &[Range<usize>]) -> AliasPlan
 /// which buffers must keep a dedicated, host-visible allocation (see
 /// [`plan_buffer_aliasing`] for the full list), plus the per-buffer
 /// barrier-group use intervals.
-fn compute_pinned(plan: &ExecutionPlan, groups: &[Range<usize>]) -> (Vec<bool>, Vec<BufferUse>) {
+fn compute_pinned(
+    plan: &ExecutionPlan,
+    groups: &[Range<usize>],
+    pin_spec: Option<&str>,
+) -> (Vec<bool>, Vec<BufferUse>) {
     let n = plan.buffers.len();
     let mut pinned = vec![false; n];
     let pin = |b: BufferRef, pinned: &mut Vec<bool>| {
@@ -266,7 +278,7 @@ fn compute_pinned(plan: &ExecutionPlan, groups: &[Range<usize>]) -> (Vec<bool>, 
     // Debug aid: MEGANEURA_PIN_BUFS="3,17,25-40" force-pins logical
     // buffers, excluding them from aliasing. Used to bisect aliasing
     // corruption down to a single buffer.
-    if let Some(spec) = crate::config::PIN_BUFS.text() {
+    if let Some(spec) = pin_spec {
         for part in spec.split(',').filter(|s| !s.is_empty()) {
             if let Some((a, b)) = part.split_once('-') {
                 let (a, b): (usize, usize) = (a.parse().unwrap(), b.parse().unwrap());
@@ -388,7 +400,7 @@ mod tests {
         p.input_buffers.push(("x".into(), BufferRef(0)));
         p.output_buffers.push(BufferRef(4));
         let groups: Vec<Range<usize>> = (0..4).map(|i| i..i + 1).collect();
-        let alias = plan_buffer_aliasing(&p, &groups);
+        let alias = plan_buffer_aliasing(&p, &groups, None);
 
         assert_eq!(alias.map[1], alias.map[3], "t1 and t3 should alias");
         assert_ne!(alias.map[2], alias.map[1], "t2 overlaps t1");
@@ -428,7 +440,7 @@ mod tests {
         p.input_buffers.push(("x".into(), BufferRef(0)));
         p.output_buffers.push(BufferRef(4));
         let groups: Vec<Range<usize>> = (0..4).map(|i| i..i + 1).collect();
-        let alias = plan_no_alias(&p, &groups);
+        let alias = plan_no_alias(&p, &groups, None);
         assert_eq!(alias.map, vec![0, 1, 2, 3, 4]);
         assert_eq!(alias.sizes, p.buffers);
         assert_eq!(alias.device_local, vec![false, true, true, true, false]);
@@ -446,7 +458,7 @@ mod tests {
         p.input_buffers.push(("x".into(), BufferRef(0)));
         p.output_buffers.push(BufferRef(3));
         let groups = vec![0..2, 2..3];
-        let alias = plan_buffer_aliasing(&p, &groups);
+        let alias = plan_buffer_aliasing(&p, &groups, None);
         assert_ne!(alias.map[1], alias.map[2]);
         check_disjoint(&p, &groups, &alias);
     }
@@ -462,7 +474,7 @@ mod tests {
         p.input_buffers.push(("x".into(), BufferRef(0)));
         p.output_buffers.push(BufferRef(3));
         let groups: Vec<Range<usize>> = (0..3).map(|i| i..i + 1).collect();
-        let alias = plan_buffer_aliasing(&p, &groups);
+        let alias = plan_buffer_aliasing(&p, &groups, None);
         // Buffer 2 dies at group 2 and nothing later could reuse buffer 1's
         // slot anyway; the property under test: 1 keeps a dedicated slot.
         assert!(alias.map.iter().filter(|&&m| m == alias.map[1]).count() == 1);
@@ -479,7 +491,7 @@ mod tests {
         p.input_buffers.push(("kv".into(), BufferRef(0)));
         p.output_buffers.push(BufferRef(3));
         let groups: Vec<Range<usize>> = (0..3).map(|i| i..i + 1).collect();
-        let alias = plan_buffer_aliasing(&p, &groups);
+        let alias = plan_buffer_aliasing(&p, &groups, None);
         assert!(alias.map.iter().filter(|&&m| m == alias.map[1]).count() == 1);
     }
 
@@ -494,7 +506,7 @@ mod tests {
         p.param_grad_pairs.push((BufferRef(1), BufferRef(4)));
         p.output_buffers.push(BufferRef(3));
         let groups: Vec<Range<usize>> = (0..3).map(|i| i..i + 1).collect();
-        let alias = plan_buffer_aliasing(&p, &groups);
+        let alias = plan_buffer_aliasing(&p, &groups, None);
         for pinned in [0usize, 1, 3, 4] {
             assert!(
                 alias

--- a/src/memplan.rs
+++ b/src/memplan.rs
@@ -266,7 +266,7 @@ fn compute_pinned(plan: &ExecutionPlan, groups: &[Range<usize>]) -> (Vec<bool>, 
     // Debug aid: MEGANEURA_PIN_BUFS="3,17,25-40" force-pins logical
     // buffers, excluding them from aliasing. Used to bisect aliasing
     // corruption down to a single buffer.
-    if let Ok(spec) = std::env::var("MEGANEURA_PIN_BUFS") {
+    if let Some(spec) = crate::config::PIN_BUFS.text() {
         for part in spec.split(',').filter(|s| !s.is_empty()) {
             if let Some((a, b)) = part.split_once('-') {
                 let (a, b): (usize, usize) = (a.parse().unwrap(), b.parse().unwrap());

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -106,7 +106,7 @@ impl OptimizeConfig {
     /// - `MEGANEURA_EGRAPH_CUTOFF=<positive integer>`
     pub fn from_env() -> Self {
         let mut config = Self::default();
-        if let Ok(value) = std::env::var("MEGANEURA_OPTIMIZER") {
+        if let Some(value) = crate::config::OPTIMIZER.text() {
             config.mode = match value.as_str() {
                 "off" => OptimizeMode::Off,
                 "greedy" => OptimizeMode::Greedy,
@@ -119,7 +119,7 @@ impl OptimizeConfig {
                 }
             };
         }
-        if let Ok(value) = std::env::var("MEGANEURA_EGRAPH_COST") {
+        if let Some(value) = crate::config::EGRAPH_COST.text() {
             config.extraction_cost = match value.as_str() {
                 "ast-size" | "ast" | "unit" => ExtractionCost::AstSize,
                 "tensor-traffic" | "traffic" => ExtractionCost::TensorTraffic,
@@ -129,12 +129,11 @@ impl OptimizeConfig {
                 }
             };
         }
-        if let Ok(value) = std::env::var("MEGANEURA_EGRAPH_CUTOFF") {
-            match value.parse::<usize>() {
-                Ok(value) if value > 0 => config.saturation_cutoff = value,
-                _ => log::warn!(
-                    "invalid MEGANEURA_EGRAPH_CUTOFF={value:?}; using {SATURATION_CUTOFF}"
-                ),
+        if let Some(value) = crate::config::EGRAPH_CUTOFF.u32_value() {
+            if value > 0 {
+                config.saturation_cutoff = value as usize;
+            } else {
+                log::warn!("MEGANEURA_EGRAPH_CUTOFF must be > 0; using {SATURATION_CUTOFF}");
             }
         }
         config

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -98,48 +98,6 @@ impl Default for OptimizeConfig {
     }
 }
 
-impl OptimizeConfig {
-    /// Read benchmark-oriented overrides while retaining production defaults.
-    ///
-    /// - `MEGANEURA_OPTIMIZER=off|greedy|egglog-windowed|egglog-outlined|egglog-whole`
-    /// - `MEGANEURA_EGRAPH_COST=ast-size|tensor-traffic`
-    /// - `MEGANEURA_EGRAPH_CUTOFF=<positive integer>`
-    pub fn from_env() -> Self {
-        let mut config = Self::default();
-        if let Some(value) = crate::config::OPTIMIZER.text() {
-            config.mode = match value.as_str() {
-                "off" => OptimizeMode::Off,
-                "greedy" => OptimizeMode::Greedy,
-                "egglog-windowed" | "windowed" => OptimizeMode::EgglogWindowed,
-                "egglog-outlined" | "outlined" => OptimizeMode::EgglogOutlined,
-                "egglog-whole" | "whole" => OptimizeMode::EgglogWhole,
-                _ => {
-                    log::warn!("unknown MEGANEURA_OPTIMIZER={value:?}; using greedy");
-                    OptimizeMode::Greedy
-                }
-            };
-        }
-        if let Some(value) = crate::config::EGRAPH_COST.text() {
-            config.extraction_cost = match value.as_str() {
-                "ast-size" | "ast" | "unit" => ExtractionCost::AstSize,
-                "tensor-traffic" | "traffic" => ExtractionCost::TensorTraffic,
-                _ => {
-                    log::warn!("unknown MEGANEURA_EGRAPH_COST={value:?}; using tensor-traffic");
-                    ExtractionCost::TensorTraffic
-                }
-            };
-        }
-        if let Some(value) = crate::config::EGRAPH_CUTOFF.u32_value() {
-            if value > 0 {
-                config.saturation_cutoff = value as usize;
-            } else {
-                log::warn!("MEGANEURA_EGRAPH_CUTOFF must be > 0; using {SATURATION_CUTOFF}");
-            }
-        }
-        config
-    }
-}
-
 // ---------------------------------------------------------------------------
 // HBM-traffic-aware cost model for e-graph extraction.
 //
@@ -354,7 +312,7 @@ pub fn optimize(graph: &Graph) -> Graph {
 
 /// Like `optimize`, but also returns a detailed report for debugging.
 pub fn optimize_with_report(graph: &Graph) -> (Graph, OptimizeReport) {
-    optimize_with_config(graph, OptimizeConfig::from_env())
+    optimize_with_config(graph, OptimizeConfig::default())
 }
 
 /// Optimize with an explicit strategy and extraction objective.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2037,6 +2037,33 @@ pub struct SessionOptions {
     /// [`Session::read_node`] after a step. Costs memory and bandwidth;
     /// intended for development, not benchmarking.
     pub debug: bool,
+    /// Cooperative-matrix policy (see [`CoopPolicy`]).
+    pub coop: CoopPolicy,
+    /// Disable buffer lifetime aliasing (independent of `debug`).
+    pub no_alias: bool,
+    /// Keep every buffer host-visible instead of device-local.
+    pub no_device_local: bool,
+    /// One compute pass per dispatch — serial execution for bisection.
+    pub serial_dispatch: bool,
+    /// Dump dispatch order, provenance, accesses, and the alias map at
+    /// session build.
+    pub dump_plan: bool,
+    /// Force-pin logical buffers by id/range, e.g. `"3,17,25-40"` — the
+    /// aliasing-corruption bisection aid.
+    pub pin_buffers: Option<String>,
+}
+
+/// How cooperative-matrix hardware may be used.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CoopPolicy {
+    /// Use native f32 tiles when advertised; never stage through f16.
+    #[default]
+    Auto,
+    /// Never use cooperative matrices — force the scalar paths.
+    Disabled,
+    /// Additionally allow f16-input tiles on devices that advertise no
+    /// f32 tile. Opt-in: f16 staging can overflow/round on f32 models.
+    AllowF16,
 }
 
 /// Why [`Session::read_node`] could not return a value.
@@ -2261,11 +2288,12 @@ impl Session {
     /// remains opt-in because rounding compounds across deep training graphs.
     fn select_coop_config(
         caps: &blade_graphics::CooperativeMatrix,
+        policy: CoopPolicy,
     ) -> Option<crate::codegen::CoopConfig> {
         use crate::codegen::CoopConfig;
         // Escape hatch for diagnosing coop-matrix numerical bugs.
-        if crate::config::DISABLE_COOP.bool_or(false) {
-            log::warn!("MEGANEURA_DISABLE_COOP set — forcing scalar matmul");
+        if policy == CoopPolicy::Disabled {
+            log::warn!("cooperative matrices disabled by policy — forcing scalar matmul");
             return None;
         }
         log::info!(
@@ -2279,7 +2307,7 @@ impl Session {
         // prefer f32 coop tiles; treat f16 as opt-in (MEGANEURA_COOP_F16)
         // for throughput when the model is known to fit f16. With only f16
         // tiles and no opt-in, fall back to scalar f32 (correct).
-        let want_f16 = crate::config::COOP_F16.bool_or(false);
+        let want_f16 = policy == CoopPolicy::AllowF16;
         if caps.f32_tile > 0 {
             Some(CoopConfig {
                 tile_size: caps.f32_tile,
@@ -2481,9 +2509,8 @@ impl Session {
     }
 
     fn build_session_impl(plan: ExecutionPlan, gpu: Arc<Gpu>, opts: SessionOptions) -> Self {
-        crate::config::log_overrides();
         let coop_caps = gpu.capabilities().cooperative_matrix;
-        let coop_config = Self::select_coop_config(&coop_caps)
+        let coop_config = Self::select_coop_config(&coop_caps, opts.coop)
             .filter(|config| Self::test_coop_matmul(&gpu, config));
         if let Some(ref config) = coop_config {
             log::info!(
@@ -2517,7 +2544,7 @@ impl Session {
         // Reorder dispatches by dependency level so parallel branches (e.g. Q/K/V
         // projections) cluster together, then partition into barrier groups.
         reorder_by_level(&mut plan.dispatches);
-        let groups = if crate::config::SERIAL_DISPATCH.bool_or(false) {
+        let groups = if opts.serial_dispatch {
             // Debug: one dispatch per pass — guarantees serial execution.
             log::info!("MEGANEURA_SERIAL_DISPATCH: forcing one dispatch per pass");
             (0..plan.dispatches.len()).map(|i| i..i + 1).collect()
@@ -2556,20 +2583,20 @@ impl Session {
         // physical allocation. See `memplan` for the safety argument.
         // Debug sessions keep every logical buffer distinct and
         // host-visible so any node's value can be read back after a step.
-        let mut alias = if opts.debug || crate::config::NO_ALIAS.bool_or(false) {
+        let mut alias = if opts.debug || opts.no_alias {
             if opts.debug {
                 log::info!("debug session: buffer aliasing disabled");
             } else {
                 log::info!("MEGANEURA_NO_ALIAS: buffer aliasing disabled");
             }
-            crate::memplan::plan_no_alias(&plan, &groups)
+            crate::memplan::plan_no_alias(&plan, &groups, opts.pin_buffers.as_deref())
         } else {
-            crate::memplan::plan_buffer_aliasing(&plan, &groups)
+            crate::memplan::plan_buffer_aliasing(&plan, &groups, opts.pin_buffers.as_deref())
         };
         // Step-local intermediates default to device-local memory on the
         // theory that host-visible (ReBAR) traffic is slower on discrete
         // boards; kill switch for measurement and UMA debugging.
-        if opts.debug || crate::config::NO_DEVICE_LOCAL.bool_or(false) {
+        if opts.debug || opts.no_device_local {
             if !opts.debug {
                 log::info!("MEGANEURA_NO_DEVICE_LOCAL: all buffers host-visible");
             }
@@ -2578,7 +2605,7 @@ impl Session {
         let alias = alias;
         // Debug aid: dump dispatch order, declared accesses, and the
         // alias map for corruption bisection (see MEGANEURA_PIN_BUFS).
-        if crate::config::DUMP_PLAN.bool_or(false) {
+        if opts.dump_plan {
             for (gi, range) in groups.iter().enumerate() {
                 for i in range.clone() {
                     let d = &plan.dispatches[i];
@@ -3071,17 +3098,26 @@ impl Session {
 /// # Safety
 /// Wraps `blade_graphics::Context::init`, which is `unsafe` because it
 /// loads the system graphics driver.
+/// GPU context creation options. The library never reads the environment;
+/// map `MEGANEURA_DEVICE_ID` / `MEGANEURA_GPU_TIMING` with
+/// [`GpuOptions::from_env`] if you want env-driven selection.
+#[derive(Clone, Debug, Default)]
+pub struct GpuOptions {
+    /// Adapter selection by backend-reported numeric device id.
+    pub device_id: Option<u32>,
+    /// Enable hardware timestamp query pools (needed before the context
+    /// exists; feeds `dump_gpu_timings` and the profiler).
+    pub timing: bool,
+}
+
 pub fn init_gpu_context() -> Result<blade_graphics::Context, blade_graphics::NotSupportedError> {
-    crate::config::log_overrides();
-    let dev_id = crate::config::DEVICE_ID.text().and_then(|value| {
-        let parsed = parse_device_id(&value);
-        if parsed.is_none() {
-            log::warn!(
-                "ignoring invalid MEGANEURA_DEVICE_ID={value:?}; expected decimal or 0x-prefixed u32"
-            );
-        }
-        parsed
-    });
+    init_gpu_context_with(GpuOptions::default())
+}
+
+pub fn init_gpu_context_with(
+    options: GpuOptions,
+) -> Result<blade_graphics::Context, blade_graphics::NotSupportedError> {
+    let dev_id = options.device_id;
     unsafe {
         blade_graphics::Context::init(blade_graphics::ContextDesc {
             validation: cfg!(debug_assertions),
@@ -3089,7 +3125,7 @@ pub fn init_gpu_context() -> Result<blade_graphics::Context, blade_graphics::Not
             // Blade's timing collection reads the query pool without waiting
             // when a command buffer is re-begun; on slow GPUs the previous
             // submission may still be in flight. Keep this off by default.
-            timing: crate::config::GPU_TIMING.bool_or(false),
+            timing: options.timing,
             capture: false,
             overlay: false,
             device_id: dev_id,
@@ -3098,7 +3134,7 @@ pub fn init_gpu_context() -> Result<blade_graphics::Context, blade_graphics::Not
     }
 }
 
-fn parse_device_id(value: &str) -> Option<u32> {
+pub(crate) fn parse_device_id(value: &str) -> Option<u32> {
     let value = value.trim();
     value
         .strip_prefix("0x")

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2264,7 +2264,7 @@ impl Session {
     ) -> Option<crate::codegen::CoopConfig> {
         use crate::codegen::CoopConfig;
         // Escape hatch for diagnosing coop-matrix numerical bugs.
-        if std::env::var("MEGANEURA_DISABLE_COOP").is_ok() {
+        if crate::config::DISABLE_COOP.bool_or(false) {
             log::warn!("MEGANEURA_DISABLE_COOP set — forcing scalar matmul");
             return None;
         }
@@ -2279,7 +2279,7 @@ impl Session {
         // prefer f32 coop tiles; treat f16 as opt-in (MEGANEURA_COOP_F16)
         // for throughput when the model is known to fit f16. With only f16
         // tiles and no opt-in, fall back to scalar f32 (correct).
-        let want_f16 = std::env::var("MEGANEURA_COOP_F16").is_ok();
+        let want_f16 = crate::config::COOP_F16.bool_or(false);
         if caps.f32_tile > 0 {
             Some(CoopConfig {
                 tile_size: caps.f32_tile,
@@ -2481,6 +2481,7 @@ impl Session {
     }
 
     fn build_session_impl(plan: ExecutionPlan, gpu: Arc<Gpu>, opts: SessionOptions) -> Self {
+        crate::config::log_overrides();
         let coop_caps = gpu.capabilities().cooperative_matrix;
         let coop_config = Self::select_coop_config(&coop_caps)
             .filter(|config| Self::test_coop_matmul(&gpu, config));
@@ -2516,7 +2517,7 @@ impl Session {
         // Reorder dispatches by dependency level so parallel branches (e.g. Q/K/V
         // projections) cluster together, then partition into barrier groups.
         reorder_by_level(&mut plan.dispatches);
-        let groups = if std::env::var("MEGANEURA_SERIAL_DISPATCH").is_ok() {
+        let groups = if crate::config::SERIAL_DISPATCH.bool_or(false) {
             // Debug: one dispatch per pass — guarantees serial execution.
             log::info!("MEGANEURA_SERIAL_DISPATCH: forcing one dispatch per pass");
             (0..plan.dispatches.len()).map(|i| i..i + 1).collect()
@@ -2555,7 +2556,7 @@ impl Session {
         // physical allocation. See `memplan` for the safety argument.
         // Debug sessions keep every logical buffer distinct and
         // host-visible so any node's value can be read back after a step.
-        let mut alias = if opts.debug || std::env::var("MEGANEURA_NO_ALIAS").is_ok() {
+        let mut alias = if opts.debug || crate::config::NO_ALIAS.bool_or(false) {
             if opts.debug {
                 log::info!("debug session: buffer aliasing disabled");
             } else {
@@ -2568,7 +2569,7 @@ impl Session {
         // Step-local intermediates default to device-local memory on the
         // theory that host-visible (ReBAR) traffic is slower on discrete
         // boards; kill switch for measurement and UMA debugging.
-        if opts.debug || std::env::var("MEGANEURA_NO_DEVICE_LOCAL").is_ok() {
+        if opts.debug || crate::config::NO_DEVICE_LOCAL.bool_or(false) {
             if !opts.debug {
                 log::info!("MEGANEURA_NO_DEVICE_LOCAL: all buffers host-visible");
             }
@@ -2577,7 +2578,7 @@ impl Session {
         let alias = alias;
         // Debug aid: dump dispatch order, declared accesses, and the
         // alias map for corruption bisection (see MEGANEURA_PIN_BUFS).
-        if std::env::var("MEGANEURA_DUMP_PLAN").is_ok() {
+        if crate::config::DUMP_PLAN.bool_or(false) {
             for (gi, range) in groups.iter().enumerate() {
                 for i in range.clone() {
                     let d = &plan.dispatches[i];
@@ -3071,7 +3072,8 @@ impl Session {
 /// Wraps `blade_graphics::Context::init`, which is `unsafe` because it
 /// loads the system graphics driver.
 pub fn init_gpu_context() -> Result<blade_graphics::Context, blade_graphics::NotSupportedError> {
-    let dev_id = std::env::var("MEGANEURA_DEVICE_ID").ok().and_then(|value| {
+    crate::config::log_overrides();
+    let dev_id = crate::config::DEVICE_ID.text().and_then(|value| {
         let parsed = parse_device_id(&value);
         if parsed.is_none() {
             log::warn!(
@@ -3087,7 +3089,7 @@ pub fn init_gpu_context() -> Result<blade_graphics::Context, blade_graphics::Not
             // Blade's timing collection reads the query pool without waiting
             // when a command buffer is re-begun; on slow GPUs the previous
             // submission may still be in flight. Keep this off by default.
-            timing: std::env::var("MEGANEURA_GPU_TIMING").is_ok(),
+            timing: crate::config::GPU_TIMING.bool_or(false),
             capture: false,
             overlay: false,
             device_id: dev_id,

--- a/src/train.rs
+++ b/src/train.rs
@@ -260,12 +260,12 @@ pub struct SessionConfig<'a> {
     /// debugging gradient flow through aggressively-fused ops. Training
     /// mode only.
     pub skip_full_optimize: bool,
-    /// Build a debug session: buffer aliasing off, every buffer
-    /// host-visible, so any node's value can be read after a step via
-    /// [`Session::read_node`] / [`Session::read_node_by_name`], and
-    /// [`Session::step_debug`] can attribute the first NaN/Inf to a graph
-    /// node. Costs memory and bandwidth; keep it off for benchmarking.
-    pub debug: bool,
+    /// Graph-rewrite configuration (mode, extraction cost, cutoff).
+    pub optimize: optimize::OptimizeConfig,
+    /// Runtime session options: debug observability, cooperative-matrix
+    /// policy, and the diagnostic switches (aliasing, device-local,
+    /// serial dispatch, plan dumps, buffer pinning).
+    pub runtime: runtime::SessionOptions,
     /// Run [`Session::tune`] after construction: measure `step()` wall-clock
     /// with each flippable kernel family on its cooperative variant vs its
     /// scalar fallback and keep the faster one — replacing static promotion
@@ -279,7 +279,10 @@ impl SessionConfig<'_> {
     /// `build(&g, SessionConfig::debug())` is the "print any tensor" mode.
     pub fn debug() -> Self {
         Self {
-            debug: true,
+            runtime: runtime::SessionOptions {
+                debug: true,
+                ..Default::default()
+            },
             ..Self::default()
         }
     }
@@ -299,7 +302,7 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
     let _span = tracing::info_span!("build_session").entered();
     let mode = cfg.mode;
     let mut options = cfg.options;
-    if cfg.debug {
+    if cfg.runtime.debug {
         // Dispatch-level fusion is numerics-neutral; disabling it in debug
         // sessions keeps every graph node's value materialized for
         // `read_node` without changing what the model computes.
@@ -322,7 +325,7 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
         }
     };
     let mut coop_caps = runtime::auto_tune(&gpu, 0).coop_caps;
-    if crate::config::DISABLE_COOP.bool_or(false) {
+    if cfg.runtime.coop == runtime::CoopPolicy::Disabled {
         coop_caps = crate::codegen::CoopCaps::default();
     }
     let mode_tag = match mode {
@@ -335,7 +338,7 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
         match cache::load_build_plan(forward_graph, build_hash, path) {
             Ok(Some(plan)) => {
                 log::info!("loaded cached execution plan from {}", path.display());
-                let session = make_session(plan, gpu, cfg.debug);
+                let session = make_session(plan, gpu, cfg.runtime.clone());
                 return (session, OptimizeReport::empty());
             }
             Ok(None) => log::info!("no valid cache found, recompiling"),
@@ -345,7 +348,7 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
 
     let (optimized_forward, forward_report) = {
         let _span = tracing::info_span!("optimize_forward").entered();
-        optimize::optimize_with_report(forward_graph)
+        optimize::optimize_with_config(forward_graph, cfg.optimize)
     };
     log::info!(
         "optimized forward: {} nodes",
@@ -383,7 +386,7 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
                 (full, forward_report)
             } else {
                 let _span = tracing::info_span!("optimize_full").entered();
-                optimize::optimize_with_report(&full)
+                optimize::optimize_with_config(&full, cfg.optimize)
             }
         }
     };
@@ -408,9 +411,9 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
 
     let mut session = {
         let _span = tracing::info_span!("gpu_init").entered();
-        make_session(plan, gpu, cfg.debug)
+        make_session(plan, gpu, cfg.runtime.clone())
     };
-    if crate::config::TUNE.bool_or(cfg.tune) {
+    if cfg.tune {
         let _span = tracing::info_span!("tune").entered();
         session.tune();
     }
@@ -420,9 +423,9 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
 fn make_session(
     plan: compile::ExecutionPlan,
     gpu: Arc<blade_graphics::Context>,
-    debug: bool,
+    opts: runtime::SessionOptions,
 ) -> Session {
-    Session::with_context_opts(plan, gpu, runtime::SessionOptions { debug })
+    Session::with_context_opts(plan, gpu, opts)
 }
 
 /// Sugar for `build(g, SessionConfig::default()).0` — the common

--- a/src/train.rs
+++ b/src/train.rs
@@ -322,7 +322,7 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
         }
     };
     let mut coop_caps = runtime::auto_tune(&gpu, 0).coop_caps;
-    if std::env::var("MEGANEURA_DISABLE_COOP").is_ok() {
+    if crate::config::DISABLE_COOP.bool_or(false) {
         coop_caps = crate::codegen::CoopCaps::default();
     }
     let mode_tag = match mode {
@@ -410,12 +410,7 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
         let _span = tracing::info_span!("gpu_init").entered();
         make_session(plan, gpu, cfg.debug)
     };
-    let tune = match std::env::var("MEGANEURA_TUNE").as_deref() {
-        Ok("0") => false,
-        Ok(_) => true,
-        Err(_) => cfg.tune,
-    };
-    if tune {
+    if crate::config::TUNE.bool_or(cfg.tune) {
         let _span = tracing::info_span!("tune").entered();
         session.tune();
     }

--- a/tests/adam_state_rw.rs
+++ b/tests/adam_state_rw.rs
@@ -5,7 +5,7 @@
 //! training loop reshapes a parameter table (RadFoam densification was
 //! the original motivating use case).
 
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 #[test]
 fn adam_state_roundtrip_and_step_counter() {
@@ -24,7 +24,7 @@ fn adam_state_roundtrip_and_step_counter() {
     let loss = g.mse_loss(pred, labels);
     g.set_outputs(vec![loss]);
 
-    let mut sess = build_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     sess.set_adam(0.01, 0.9, 0.999, 1e-8);
     sess.set_parameter("log_density", &vec![1.0_f32; n]);
     sess.set_input("x", &vec![0.0_f32; n]);

--- a/tests/back_to_back_step.rs
+++ b/tests/back_to_back_step.rs
@@ -6,7 +6,7 @@
 /// Empirically the SIL pattern has zero downstream effect; this test
 /// isolates whether the meganeura session correctly applies a second
 /// optimizer step in this pattern.
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 fn build_linear_regression(batch_size: usize, in_dim: usize, out_dim: usize) -> Graph {
     let mut g = Graph::new();
@@ -31,7 +31,7 @@ fn back_to_back_step_applies_two_distinct_updates() {
     let in_d = 3;
     let out_d = 2;
     let g = build_linear_regression(batch, in_d, out_d);
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     // Init params deterministically.
     let n_w = in_d * out_d;
@@ -121,7 +121,7 @@ fn set_adam_persists_across_steps_without_re_arming() {
     let in_d = 3;
     let out_d = 2;
     let g = build_linear_regression(batch, in_d, out_d);
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     let n_w = in_d * out_d;
     let w_init: Vec<f32> = (0..n_w).map(|i| (i as f32 * 0.1).sin()).collect();
@@ -163,7 +163,7 @@ fn clear_optimizer_stops_updates() {
     let in_d = 3;
     let out_d = 2;
     let g = build_linear_regression(batch, in_d, out_d);
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     let n_w = in_d * out_d;
     let w_init: Vec<f32> = (0..n_w).map(|i| (i as f32 * 0.1).sin()).collect();
@@ -203,7 +203,7 @@ fn back_to_back_with_zero_lr_in_between_does_not_compound() {
     let in_d = 3;
     let out_d = 2;
     let g = build_linear_regression(batch, in_d, out_d);
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     let n_w = in_d * out_d;
     let w_init: Vec<f32> = (0..n_w).map(|i| (i as f32 * 0.1).sin()).collect();

--- a/tests/checkpoint_validation.rs
+++ b/tests/checkpoint_validation.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 use safetensors::tensor::{Dtype, TensorView};
 
 fn training_session() -> meganeura::Session {
@@ -10,7 +10,7 @@ fn training_session() -> meganeura::Session {
     let y = graph.matmul(x, w);
     let loss = graph.mean_all(y);
     graph.set_outputs(vec![loss]);
-    build_session(&graph)
+    meganeura::build(&graph, meganeura::SessionConfig::from_env()).0
 }
 
 #[test]

--- a/tests/conv1x1_grad_residual.rs
+++ b/tests/conv1x1_grad_residual.rs
@@ -10,7 +10,7 @@
 //! stale (aliased) memory — but only when batch*H*W exceeds the tile
 //! coverage, so this checks spatial sizes on both sides of it.
 
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 const EPS: f32 = 1e-2;
 const TOL: f32 = 5e-2;
@@ -40,7 +40,7 @@ fn check_at(res: u32) {
     let loss = g.mse_loss(pred, target);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     session.set_parameter("w0", &ramp((mid_c * in_c * 9) as usize, 0.3, 0.05));
     session.set_parameter("w1", &ramp((mid_c * mid_c * 9) as usize, 0.3, 0.05));
     session.set_parameter("w2", &ramp((out_c * mid_c) as usize, 0.3, 0.05));

--- a/tests/coop_conv_unaligned_k.rs
+++ b/tests/coop_conv_unaligned_k.rs
@@ -13,7 +13,7 @@
 //! no-coop hardware (e.g. lavapipe CI) both paths are scalar and the test
 //! trivially passes.
 
-use meganeura::{Graph, build_inference_session, build_session};
+use meganeura::Graph;
 use std::sync::Mutex;
 
 static GPU_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -38,7 +38,7 @@ fn conv_out(in_c: u32, coop: bool) -> Vec<f32> {
     let k = g.parameter("k", &[k_size]);
     let y = g.conv2d(x, k, batch, in_c, hw, hw, out_c, 3, 3, 1, 1);
     g.set_outputs(vec![y]);
-    let mut s = build_inference_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     // Small bounded values so f16 coop precision is not the issue.
     let xd: Vec<f32> = (0..in_size)
         .map(|i| ((i * 31 % 17) as f32 / 16.0 - 0.5) * 0.2)
@@ -77,7 +77,7 @@ fn conv_input_grad(coop: bool) -> Vec<f32> {
     let loss = g.mean_all(y);
     g.set_outputs(vec![loss]);
 
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let xd: Vec<f32> = (0..x_size)
         .map(|i| ((i * 31 % 17) as f32 - 8.0) * 0.01)
         .collect();

--- a/tests/coop_matmul_skinny.rs
+++ b/tests/coop_matmul_skinny.rs
@@ -123,7 +123,7 @@ fn run_matmul(m: usize, k: usize, n: usize) -> Vec<f32> {
         &g,
         SessionConfig {
             mode: Mode::Inference,
-            ..Default::default()
+            ..SessionConfig::from_env()
         },
     );
     let a_data = pcg_inputs(m * k, 1);
@@ -150,7 +150,7 @@ fn run_matmul_at(m: usize, k: usize, n: usize) -> Vec<f32> {
         &g,
         SessionConfig {
             mode: Mode::Inference,
-            ..Default::default()
+            ..SessionConfig::from_env()
         },
     );
     let a_data = pcg_inputs(k * m, 1);
@@ -177,7 +177,7 @@ fn run_matmul_bt(m: usize, k: usize, n: usize) -> Vec<f32> {
         &g,
         SessionConfig {
             mode: Mode::Inference,
-            ..Default::default()
+            ..SessionConfig::from_env()
         },
     );
     let a_data = pcg_inputs(m * k, 1);
@@ -353,7 +353,7 @@ fn run_matmul_sigmoid(m: usize, k: usize, n: usize) -> Vec<f32> {
         &g,
         SessionConfig {
             mode: Mode::Inference,
-            ..Default::default()
+            ..SessionConfig::from_env()
         },
     );
     let a_data = pcg_inputs(m * k, 1);

--- a/tests/debug_session.rs
+++ b/tests/debug_session.rs
@@ -4,7 +4,7 @@
 use meganeura::graph::Graph;
 use meganeura::nn::Linear;
 use meganeura::runtime::ReadNodeError;
-use meganeura::{Mode, SessionConfig, build};
+use meganeura::{Mode, SessionConfig, SessionOptions, build};
 
 fn build_mlp() -> Graph {
     let mut g = Graph::new();
@@ -26,8 +26,11 @@ fn read_node_by_name_matches_cpu() {
         &g,
         SessionConfig {
             mode: Mode::Inference,
-            debug: true,
-            ..SessionConfig::default()
+            runtime: SessionOptions {
+                debug: true,
+                ..Default::default()
+            },
+            ..SessionConfig::from_env()
         },
     );
 
@@ -85,8 +88,11 @@ fn step_debug_attributes_first_nan() {
         &g,
         SessionConfig {
             mode: Mode::Inference,
-            debug: true,
-            ..SessionConfig::default()
+            runtime: SessionOptions {
+                debug: true,
+                ..Default::default()
+            },
+            ..SessionConfig::from_env()
         },
     );
 

--- a/tests/device_local.rs
+++ b/tests/device_local.rs
@@ -7,7 +7,7 @@
 //! Kept in its own test binary: the env var is process-global and the
 //! sessions here are built sequentially to avoid racing other tests.
 
-use meganeura::{Graph, build_session, nn};
+use meganeura::{Graph, nn};
 
 fn model(bs: usize) -> Graph {
     let mut g = Graph::new();
@@ -27,7 +27,7 @@ fn model(bs: usize) -> Graph {
 
 fn run(bs: usize) -> (f32, Vec<f32>) {
     let g = model(bs);
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     s.set_parameter("fc1.weight", &vec![0.05; 8 * 16]);
     s.set_parameter("fc1.bias", &[0.1; 16]);
     s.set_parameter("norm.weight", &[1.0; 16]);

--- a/tests/eager.rs
+++ b/tests/eager.rs
@@ -50,7 +50,7 @@ fn eval_while_building_matches_compiled_session() {
         &g,
         SessionConfig {
             mode: Mode::Inference,
-            ..SessionConfig::default()
+            ..SessionConfig::from_env()
         },
     );
     s.set_input("x", &x_data);

--- a/tests/f16_embedding.rs
+++ b/tests/f16_embedding.rs
@@ -4,7 +4,7 @@
 //! This validates the f16-coefficients path (halved gather bytes) end to
 //! end — forward gather + straight-through backward + scatter-add.
 
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 fn run(use_f16: bool) -> (f32, Vec<f32>) {
     let vocab = 5usize;
@@ -24,7 +24,7 @@ fn run(use_f16: bool) -> (f32, Vec<f32>) {
     let loss = g.sum_all(prod);
     g.set_outputs(vec![loss]);
 
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let w_init: Vec<f32> = (0..vocab * hidden)
         .map(|i| (i as f32 % 7.0 - 3.0) * 0.3)
         .collect();

--- a/tests/flash_grad_kv_short.rs
+++ b/tests/flash_grad_kv_short.rs
@@ -37,7 +37,7 @@ fn run(
         SessionConfig {
             mode: Mode::Training,
             gpu: Some(gpu),
-            ..Default::default()
+            ..SessionConfig::from_env()
         },
     );
     let uses_coop = session
@@ -88,7 +88,9 @@ fn assert_close(label: &str, scalar: &[f32], cooperative: &[f32]) {
 
 #[test]
 fn short_cross_and_self_attention_grad_kv_match_scalar() {
-    let gpu = Arc::new(meganeura::runtime::init_gpu_context().expect("GPU context"));
+    let gpu = Arc::new(
+        meganeura::init_gpu_context_with(meganeura::GpuOptions::from_env()).expect("GPU context"),
+    );
     let has_coop = gpu.capabilities().cooperative_matrix.f16_tile == 16;
 
     for (label, q_seq, kv_seq) in [("cross", 50, 16), ("self", 50, 50)] {

--- a/tests/fusion_preserves_outputs.rs
+++ b/tests/fusion_preserves_outputs.rs
@@ -4,7 +4,7 @@
 //! dead output from `outputs()`, collapsing `num_outputs()` and making
 //! `read_output_by_index(1)` panic.
 
-use meganeura::{Graph, build_session, nn};
+use meganeura::{Graph, nn};
 
 #[test]
 fn output_matmul_survives_matmul_add_fusion() {
@@ -23,7 +23,7 @@ fn output_matmul_survives_matmul_add_fusion() {
     let loss = g.mse_loss(pred_pre_bias, target);
     g.set_outputs(vec![loss, pred_pre_bias]);
 
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     assert_eq!(
         s.num_outputs(),
         2,

--- a/tests/gemv_parity.rs
+++ b/tests/gemv_parity.rs
@@ -5,7 +5,7 @@
 //! it produces numerically identical output to the tiled matmul for
 //! representative decode-sized shapes.
 
-use meganeura::{Graph, build_inference_session, compile};
+use meganeura::{Graph, compile};
 
 /// Reference CPU matmul for [1,K] × [K,N] → [1,N].
 fn cpu_gemv(a: &[f32], b: &[f32], k: usize, n: usize) -> Vec<f32> {
@@ -27,7 +27,7 @@ fn run_gpu_gemv(a_data: &[f32], b_data: &[f32], k: usize, n: usize) -> Vec<f32> 
     let c = g.matmul(a, b);
     g.set_outputs(vec![c]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Sanity: when N % 4 == 0 the plan should route through GEMV;
     // otherwise it falls back to the tile matmul.
@@ -153,7 +153,7 @@ fn test_gemv_add_shape(k: usize, n: usize, seed: u32) {
     let out = g.add(mm, d_n);
     g.set_outputs(vec![out]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     // Sanity: the optimizer should fuse MatMul+Add to FusedMatMulAdd, which
     // at M=1 with N%4==0 routes through MatMulGemvAdd.
     let plan = session.plan();
@@ -231,7 +231,7 @@ fn test_gemv_bt_shape(k: usize, n: usize, seed: u32) {
     let c = g.matmul_bt(a_n, b_n);
     g.set_outputs(vec![c]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     let plan = session.plan();
     let gemv_bt_count = plan

--- a/tests/gpu_smoke.rs
+++ b/tests/gpu_smoke.rs
@@ -1,7 +1,7 @@
 /// GPU smoke test: validates that all shaders compile with blade + lavapipe
 /// and that a simple forward pass executes without errors.
 use meganeura::{
-    Graph, build_inference_session, build_session, build_session_unoptimized,
+    Graph, build_session, build_session_unoptimized,
     compile::BufferRef,
     models::smolvla::{self, SmolVLAConfig},
 };
@@ -42,7 +42,7 @@ fn matmul_non_uniform_values() {
     let c = g.matmul(a, b);
     g.set_outputs(vec![c]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     let a_data: Vec<f32> = (0..m * k).map(|i| (i / k + 1) as f32).collect(); // A[i,j] = i+1
     let b_data: Vec<f32> = (0..k * n).map(|i| (i % n + 1) as f32).collect(); // B[i,j] = j+1
@@ -90,7 +90,7 @@ fn shader_compilation_and_forward_pass() {
     g.set_outputs(vec![loss]);
 
     // Build session (this compiles all shaders via blade)
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     // Initialize with small data
     let w1_data = vec![0.1_f32; 8 * 5];
@@ -141,7 +141,7 @@ fn matmul_produces_correct_values() {
     let c = g.matmul(a, b);
     g.set_outputs(vec![c]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     let a_data = vec![0.1_f32; m * k];
     let b_data = vec![0.1_f32; k * n];
@@ -184,7 +184,7 @@ fn fused_matmul_add_correct() {
     let out = g.add(mm, d);
     g.set_outputs(vec![out]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     session.set_input("a", &vec![0.1_f32; m * k]);
     session.set_parameter("b", &vec![0.1_f32; k * n]);
@@ -217,7 +217,7 @@ fn simple_sgd_decreases_loss() {
     let loss = g.mean_all(y);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     session.set_parameter("w", &[0.1_f32; 8 * 4]);
     session.set_input("x", &[1.0_f32; 4 * 8]);
     session.step();
@@ -259,7 +259,7 @@ fn silu_swiglu_rmsnorm_gradients() {
     let loss = g.mean_all(rn);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     session.set_parameter("w1", &vec![0.1_f32; d * d]);
     session.set_parameter("w_gate", &vec![0.1_f32; d * d]);
     session.set_parameter("w_up", &vec![0.1_f32; d * d]);
@@ -293,7 +293,7 @@ fn smolvla_training_backprop_smoke() {
     let vlm_seq_len = 4;
 
     let training_g = smolvla::build_action_expert_training(&config, action_seq_len, vlm_seq_len);
-    let mut session = build_session(&training_g);
+    let mut session = meganeura::build(&training_g, meganeura::SessionConfig::from_env()).0;
 
     // Initialize with small uniform weights
     for (name, buf_ref) in session.plan().param_buffers.clone() {
@@ -409,7 +409,7 @@ fn multi_head_attn_gradient_check() {
     let loss_node = g_train.mean_all(out);
     g_train.set_outputs(vec![loss_node]);
 
-    let mut train_sess = build_session(&g_train);
+    let mut train_sess = meganeura::build(&g_train, meganeura::SessionConfig::from_env()).0;
 
     // Varied initialisation — using sin patterns to avoid degenerate cases
     let q_data: Vec<f32> = (0..n_q).map(|i| (i as f32 * 0.01).sin() * 0.1).collect();
@@ -455,7 +455,8 @@ fn multi_head_attn_gradient_check() {
     let out_i = g_infer.multi_head_attn(qi, ki, vi, num_heads, num_kv_heads, head_dim, false);
     let loss_i = g_infer.mean_all(out_i);
     g_infer.set_outputs(vec![loss_i]);
-    let mut infer_sess = build_inference_session(&g_infer);
+    let mut infer_sess =
+        meganeura::build(&g_infer, meganeura::SessionConfig::inference_from_env()).0;
 
     let fwd = |sess: &mut meganeura::Session, qd: &[f32], kd: &[f32], vd: &[f32]| -> f32 {
         sess.set_parameter("q", qd);
@@ -693,9 +694,9 @@ fn smollm2_e2e_gradient_finite_diff() {
     let g = meganeura::models::smollm2::build_training_graph(&config, seq);
     let use_unopt = std::env::var("UNOPT").is_ok();
     let mut train_sess = if use_unopt {
-        build_session_unoptimized(&g)
+        meganeura::build(&g, meganeura::SessionConfig::unoptimized_from_env()).0
     } else {
-        build_session(&g)
+        meganeura::build(&g, meganeura::SessionConfig::from_env()).0
     };
 
     // Deterministic init
@@ -742,7 +743,7 @@ fn smollm2_e2e_gradient_finite_diff() {
 
     // --- Build inference session for finite differences ---
     let gi = meganeura::models::smollm2::build_training_graph(&config, seq);
-    let mut infer_sess = build_inference_session(&gi);
+    let mut infer_sess = meganeura::build(&gi, meganeura::SessionConfig::inference_from_env()).0;
 
     // Same init (must use the same scale)
     for (name, buf_ref) in infer_sess.plan().param_buffers.clone() {
@@ -924,7 +925,7 @@ fn causal_attention_gradient_check() {
     let loss_node = g_train.mean_all(out);
     g_train.set_outputs(vec![loss_node]);
 
-    let mut train_sess = build_session(&g_train);
+    let mut train_sess = meganeura::build(&g_train, meganeura::SessionConfig::from_env()).0;
 
     let q_data: Vec<f32> = (0..n_q).map(|i| (i as f32 * 0.01).sin() * 0.1).collect();
     let k_data: Vec<f32> = (0..n_kv)
@@ -972,7 +973,8 @@ fn causal_attention_gradient_check() {
     let out_i = g_infer.causal_attention(qi, ki, vi, num_heads, num_kv_heads, head_dim);
     let loss_i = g_infer.mean_all(out_i);
     g_infer.set_outputs(vec![loss_i]);
-    let mut infer_sess = build_inference_session(&g_infer);
+    let mut infer_sess =
+        meganeura::build(&g_infer, meganeura::SessionConfig::inference_from_env()).0;
 
     let fwd = |sess: &mut meganeura::Session, qd: &[f32], kd: &[f32], vd: &[f32]| -> f32 {
         sess.set_parameter("q", qd);
@@ -1093,7 +1095,8 @@ fn flash_attention_seq128_correctness() {
     let v = g_flash.input("v", &[seq, d]);
     let out = g_flash.causal_attention(q, k, v, num_heads, num_kv_heads, head_dim);
     g_flash.set_outputs(vec![out]);
-    let mut flash_sess = build_inference_session(&g_flash);
+    let mut flash_sess =
+        meganeura::build(&g_flash, meganeura::SessionConfig::inference_from_env()).0;
 
     // Build reference graph (seq=4 uses MultiHeadAttn kernel)
     let mut g_ref = Graph::new();
@@ -1102,7 +1105,7 @@ fn flash_attention_seq128_correctness() {
     let vr = g_ref.input("v", &[ref_seq, d]);
     let out_ref = g_ref.causal_attention(qr, kr, vr, num_heads, num_kv_heads, head_dim);
     g_ref.set_outputs(vec![out_ref]);
-    let mut ref_sess = build_inference_session(&g_ref);
+    let mut ref_sess = meganeura::build(&g_ref, meganeura::SessionConfig::inference_from_env()).0;
 
     // Shared data for the small prefix
     let q_data: Vec<f32> = (0..n).map(|i| (i as f32 * 0.01).sin() * 0.1).collect();
@@ -1184,7 +1187,7 @@ fn flash_attention_seq128_gradient_check() {
     let loss_node = g_train.mean_all(out);
     g_train.set_outputs(vec![loss_node]);
 
-    let mut train_sess = build_session(&g_train);
+    let mut train_sess = meganeura::build(&g_train, meganeura::SessionConfig::from_env()).0;
 
     let q_data: Vec<f32> = (0..n).map(|i| (i as f32 * 0.01).sin() * 0.1).collect();
     let k_data: Vec<f32> = (0..n)
@@ -1222,7 +1225,8 @@ fn flash_attention_seq128_gradient_check() {
     let out_i = g_infer.causal_attention(qi, ki, vi, num_heads, num_kv_heads, head_dim);
     let loss_i = g_infer.mean_all(out_i);
     g_infer.set_outputs(vec![loss_i]);
-    let mut infer_sess = build_inference_session(&g_infer);
+    let mut infer_sess =
+        meganeura::build(&g_infer, meganeura::SessionConfig::inference_from_env()).0;
 
     let fwd = |sess: &mut meganeura::Session, qd: &[f32]| -> f32 {
         sess.set_parameter("q", qd);
@@ -1280,7 +1284,7 @@ fn swiglu_concat_gradient_check() {
     let loss = g_train.mean_all(swiglu);
     g_train.set_outputs(vec![loss]);
 
-    let mut sess = build_session(&g_train);
+    let mut sess = meganeura::build(&g_train, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..seq * d)
         .map(|i| (i as f32 * 0.13).sin() * 1.0)
         .collect();
@@ -1321,7 +1325,7 @@ fn swiglu_concat_gradient_check() {
     let swi = g_infer.swiglu_concat(mmi);
     let li = g_infer.mean_all(swi);
     g_infer.set_outputs(vec![li]);
-    let mut isess = build_inference_session(&g_infer);
+    let mut isess = meganeura::build(&g_infer, meganeura::SessionConfig::inference_from_env()).0;
 
     let fwd = |s: &mut meganeura::Session, wd: &[f32]| -> f32 {
         s.set_parameter("w", wd);
@@ -1375,7 +1379,7 @@ fn abs_log_recip_ops() {
     let a = g.abs(x);
     g.set_outputs(vec![a]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let input: Vec<f32> = vec![-3.0, -2.0, -1.0, -0.5, 0.5, 1.0, 2.0, 3.0];
     session.set_input("x", &input);
     session.step();
@@ -1399,7 +1403,7 @@ fn abs_log_recip_ops() {
     let l = g.log(x);
     g.set_outputs(vec![l]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let input: Vec<f32> = vec![0.1, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 100.0];
     session.set_input("x", &input);
     session.step();
@@ -1423,7 +1427,7 @@ fn abs_log_recip_ops() {
     let r = g.recip(x);
     g.set_outputs(vec![r]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let input: Vec<f32> = vec![0.1, 0.5, 1.0, 2.0, 4.0, 5.0, 10.0, 100.0];
     session.set_input("x", &input);
     session.step();
@@ -1453,7 +1457,7 @@ fn mse_loss_training() {
     let loss = g.mse_loss(pred, target);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     session.set_parameter("w", &[0.1_f32; 16]);
     session.set_input("x", &[1.0_f32; 16]);
     session.set_input("target", &[0.0_f32; 16]);
@@ -1490,7 +1494,7 @@ fn bce_loss_forward() {
     let loss = g.bce_loss(pred, labels);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     session.set_input("pred", &[0.9, 0.1, 0.8, 0.2]);
     session.set_input("labels", &[1.0, 0.0, 1.0, 0.0]);
 
@@ -1520,7 +1524,7 @@ fn checkpoint_round_trip() {
     let loss = g.mean_all(y);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     session.set_parameter("w", &[0.1_f32; 8 * 4]);
     session.set_input("x", &[1.0_f32; 4 * 8]);
 
@@ -1549,7 +1553,7 @@ fn checkpoint_round_trip() {
     session.read_buffer(w_buf, &mut w_saved);
 
     // Fresh session, load checkpoint
-    let mut session2 = build_session(&g);
+    let mut session2 = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     session2.load_checkpoint(&tmp).expect("load checkpoint");
 
     let mut w_loaded = vec![0.0f32; 32];
@@ -1619,7 +1623,7 @@ fn kv_cache_ops_smoke() {
 
     g.set_outputs(vec![attn]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Initialize caches to zero
     session.set_parameter("k_cache", &vec![0.0f32; max_seq * kv_dim]);
@@ -1687,7 +1691,7 @@ fn conv2d_forward_smoke() {
     );
     g.set_outputs(vec![output]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // All-ones input, all-ones kernel → each output = 9.0 (sum of 3×3 ones)
     session.set_input("input", &vec![1.0f32; in_size]);
@@ -1737,7 +1741,7 @@ fn conv2d_padding_smoke() {
     );
     g.set_outputs(vec![output]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     session.set_input("input", &vec![1.0f32; in_size]);
     session.set_parameter("kernel", &vec![1.0f32; kernel_size]);
 
@@ -1798,7 +1802,7 @@ fn conv2d_dw_smoke() {
     );
     g.set_outputs(vec![output]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Fill input channel c with constant (c+1): channel 0 = 1.0, channel 1 = 2.0, channel 2 = 3.0.
     let mut x = vec![0.0f32; in_size];
@@ -1888,7 +1892,7 @@ fn conv2d_dw_channel_isolation() {
     );
     g.set_outputs(vec![output]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     let hw = (h * w) as usize;
     let mut x = vec![1.0f32; in_size];
@@ -1940,7 +1944,7 @@ fn mul_per_channel_smoke() {
     let out = g.mul_per_channel(src, gate, channels, spatial);
     g.set_outputs(vec![out]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // src = i (linear ramp), gate[n,c] = 10 + n*100 + c*10
     let mut src_data = vec![0.0f32; total];
@@ -2055,7 +2059,7 @@ fn conv2d_backward_smoke() {
         let loss2 = g2.sum_all(conv2);
         g2.set_outputs(vec![loss2]);
 
-        let mut s2 = build_inference_session(&g2);
+        let mut s2 = meganeura::build(&g2, meganeura::SessionConfig::inference_from_env()).0;
         s2.set_input("input", &input_data);
         s2.set_parameter("kernel", &k_plus);
         s2.step();
@@ -2081,7 +2085,7 @@ fn conv2d_backward_smoke() {
 /// finite norms in compile order matching individual read_param_grad.
 #[test]
 fn grad_inspection_api_basic() {
-    use meganeura::{Graph, build_session};
+    use meganeura::Graph;
     let mut g = Graph::new();
     let x = g.input("x", &[2, 3]);
     let w = g.parameter("weights", &[3, 2]);
@@ -2091,7 +2095,7 @@ fn grad_inspection_api_basic() {
     let target = g.input("target", &[2, 2]);
     let loss = g.mse_loss(h, target);
     g.set_outputs(vec![loss]);
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     session.set_input("x", &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     session.set_input("target", &[0.5, 0.5, 0.5, 0.5]);
@@ -2151,7 +2155,7 @@ fn grad_inspection_api_basic() {
 /// scaled param should have moved that-many-times-more.
 #[test]
 fn lr_multipliers_apply_to_sgd_update() {
-    use meganeura::{Graph, build_session};
+    use meganeura::Graph;
     let mut g = Graph::new();
     let x = g.input("x", &[2, 2]);
     let w_a = g.parameter("a.weight", &[2, 2]);
@@ -2161,7 +2165,7 @@ fn lr_multipliers_apply_to_sgd_update() {
     let target = g.input("target", &[2, 2]);
     let loss = g.mse_loss(h, target);
     g.set_outputs(vec![loss]);
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     let init = vec![1.0, 0.1, 0.1, 1.0];
 
@@ -2269,7 +2273,7 @@ fn rope_per_head_correctness() {
     let x = g.input("x", &[seq, dim]);
     let y = g.rope(x, theta, head_dim);
     g.set_outputs(vec![y]);
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Input: all ones — makes it easy to verify rotation
     let input = vec![1.0f32; seq * dim];
@@ -2359,7 +2363,7 @@ fn cross_entropy_gradient_check() {
     let loss = g.cross_entropy_loss(logits, labels);
     g.set_outputs(vec![loss]);
 
-    let mut sess = build_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     let x_data: Vec<f32> = (0..seq * hidden)
         .map(|i| (i as f32 * 0.1).sin() * 0.5)
@@ -2401,7 +2405,7 @@ fn cross_entropy_gradient_check() {
     let la = gi.input("labels", &[seq, vocab]);
     let lo = gi.cross_entropy_loss(li, la);
     gi.set_outputs(vec![lo]);
-    let mut isess = build_inference_session(&gi);
+    let mut isess = meganeura::build(&gi, meganeura::SessionConfig::inference_from_env()).0;
 
     let fwd = |s: &mut meganeura::Session, xd: &[f32], wd: &[f32]| -> f32 {
         s.set_parameter("x", xd);
@@ -2472,7 +2476,7 @@ fn cross_entropy_gradient_check_weighted_labels() {
     let loss = g.cross_entropy_loss(logits, labels);
     g.set_outputs(vec![loss]);
 
-    let mut sess = build_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     let x_data: Vec<f32> = (0..seq * hidden)
         .map(|i| (i as f32 * 0.13).sin() * 0.4)
@@ -2513,7 +2517,7 @@ fn cross_entropy_gradient_check_weighted_labels() {
     let la = gi.input("labels", &[seq, vocab]);
     let lo = gi.cross_entropy_loss(li, la);
     gi.set_outputs(vec![lo]);
-    let mut isess = build_inference_session(&gi);
+    let mut isess = meganeura::build(&gi, meganeura::SessionConfig::inference_from_env()).0;
 
     let fwd = |s: &mut meganeura::Session, xd: &[f32], wd: &[f32]| -> f32 {
         s.set_parameter("x", xd);
@@ -2580,7 +2584,7 @@ fn matmul_bt_gradient_check() {
     let loss = g.mean_all(c);
     g.set_outputs(vec![loss]);
 
-    let mut sess = build_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let a_data: Vec<f32> = (0..m * k).map(|i| (i as f32 * 0.1).sin()).collect();
     let b_data: Vec<f32> = (0..n * k).map(|i| (i as f32 * 0.07 + 1.0).cos()).collect();
     sess.set_parameter("a", &a_data);
@@ -2606,7 +2610,7 @@ fn matmul_bt_gradient_check() {
     let ci = gi.matmul_bt(ai, bi);
     let li = gi.mean_all(ci);
     gi.set_outputs(vec![li]);
-    let mut isess = build_inference_session(&gi);
+    let mut isess = meganeura::build(&gi, meganeura::SessionConfig::inference_from_env()).0;
 
     let fwd = |s: &mut meganeura::Session, ad: &[f32], bd: &[f32]| -> f32 {
         s.set_parameter("a", ad);
@@ -2672,7 +2676,7 @@ fn tanh_gradient_check() {
     let loss = g_train.mean_all(y);
     g_train.set_outputs(vec![loss]);
 
-    let mut train_sess = build_session(&g_train);
+    let mut train_sess = meganeura::build(&g_train, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..n).map(|i| i as f32 * 0.02 - 2.56).collect();
     train_sess.set_parameter("x", &x_data);
     train_sess.step();
@@ -2691,7 +2695,8 @@ fn tanh_gradient_check() {
     let yi = g_infer.tanh(xi);
     let li = g_infer.mean_all(yi);
     g_infer.set_outputs(vec![li]);
-    let mut infer_sess = build_inference_session(&g_infer);
+    let mut infer_sess =
+        meganeura::build(&g_infer, meganeura::SessionConfig::inference_from_env()).0;
 
     let eps = 1e-3_f32;
     let check_idxs = [0, 10, 64, 128, 200, 255];
@@ -2755,7 +2760,7 @@ fn sliding_window_attention_gradient_check() {
     let loss_node = g_train.mean_all(out);
     g_train.set_outputs(vec![loss_node]);
 
-    let mut train_sess = build_session(&g_train);
+    let mut train_sess = meganeura::build(&g_train, meganeura::SessionConfig::from_env()).0;
 
     let q_data: Vec<f32> = (0..n_q).map(|i| (i as f32 * 0.01).sin() * 0.1).collect();
     let k_data: Vec<f32> = (0..n_kv)
@@ -2811,7 +2816,8 @@ fn sliding_window_attention_gradient_check() {
     );
     let loss_i = g_infer.mean_all(out_i);
     g_infer.set_outputs(vec![loss_i]);
-    let mut infer_sess = build_inference_session(&g_infer);
+    let mut infer_sess =
+        meganeura::build(&g_infer, meganeura::SessionConfig::inference_from_env()).0;
 
     let fwd = |sess: &mut meganeura::Session, qd: &[f32], kd: &[f32], vd: &[f32]| -> f32 {
         sess.set_parameter("q", qd);
@@ -2912,8 +2918,8 @@ fn q4_matmul_correctness() {
     let c_q4 = g_q4.matmul(a_q4, b_q4);
     g_q4.set_outputs(vec![c_q4]);
 
-    let mut sess_ref = build_inference_session(&g_ref);
-    let mut sess_q4 = build_inference_session(&g_q4);
+    let mut sess_ref = meganeura::build(&g_ref, meganeura::SessionConfig::inference_from_env()).0;
+    let mut sess_q4 = meganeura::build(&g_q4, meganeura::SessionConfig::inference_from_env()).0;
 
     // Use values closer to real model scale
     let a_data: Vec<f32> = (0..m * k).map(|i| ((i % 7) as f32 - 3.0) * 0.5).collect();
@@ -3050,7 +3056,7 @@ fn q4_layer_nan_hunt() {
             g.set_outputs(vec![x]);
         }
 
-        let mut session = build_inference_session(&g);
+        let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
         // Set dummy inputs
         session.set_input_u32("token_ids", &[10, 20, 30, 40, 50, 60]);
@@ -3139,7 +3145,7 @@ fn conv2d_1x1_batch_replicated_input_is_uniform() {
     let y = g.conv2d(input, kernel, batch, in_ch, h, w, out_ch, 1, 1, 1, 0);
     g.set_outputs(vec![y]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Deterministic kernel weights so every conv output is nonzero.
     let kernel_data: Vec<f32> = (0..(out_ch * in_ch))
@@ -3206,7 +3212,7 @@ fn add_per_channel_smoke() {
     let out = g.add_per_channel(src, bias, channels, spatial);
     g.set_outputs(vec![out]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     let mut src_data = vec![0.0f32; total];
     for (i, v) in src_data.iter_mut().enumerate() {
@@ -3269,7 +3275,7 @@ fn upload_buffer_rejects_undersized_parameter_upload() {
     let y = g.bias_add(x, bias);
     g.set_outputs(vec![y]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let undersized = vec![0.5_f32; 24]; // 24 floats == 96 bytes
     // Buffer is 48 floats == 192 bytes.  upload_buffer must panic with
     // "byte-size mismatch ... got 96, slot expects 192".

--- a/tests/grad_accumulate.rs
+++ b/tests/grad_accumulate.rs
@@ -2,7 +2,7 @@
 //! the persistent accumulator, then one optimizer step, must match a
 //! single optimizer step on the mean of those K gradients.
 
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 fn build() -> Graph {
     // Simple linear regression: loss = mse(x @ w, target).
@@ -29,7 +29,7 @@ fn accumulate_two_micro_equals_mean_grad_step() {
 
     // --- Reference: read gradA and gradB separately, mean, manual SGD ---
     let g = build();
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     s.set_parameter("w", &W_INIT);
     s.clear_optimizer();
     s.set_input("x", &a_x);
@@ -51,7 +51,7 @@ fn accumulate_two_micro_equals_mean_grad_step() {
     }
 
     // --- Native accumulation: zero_grad, A, B (scale 1/2), then SGD ---
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     s.set_parameter("w", &W_INIT);
     s.set_grad_accumulate(2);
     s.zero_grad();
@@ -83,7 +83,7 @@ fn zero_grad_clears_accumulator() {
     let x = vec![1.0f32, 0.5, -0.3, 0.2, 0.8, 0.1];
     let t = vec![0.4f32, -0.1, 0.6, 0.2];
     let g = build();
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     s.set_parameter("w", &W_INIT);
     s.set_grad_accumulate(2);
 

--- a/tests/grad_clip.rs
+++ b/tests/grad_clip.rs
@@ -4,7 +4,7 @@
 /// gradient is large enough to push the parameter past the target
 /// in one update; with `set_grad_clip_norm(small)` the update should
 /// become much smaller.
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 fn build_linreg(batch: usize, in_d: usize, out_d: usize) -> Graph {
     let mut g = Graph::new();
@@ -19,7 +19,7 @@ fn build_linreg(batch: usize, in_d: usize, out_d: usize) -> Graph {
 
 fn run_one_step(grad_clip: Option<f32>) -> Vec<f32> {
     let g = build_linreg(4, 3, 2);
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     // Same init for every run so we can compare.
     let w_init: Vec<f32> = (0..6).map(|i| (i as f32 * 0.1).sin()).collect();
@@ -105,7 +105,7 @@ fn grad_clip_zero_disables() {
 #[test]
 fn grad_clip_every_skips_clip() {
     let g = build_linreg(4, 3, 2);
-    let mut s = build_session(&g);
+    let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let w_init: Vec<f32> = (0..6).map(|i| (i as f32 * 0.1).sin()).collect();
     s.set_parameter("w.weight", &w_init);
     s.set_parameter("w.bias", &[0.0; 2]);

--- a/tests/grad_debug.rs
+++ b/tests/grad_debug.rs
@@ -1,5 +1,5 @@
 /// Gradient debugging: test individual components with large weights
-use meganeura::{Graph, build_inference_session, build_session, compile::BufferRef};
+use meganeura::{Graph, compile::BufferRef};
 use std::collections::HashMap;
 
 fn name_seed(name: &str) -> f32 {
@@ -21,7 +21,7 @@ fn check_grad(
     check_indices: &[usize],
 ) {
     let g_train = build_train();
-    let mut train_sess = build_session(&g_train);
+    let mut train_sess = meganeura::build(&g_train, meganeura::SessionConfig::from_env()).0;
     for (name, data) in params_init {
         train_sess.set_parameter(name, data);
     }
@@ -46,7 +46,8 @@ fn check_grad(
 
     // Finite differences
     let g_infer = build_infer();
-    let mut infer_sess = build_inference_session(&g_infer);
+    let mut infer_sess =
+        meganeura::build(&g_infer, meganeura::SessionConfig::inference_from_env()).0;
     let orig_data = params_init
         .iter()
         .find(|(name, _)| name == check_param)

--- a/tests/gradcheck.rs
+++ b/tests/gradcheck.rs
@@ -17,7 +17,7 @@
 //! `mul(scalar)` and `add(other_term)`) and compares analytical
 //! gradients against finite-difference gradients.
 
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 const EPS: f32 = 5e-3;
 const TOL: f32 = 1e-2;
@@ -107,7 +107,7 @@ fn mean_all_mid_chain_respects_upstream_coef() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.7 - 1.5).collect();
     let w_init: Vec<f32> = (0..6).map(|i| (i as f32) * 0.3 + 0.1).collect();
     session.set_parameter("w", &w_init);
@@ -129,7 +129,7 @@ fn sum_all_mid_chain_respects_upstream_coef() {
     let loss = g.mul(sum, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.5 - 1.0).collect();
     let w_init: Vec<f32> = (0..6).map(|i| (i as f32) * 0.2 + 0.05).collect();
     session.set_parameter("w", &w_init);
@@ -154,7 +154,7 @@ fn sum_inner_mid_chain_respects_upstream_coef() {
     let loss = g.mul(s, coef); // [1]; grad_output reaches sum_inner via sum_all
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.5 - 1.0).collect();
     let w_init: Vec<f32> = (0..6).map(|i| (i as f32) * 0.2 + 0.05).collect();
     session.set_parameter("w", &w_init);
@@ -179,7 +179,7 @@ fn mse_loss_with_coef_scales_param_gradient() {
     let loss = g.mul(mse, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.3 + 0.5).collect();
     let target_data: Vec<f32> = (0..4).map(|i| (i as f32) * 0.4 - 0.2).collect();
     let w_init: Vec<f32> = (0..6).map(|i| (i as f32) * 0.25 + 0.1).collect();
@@ -209,7 +209,7 @@ fn cross_entropy_loss_with_coef_scales_param_gradient() {
     let loss = g.mul(ce, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = vec![-0.5, 0.2, 0.7];
     let labels_data: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
     let w_init: Vec<f32> = (0..12).map(|i| (i as f32) * 0.1 - 0.5).collect();
@@ -236,7 +236,7 @@ fn bce_loss_with_coef_scales_param_gradient() {
     let loss = g.mul(bce, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.2 - 0.4).collect();
     let labels_data: Vec<f32> = vec![0.7, 0.3];
     let w_init: Vec<f32> = vec![0.2, -0.3, 0.5];
@@ -270,7 +270,7 @@ fn multi_loss_with_independent_coefs() {
     let total = g.add(policy_loss, value_loss);
     g.set_outputs(vec![total]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = vec![0.5, 0.7, 0.9];
     let labels_data: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
     let vt_data: Vec<f32> = vec![1.0];
@@ -310,7 +310,7 @@ fn check_activation_mid_chain(
     let coef_node = g.scalar(coef);
     let loss = g.mul(mean, coef_node);
     g.set_outputs(vec![loss]);
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.3 - 0.5).collect();
     let w_init: Vec<f32> = (0..6).map(|i| (i as f32) * 0.2 + 0.1).collect();
     session.set_parameter("w", &w_init);
@@ -361,7 +361,7 @@ fn log_softmax_mid_chain() {
     let coef = g.scalar(0.5);
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.3 - 0.5).collect();
     let w_init: Vec<f32> = (0..12).map(|i| (i as f32) * 0.1 - 0.4).collect();
     session.set_parameter("w", &w_init);
@@ -393,7 +393,7 @@ fn softmax_mid_chain() {
     let coef = g.scalar(0.5);
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.3 - 0.5).collect();
     let targets_data: Vec<f32> = vec![1.0, 0.5, -0.2, 0.8, -1.0, 0.3, 0.7, -0.4];
     let w_init: Vec<f32> = (0..12).map(|i| (i as f32) * 0.1 - 0.4).collect();
@@ -418,7 +418,7 @@ fn transpose_mid_chain() {
     let coef = g.scalar(0.5);
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.3 - 0.5).collect();
     let w_init: Vec<f32> = (0..12).map(|i| (i as f32) * 0.1 - 0.4).collect();
     session.set_parameter("w", &w_init);
@@ -443,7 +443,7 @@ fn recip_mid_chain() {
     let coef = g.scalar(0.5);
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.3 - 0.5).collect();
     let w_init: Vec<f32> = (0..6).map(|i| (i as f32) * 0.2 + 0.1).collect();
     session.set_parameter("w", &w_init);
@@ -480,7 +480,7 @@ fn split_a_mid_chain_backprops_to_parameter() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let w_init: Vec<f32> = vec![0.5, -0.3, 1.2, -0.8];
     session.set_parameter("w", &w_init);
     let set_inputs = |_: &mut meganeura::Session| {};
@@ -500,7 +500,7 @@ fn split_b_mid_chain_backprops_to_parameter() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let w_init: Vec<f32> = vec![0.2, -0.6, 0.9, 0.3];
     session.set_parameter("w", &w_init);
     let set_inputs = |_: &mut meganeura::Session| {};
@@ -522,7 +522,7 @@ fn cross_entropy_buffer_aliasing_at_batch_2() {
     let loss = g.mul(ce, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data: Vec<f32> = (0..6).map(|i| (i as f32) * 0.4 - 1.0).collect();
     let labels_data: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4, 0.4, 0.3, 0.2, 0.1];
     let w_init: Vec<f32> = (0..12).map(|i| (i as f32) * 0.1 - 0.5).collect();

--- a/tests/gradcheck_vision.rs
+++ b/tests/gradcheck_vision.rs
@@ -5,7 +5,7 @@
 //! non-uniform target so the loss is non-degenerate, `* coef` to catch
 //! dropped upstream gradients, analytical vs central finite differences.
 
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 const EPS: f32 = 5e-3;
 const TOL: f32 = 1e-2;
@@ -97,7 +97,7 @@ fn silu_mid_chain() {
     let coef = g.scalar(0.7);
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(6, 1.0, 0.0);
     session.set_parameter("w", &ramp(6, 0.5, 0.1));
     let set_inputs = |s: &mut meganeura::Session| s.set_input("x", &x_data);
@@ -124,7 +124,7 @@ fn conv2d_3x3_s1_kernel_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(in_size, 1.0, 0.0);
     let t_data = ramp(out_size, 1.0, 0.2);
     session.set_parameter("k", &ramp(k_size, 0.4, 0.0));
@@ -156,7 +156,7 @@ fn conv2d_3x3_s2_kernel_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(in_size, 1.0, 0.0);
     let t_data = ramp(out_size, 1.0, 0.2);
     session.set_parameter("k", &ramp(k_size, 0.4, 0.0));
@@ -190,7 +190,7 @@ fn conv2d_1x1_input_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(in_size, 1.0, 0.0);
     let t_data = ramp(out_size, 1.0, 0.2);
     session.set_parameter("w", &ramp(in_size, 0.5, 0.2));
@@ -223,7 +223,7 @@ fn conv2d_3x3_s1_input_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(in_size, 1.0, 0.0);
     let t_data = ramp(out_size, 1.0, 0.2);
     session.set_parameter("w", &ramp(in_size, 0.5, 0.2));
@@ -253,7 +253,7 @@ fn group_norm_weight_bias_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(x_size, 1.0, 0.0);
     let t_data = ramp(x_size, 1.0, 0.3);
     session.set_parameter("w", &ramp(c as usize, 0.5, 1.0));
@@ -287,7 +287,7 @@ fn group_norm_input_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(x_size, 1.0, 0.5);
     let t_data = ramp(x_size, 1.0, 0.3);
     session.set_parameter("w", &ramp(x_size, 0.5, 1.0));
@@ -319,7 +319,7 @@ fn upsample_2x_input_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(in_size, 1.0, 0.0);
     let t_data = ramp(out_size, 1.0, 0.2);
     session.set_parameter("w", &ramp(in_size, 0.5, 0.3));
@@ -354,7 +354,7 @@ fn concat_both_branches_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let xa_data = ramp(a_size, 1.0, 0.0);
     let xb_data = ramp(b_size, 1.0, 0.1);
     let t_data = ramp(out_size, 1.0, 0.2);
@@ -388,7 +388,7 @@ fn embedding_table_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let t_data = ramp(out_size, 1.0, 0.2);
     session.set_parameter("table", &ramp(vocab * dim, 0.5, 0.0));
     let set_inputs = |s: &mut meganeura::Session| {

--- a/tests/gradcheck_vision_large.rs
+++ b/tests/gradcheck_vision_large.rs
@@ -6,7 +6,7 @@
 //! otherwise too slow); tolerances are loose — we hunt factor-of-N or
 //! sign errors, not 1% noise.
 
-use meganeura::{Graph, build_session};
+use meganeura::Graph;
 
 const EPS: f32 = 2e-2;
 const TOL: f32 = 5e-2;
@@ -108,7 +108,7 @@ fn group_norm_large_spatial() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(x_size, 1.0, 0.5);
     let t_data = ramp(x_size, 1.0, 0.3);
     session.set_parameter("w", &ramp(x_size, 0.5, 1.0));
@@ -143,7 +143,7 @@ fn conv2d_large_spatial_kernel_grad() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(in_size, 1.0, 0.0);
     let t_data = ramp(out_size, 1.0, 0.2);
     session.set_parameter("k", &ramp(k_size, 0.4, 0.0));
@@ -173,7 +173,7 @@ fn film_matmul_large_spatial() {
     let loss = g.mul(mean, coef);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let t_data = ramp(c * spatial, 1.0, 0.2);
     session.set_parameter("e", &ramp(c, 0.5, 0.1));
     let set_inputs = |s: &mut meganeura::Session| {
@@ -195,7 +195,7 @@ fn mse_loss_large() {
     let loss = g.mse_loss(pred, target);
     g.set_outputs(vec![loss]);
 
-    let mut session = build_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
     let x_data = ramp(n, 1.0, 0.0);
     let target_data = ramp(n, 1.0, 0.4);
     session.set_parameter("w", &ramp(n, 0.5, 0.2));

--- a/tests/inference_parity_large.rs
+++ b/tests/inference_parity_large.rs
@@ -5,7 +5,7 @@
 //! training but garbage sampling, which is what van-world SR sampling
 //! shows at step 10k-20k.
 
-use meganeura::{Graph, build_inference_session};
+use meganeura::Graph;
 
 fn ramp(n: usize, scale: f32, offset: f32) -> Vec<f32> {
     (0..n)
@@ -34,7 +34,7 @@ fn check_conv3x3(c_in: u32, c_out: u32, hw: u32) {
     let y = g.conv2d(x, k, 1, c_in, hw, hw, c_out, 3, 3, 1, 1);
     g.set_outputs(vec![y]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let x_data = ramp(in_size, 0.7, 0.1);
     let k_data = ramp(k_size, 0.2, 0.0);
     session.set_parameter("k", &k_data);
@@ -100,7 +100,7 @@ fn group_norm_silu_parity_sr_scale() {
     let y = g.silu(y);
     g.set_outputs(vec![y]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let x_data = ramp(n, 1.0, 0.4);
     let w_data = ramp(c as usize, 0.2, 1.0);
     let b_data = ramp(c as usize, 0.2, 0.0);
@@ -153,7 +153,7 @@ fn conv1x1_layout_parity() {
     let y = g.conv2d(x, k, 1, c_in, hw, hw, c_out, 1, 1, 1, 0);
     g.set_outputs(vec![y]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let x_data = ramp(in_size, 0.7, 0.1);
     let k_data = ramp(k_size, 0.4, 0.1);
     session.set_parameter("k", &k_data);
@@ -210,7 +210,7 @@ fn conv3x1_flat_spatial_dispatch_parity() {
     );
     g.set_outputs(vec![y]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let x_data = ramp(in_size, 0.7, 0.1);
     let k_data = ramp(c_out * c_in * 3, 0.2, 0.0);
     session.set_parameter("k", &k_data);

--- a/tests/intermediate_output_aliasing.rs
+++ b/tests/intermediate_output_aliasing.rs
@@ -2,7 +2,7 @@
 //! consumers and a backward gradient path) returned to the user via
 //! `set_outputs` becomes corrupted after `step()` at batch_size > 1.
 
-use meganeura::{Graph, build_session, nn};
+use meganeura::{Graph, nn};
 
 #[test]
 fn intermediate_node_output_is_stable_across_batch_sizes() {
@@ -24,7 +24,7 @@ fn intermediate_node_output_is_stable_across_batch_sizes() {
         let loss = g.mse_loss(y2, target);
         g.set_outputs(vec![loss, y]);
 
-        let mut s = build_session(&g);
+        let mut s = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
         s.set_parameter("fc1.weight", &[0.1; 16]);
         s.set_parameter("fc1.bias", &[0.1; 4]);
         s.set_parameter("norm.weight", &[1.0; 4]);

--- a/tests/matmul_param_order.rs
+++ b/tests/matmul_param_order.rs
@@ -4,7 +4,7 @@
 //! one of them is wrong. Verify C = A @ B against CPU for non-square
 //! shapes through the real session pipeline.
 
-use meganeura::{Graph, build_inference_session};
+use meganeura::Graph;
 
 fn check(m: usize, k: usize, n: usize) {
     let mut g = Graph::new();
@@ -13,7 +13,7 @@ fn check(m: usize, k: usize, n: usize) {
     let c = g.matmul(a, b);
     g.set_outputs(vec![c]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     let a_data: Vec<f32> = (0..m * k).map(|i| (i as f32) * 0.1 + 0.5).collect();
     let b_data: Vec<f32> = (0..k * n).map(|i| (i as f32) * 0.01 - 0.3).collect();
     session.set_input("a", &a_data);

--- a/tests/mha_head_dim32.rs
+++ b/tests/mha_head_dim32.rs
@@ -4,7 +4,7 @@
 //! inactive lanes were zero-padded, `head_dim=32` made lanes 32..63 read the
 //! next head (or the next sequence row), corrupting every Q/K/V derivative.
 
-use meganeura::{Graph, Session, build_inference_session, build_session};
+use meganeura::{Graph, Session};
 
 fn values(n: usize, frequency: f32, phase: f32) -> Vec<f32> {
     (0..n)
@@ -42,7 +42,7 @@ fn scalar_attention_backward_masks_inactive_lanes() {
     let v = values(n, 0.023, 1.1);
     let weights = values(n, 0.013, 1.7);
 
-    let mut training = build_session(&graph);
+    let mut training = meganeura::build(&graph, meganeura::SessionConfig::from_env()).0;
     set_parameters(&mut training, &q, &k, &v);
     training.set_input("weights", &weights);
     training.step();
@@ -57,7 +57,7 @@ fn scalar_attention_backward_masks_inactive_lanes() {
         training.read_param_grad(name, gradient);
     }
 
-    let mut inference = build_inference_session(&graph);
+    let mut inference = meganeura::build(&graph, meganeura::SessionConfig::inference_from_env()).0;
     let finite_difference =
         |session: &mut Session, name: &str, data: &mut [f32], index: usize| -> f32 {
             let original = data[index];

--- a/tests/mixed_attention_widths.rs
+++ b/tests/mixed_attention_widths.rs
@@ -2,7 +2,7 @@
 //! example, a multimodal vision encoder and text decoder). Each generated
 //! attention pipeline must be specialized independently.
 
-use meganeura::{Graph, build_inference_session};
+use meganeura::Graph;
 
 fn values(len: usize, phase: f32) -> Vec<f32> {
     (0..len)
@@ -19,7 +19,7 @@ fn run_single(head_dim: usize, q: &[f32], k: &[f32], v: &[f32]) -> Vec<f32> {
     let out = graph.full_attention(qn, kn, vn, 1, 1, head_dim as u32);
     graph.set_outputs(vec![out]);
 
-    let mut session = build_inference_session(&graph);
+    let mut session = meganeura::build(&graph, meganeura::SessionConfig::inference_from_env()).0;
     session.set_input("q", q);
     session.set_input("k", k);
     session.set_input("v", v);
@@ -52,7 +52,7 @@ fn mixed_head_dims_match_independent_sessions() {
     let out_b = graph.full_attention(qb_node, kb_node, vb_node, 1, 1, hd_b as u32);
     graph.set_outputs(vec![out_a, out_b]);
 
-    let mut session = build_inference_session(&graph);
+    let mut session = meganeura::build(&graph, meganeura::SessionConfig::inference_from_env()).0;
     for (name, data) in [
         ("qa", qa.as_slice()),
         ("ka", ka.as_slice()),

--- a/tests/multi_input_trainer.rs
+++ b/tests/multi_input_trainer.rs
@@ -8,7 +8,7 @@
 //! input rework, the loader declares N named streams and the trainer
 //! binds them by name.
 
-use meganeura::{DataLoader, Graph, TrainConfig, Trainer, build_session, data::InputStream, nn};
+use meganeura::{DataLoader, Graph, TrainConfig, Trainer, data::InputStream, nn};
 
 fn build_xy_plus_bias_regressor(batch: usize, in_d: usize, out_d: usize) -> Graph {
     let mut g = Graph::new();
@@ -33,7 +33,7 @@ fn trainer_drives_three_named_streams() {
     let n = 32;
 
     let g = build_xy_plus_bias_regressor(batch, in_d, out_d);
-    let session = build_session(&g);
+    let session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     // Deterministic synthetic data.
     let x: Vec<f32> = (0..n * in_d).map(|i| (i as f32 * 0.1).sin()).collect();

--- a/tests/outline_optimize.rs
+++ b/tests/outline_optimize.rs
@@ -6,8 +6,7 @@
 
 use meganeura::graph::Op;
 use meganeura::{
-    Graph, OptimizeConfig, OptimizeMode, autodiff, build_session, compile, optimize,
-    runtime::Session,
+    Graph, OptimizeConfig, OptimizeMode, autodiff, compile, optimize, runtime::Session,
 };
 
 /// Residual MLP with a decomposed-Silu activation. Each layer carries
@@ -112,7 +111,7 @@ fn production_optimization_preserves_outputs() {
     // Fully optimized production training session (forward optimize →
     // autodiff → full-graph optimize). Greedy is the production default;
     // the two tests above exercise outlined egglog explicitly.
-    let mut opt_session = build_session(&g);
+    let mut opt_session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     // Baseline: autodiff + compile with no optimization at all.
     let sorted = g.toposort();

--- a/tests/resnet_correctness.rs
+++ b/tests/resnet_correctness.rs
@@ -1,7 +1,7 @@
 /// Compare ResNet mini-model output against PyTorch reference.
 ///
 /// Run `python3 scripts/gen_reference.py` first to generate the reference.
-use meganeura::{Graph, build_inference_session};
+use meganeura::Graph;
 
 fn parse_f32_array(json: &str, key: &str) -> Vec<f32> {
     let needle = format!("\"{key}\": [");
@@ -88,7 +88,7 @@ fn resnet_mini_matches_pytorch() {
     let logits = g.bias_add(logits, fc_b);
     g.set_outputs(vec![logits]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Load weights
     session.set_parameter("conv1_weight", &parse_f32_array(&json, "conv1_weight"));

--- a/tests/rmsnorm_matmul_prologue.rs
+++ b/tests/rmsnorm_matmul_prologue.rs
@@ -2,7 +2,7 @@
 //! prologue fusion. Ineligible matmuls must remain scalar, while eligible
 //! matmuls must preserve the rsqrt dependency and observe parameter updates.
 
-use meganeura::{Graph, Session, build_inference_session};
+use meganeura::{Graph, Session};
 use std::sync::Mutex;
 
 static GPU_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -35,7 +35,7 @@ fn build(cooperative: bool, expose_normalized: bool) -> Session {
     } else {
         graph.set_outputs(vec![output]);
     }
-    build_inference_session(&graph)
+    meganeura::build(&graph, meganeura::SessionConfig::inference_from_env()).0
 }
 
 fn run(

--- a/tests/schedule_pointwise.rs
+++ b/tests/schedule_pointwise.rs
@@ -11,7 +11,7 @@ fn inference(g: &Graph, opts: CompileOptions) -> Session {
         SessionConfig {
             mode: Mode::Inference,
             options: opts,
-            ..SessionConfig::default()
+            ..SessionConfig::from_env()
         },
     )
     .0

--- a/tests/schedule_reduction.rs
+++ b/tests/schedule_reduction.rs
@@ -31,7 +31,7 @@ fn run(build: &dyn Fn(&mut Graph) -> BuildResult, n_out: usize, fuse: bool) -> V
         SessionConfig {
             mode: Mode::Inference,
             options: opts,
-            ..SessionConfig::default()
+            ..SessionConfig::from_env()
         },
     )
     .0;

--- a/tests/sd_unet_coop_parity.rs
+++ b/tests/sd_unet_coop_parity.rs
@@ -4,7 +4,7 @@
 //! opening 4-to-64-channel convolution then corrupted the whole SD U-Net.
 
 use meganeura::models::sd_unet::{self, SDUNetConfig};
-use meganeura::{Graph, Session, build_inference_session};
+use meganeura::{Graph, Session};
 use std::sync::Mutex;
 
 static GPU_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -52,7 +52,7 @@ fn run(cooperative: bool) -> Vec<f32> {
     let mut graph = Graph::new();
     let output = sd_unet::build_unet(&mut graph, &config);
     graph.set_outputs(vec![output]);
-    let mut session = build_inference_session(&graph);
+    let mut session = meganeura::build(&graph, meganeura::SessionConfig::inference_from_env()).0;
     initialize(&mut session);
 
     let noisy_latent = (0..output_len)

--- a/tests/smollm2_correctness.rs
+++ b/tests/smollm2_correctness.rs
@@ -6,7 +6,7 @@
 //! Run: cargo test --test smollm2_correctness -- --ignored
 
 use meganeura::{
-    Graph, build_inference_session,
+    Graph,
     data::safetensors::SafeTensorsModel,
     models::smollm2::{self, SmolLM2Config},
 };
@@ -117,7 +117,7 @@ fn smollm2_logits_match_pytorch() {
     let logits = smollm2::build_graph(&mut g, &config, SEQ_LEN);
     g.set_outputs(vec![logits]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     let model =
         SafeTensorsModel::download("HuggingFaceTB/SmolLM2-135M").expect("failed to download model");

--- a/tests/submission_chunks.rs
+++ b/tests/submission_chunks.rs
@@ -59,7 +59,7 @@ fn run(chunks: usize, layers: usize, rows: usize, dim: usize, steps: usize) -> V
         &g,
         SessionConfig {
             mode: Mode::Inference,
-            ..Default::default()
+            ..SessionConfig::from_env()
         },
     );
     session.set_submission_chunks(chunks);

--- a/tests/training_correctness.rs
+++ b/tests/training_correctness.rs
@@ -1,6 +1,6 @@
 /// Training correctness tests: verify that each model's training graph
 /// compiles, runs forward+backward, and loss decreases over SGD steps.
-use meganeura::{Graph, build_inference_session, build_session};
+use meganeura::Graph;
 
 /// Helper: initialize all parameters with small deterministic values,
 /// run a few SGD steps, verify loss decreases.
@@ -88,7 +88,7 @@ fn smollm2_training_loss_decreases() {
         seq_len, vocab
     );
     let g = smollm2::build_training_graph(&config, seq_len);
-    let session = build_session(&g);
+    let session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     // Deterministic input: token_ids and one-hot labels
     let token_ids: Vec<u32> = (0..seq_len as u32).map(|i| i % vocab as u32).collect();
@@ -129,11 +129,12 @@ fn smollm2_weight_sharing_inference_to_training() {
     let mut infer_g = Graph::new();
     let logits = smollm2::build_graph(&mut infer_g, &config, seq_len);
     infer_g.set_outputs(vec![logits]);
-    let mut infer_session = build_inference_session(&infer_g);
+    let mut infer_session =
+        meganeura::build(&infer_g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Build training session (forward + backward + loss)
     let train_g = smollm2::build_training_graph(&config, seq_len);
-    let mut train_session = build_session(&train_g);
+    let mut train_session = meganeura::build(&train_g, meganeura::SessionConfig::from_env()).0;
 
     // Initialize inference session with deterministic weights
     for (name, buf_ref) in infer_session.plan().param_buffers.clone() {
@@ -206,11 +207,12 @@ fn smolvla_weight_sharing_inference_to_training() {
     let mut infer_g = Graph::new();
     let pred = smolvla::build_action_expert(&mut infer_g, &config, action_seq_len, vlm_seq_len);
     infer_g.set_outputs(vec![pred]);
-    let mut infer_session = build_inference_session(&infer_g);
+    let mut infer_session =
+        meganeura::build(&infer_g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Build training session
     let train_g = smolvla::build_action_expert_training(&config, action_seq_len, vlm_seq_len);
-    let mut train_session = build_session(&train_g);
+    let mut train_session = meganeura::build(&train_g, meganeura::SessionConfig::from_env()).0;
 
     // Init inference params
     for (name, buf_ref) in infer_session.plan().param_buffers.clone() {
@@ -280,7 +282,7 @@ fn smolvla_training_loss_decreases() {
         action_seq_len, vlm_seq_len
     );
     let g = smolvla::build_action_expert_training(&config, action_seq_len, vlm_seq_len);
-    let session = build_session(&g);
+    let session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     let expert_hidden = config.expert.hidden_size;
     let kv_dim = config.expert.kv_dim();
@@ -334,7 +336,7 @@ fn sd_unet_training_loss_decreases() {
     let mut g = Graph::new();
     let loss = sd_unet::build_training_graph(&mut g, &config);
     g.set_outputs(vec![loss]);
-    let session = build_session(&g);
+    let session = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     let noisy_latent: Vec<f32> = (0..in_size).map(|i| (i as f32 * 0.01).sin()).collect();
     let noise_target: Vec<f32> = (0..in_size).map(|i| (i as f32 * 0.007).cos()).collect();
@@ -372,7 +374,7 @@ fn smollm2_kv_cache_decode_graph() {
     let (logits, k_caches, v_caches) = smollm2::build_decode_graph(&mut g, &config, max_seq);
     g.set_outputs(vec![logits]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Initialize model weights
     for (name, buf_ref) in session.plan().param_buffers.clone() {
@@ -432,7 +434,7 @@ fn resnet50_training_loss_decreases() {
     let image_size = (batch * 3 * 224 * 224) as usize;
     let num_classes = 1000;
 
-    let mut sess = build_session(&g);
+    let mut sess = meganeura::build(&g, meganeura::SessionConfig::from_env()).0;
 
     // Use very small init for ResNet (no BN at training time → needs small weights)
     for (name, buf_ref) in sess.plan().param_buffers.clone() {
@@ -493,7 +495,7 @@ fn whisper_encoder_training_loss_decreases() {
     let g = whisper::build_training_graph(&config, batch, mel_len);
 
     verify_training_decreases_loss(
-        build_session(&g),
+        meganeura::build(&g, meganeura::SessionConfig::from_env()).0,
         |s| {
             let mel_size = (batch * config.n_mels as u32 * mel_len) as usize;
             let mel: Vec<f32> = (0..mel_size).map(|i| (i as f32 * 0.01).sin()).collect();

--- a/tests/tune.rs
+++ b/tests/tune.rs
@@ -21,7 +21,7 @@ fn tune_preserves_correctness() {
         &g,
         SessionConfig {
             mode: Mode::Inference,
-            ..SessionConfig::default()
+            ..SessionConfig::from_env()
         },
     );
 

--- a/tests/vision_ops_smoke.rs
+++ b/tests/vision_ops_smoke.rs
@@ -1,6 +1,6 @@
 /// Smoke tests for vision/VLA ops on GPU (lavapipe).
 /// Tests LayerNorm, GELU, and FullAttention individually.
-use meganeura::{Graph, build_inference_session};
+use meganeura::Graph;
 
 #[test]
 fn layer_norm_basic() {
@@ -11,7 +11,7 @@ fn layer_norm_basic() {
     let y = g.layer_norm(x, w, b, 1e-5);
     g.set_outputs(vec![y]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     session.set_parameter("w", &[1.0, 1.0, 1.0, 1.0f32]);
     session.set_parameter("b", &[0.0, 0.0, 0.0, 0.0f32]);
     session.set_input("x", &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0f32]);
@@ -45,7 +45,7 @@ fn gelu_basic() {
     let y = g.gelu(x);
     g.set_outputs(vec![y]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     session.set_input("x", &[-2.0, -1.0, 0.0, 1.0f32]);
 
     session.step();
@@ -76,7 +76,7 @@ fn full_attention_basic() {
     let attn = g.full_attention(q, k, v, 2, 2, 4);
     g.set_outputs(vec![attn]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Simple identity-like attention: q=k so attention is uniform
     let qk_data: Vec<f32> = (0..32).map(|i| (i as f32) * 0.1).collect();
@@ -161,7 +161,7 @@ fn full_attention_matches_cpu_reference() {
         }
     }
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
     session.set_input("q", &q);
     session.set_input("k", &k);
     session.set_input("v", &v);
@@ -215,7 +215,7 @@ fn vision_encoder_one_layer() {
     let out = g.add(x, attn_out);
     g.set_outputs(vec![out]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Initialize with small random-ish values
     let ones: Vec<f32> = vec![1.0; hidden];

--- a/tests/whisper_correctness.rs
+++ b/tests/whisper_correctness.rs
@@ -5,7 +5,7 @@
 /// existing gpu_smoke tests.
 ///
 /// Run `python3 scripts/gen_reference.py` first to generate the reference.
-use meganeura::{Graph, build_inference_session};
+use meganeura::Graph;
 
 fn parse_f32_array(json: &str, key: &str) -> Vec<f32> {
     let needle = format!("\"{key}\": [");
@@ -107,7 +107,7 @@ fn whisper_conv_stem_ffn_matches_pytorch() {
     let x = g.layer_norm(x, fln_w, fln_b, 1e-5);
     g.set_outputs(vec![x]);
 
-    let mut session = build_inference_session(&g);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
 
     // Load weights
     session.set_parameter("conv1.weight", &parse_f32_array(&json, "conv1.weight"));


### PR DESCRIPTION
Three commits, building on each other:

**1. Roadmap: Track F rewritten as the representation-menu design.** Kernel-variant selection as a three-stage filter — legality from registered device capabilities, validity from declarative precision constraints (never empirical: the fast-but-wrong coop-threshold experiment is the canonical counterexample), speed by measured `step()` wall-clock per (archetype, shape-class). Thresholds demote to search priors; the in-memory-only tuning stance is revised (the semantic plan cache already solves invalidation); representation choice stays out of the e-graph by design.

**2. `meganeura::config`: one registry for every `MEGANEURA_*` variable.** Type, class, and docs declared once; uniform boolean semantics (unset = default, `0` = off, else on — normalizing two historical quirks); active overrides logged; unrecognized `MEGANEURA_*` names warn instead of failing silently; README env table pinned to the registry by a test.

**3. The core is now environment-free.** `compile`/`runtime`/`codegen`/`optimize` accept strongly typed options only: `CoopPolicy` (Auto/Disabled/AllowF16) and the diagnostic switches live on `SessionOptions`, flash coop toggles on `CompileOptions`, `SessionConfig` gains `optimize` + `runtime`, `GpuOptions` + `init_gpu_context_with` cover adapter selection/timestamps, `TuningKnobs::default()` is pure platform defaults. Env mapping is an explicit opt-in via the `from_env` constructors in `meganeura::config` (`SessionConfig::from_env()` resolves everything; fields assigned afterwards win). The repo's examples, benches, and tests opt in, so `MEGANEURA_DEVICE_ID=… cargo run --example mnist`, the audit checklist's diagnostic reruns, and in-test `set_var` scenarios behave exactly as before — while embedders that never call `from_env` get a fully hermetic library.

Verified: 392 tests green on Radeon 780M (incl. the env-sensitive coop/aliasing suites through the opt-in path), clippy `--all-targets` and strict rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPCoJBa6YPHV8VPZVX76xT
