### PR TITLE
Accelerate image inference and expose GPU outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+- External GPU composition: `Session::output_buffer` exposes a pinned graph
+  output as a Blade `BufferPiece`, so a renderer sharing the context can feed
+  a prediction directly into its next compute pass without a host readback.
+- GroupNorm inference splits large image groups into parallel statistics and
+  apply passes. Statistics use the generated reduction path and application is
+  an entry point in the existing GroupNorm module, rather than two new shader
+  groups. Small tensors retain the original single-pass kernel, avoiding an
+  extra tensor traversal and barrier when the split would contain one chunk.
+
 - The library core is now environment-free: `compile`, `runtime`,
   `codegen`, and `optimize` accept strongly typed options and never read
   `MEGANEURA_*` variables. New typed surface: `CoopPolicy`

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ win, so explicit code always has the last word.
 | `MEGANEURA_NO_ALIAS` | Disable buffer lifetime aliasing (every value gets its own allocation). |
 | `MEGANEURA_NO_DEVICE_LOCAL` | Keep all buffers host-visible. |
 | `MEGANEURA_SERIAL_DISPATCH` | One compute pass per dispatch — serial execution for bisection. |
+| `MEGANEURA_NO_WINOGRAD` | Skip the Conv2d-to-Winograd rewrite; its selection heuristic weighs channel counts only, so this measures which side of it a workload belongs on. |
 | `MEGANEURA_PIN_BUFS=3,25-40` | Force-pin logical buffers to bisect aliasing corruption. |
 | `MEGANEURA_DUMP_PLAN` | Dump dispatch order, provenance, and the alias map at build. |
 | `MEGANEURA_DUMP_WGSL=<dir>` | Write every generated shader into `<dir>`. |

--- a/bench/optimizer_ablation.rs
+++ b/bench/optimizer_ablation.rs
@@ -168,10 +168,14 @@ fn main() {
     assert!(cutoff > 0, "--cutoff must be positive");
     assert!(repeats > 0, "--repeats must be positive");
 
+    // The flags this bench parses win; anything it does not parse — the
+    // Winograd switch, for one — still comes from the environment, which is
+    // the precedence `from_env` documents.
     let config = OptimizeConfig {
         mode,
         extraction_cost,
         saturation_cutoff: cutoff,
+        ..OptimizeConfig::from_env()
     };
     let source = build_model_graph(&model, phase);
     let source_nodes = source.nodes().len();

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -5329,6 +5329,9 @@ mod tests {
                 ShaderEntry::GroupNorm | ShaderEntry::GroupNormSilu => {
                     vec!["src", "src_b", "bias", "dst", "params"]
                 }
+                ShaderEntry::GroupNormApply => {
+                    vec!["src", "src_b", "bias", "dst", "partials", "params"]
+                }
                 ShaderEntry::GroupNormGradInput => vec!["src_a", "src_b", "bias", "dst", "params"],
                 ShaderEntry::GroupNormGradWeightBias => {
                     vec!["src_a", "src_b", "bias", "dst", "params"]
@@ -5434,6 +5437,8 @@ mod tests {
             ShaderEntry::ScatterAdd,
             ShaderEntry::BceLoss,
             ShaderEntry::GroupNorm,
+            ShaderEntry::GroupNormSilu,
+            ShaderEntry::GroupNormApply,
             ShaderEntry::GroupNormGradInput,
             ShaderEntry::GroupNormGradWeightBias,
             ShaderEntry::Concat,
@@ -5464,24 +5469,37 @@ mod tests {
             let expected: HashSet<&str> = expected_globals(entry).into_iter().collect();
 
             let sm = generate_module(group);
+            let info = naga::valid::Validator::new(
+                naga::valid::ValidationFlags::all() ^ naga::valid::ValidationFlags::BINDINGS,
+                naga::valid::Capabilities::all(),
+            )
+            .validate(&sm.module)
+            .unwrap();
+            let ep_index = sm
+                .module
+                .entry_points
+                .iter()
+                .position(|ep| ep.name == entry.entry_point())
+                .unwrap();
+            let ep_info = info.get_entry_point(ep_index);
 
             let actual: HashSet<&str> = sm
                 .module
                 .global_variables
                 .iter()
-                .filter_map(|(_, gv)| {
-                    // Skip workgroup variables — blade doesn't bind those
-                    if gv.space == naga::AddressSpace::WorkGroup {
+                .filter_map(|(handle, gv)| {
+                    // Blade binds only resources used by this entry point.
+                    if gv.space == naga::AddressSpace::WorkGroup || ep_info[handle].is_empty() {
                         return None;
                     }
                     gv.name.as_deref()
                 })
                 .collect();
 
-            assert_eq!(
-                expected, actual,
-                "{entry:?} (group {group:?}): shader globals {actual:?} \
-                 don't match expected runtime bindings {expected:?}"
+            assert!(
+                actual.is_subset(&expected),
+                "{entry:?} (group {group:?}): shader globals {actual:?} include resources \
+                 absent from the runtime bindings {expected:?}"
             );
         }
     }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -202,6 +202,7 @@ pub enum ShaderEntry {
     RmsNormRsqrt,
     GroupNorm,
     GroupNormSilu,
+    GroupNormApply,
     GroupNormGradInput,
     GroupNormGradWeightBias,
     Concat,
@@ -318,6 +319,7 @@ impl ShaderEntry {
             | ShaderEntry::RmsNormRsqrt
             | ShaderEntry::GroupNorm
             | ShaderEntry::GroupNormSilu
+            | ShaderEntry::GroupNormApply
             | ShaderEntry::GroupNormGradInput
             | ShaderEntry::GroupNormGradWeightBias
             | ShaderEntry::GlobalAvgPool
@@ -428,6 +430,7 @@ impl ShaderEntry {
             ShaderEntry::RmsNormRsqrt => ShaderGroup::RmsNormRsqrt,
             ShaderEntry::GroupNorm => ShaderGroup::GroupNorm,
             ShaderEntry::GroupNormSilu => ShaderGroup::GroupNormSilu,
+            ShaderEntry::GroupNormApply => ShaderGroup::GroupNorm,
             ShaderEntry::GroupNormGradInput => ShaderGroup::GroupNormGrad,
             ShaderEntry::GroupNormGradWeightBias => ShaderGroup::GroupNormGrad,
             ShaderEntry::Concat => ShaderGroup::Concat,
@@ -525,6 +528,7 @@ impl ShaderEntry {
             ShaderEntry::LayerNormGradX => "layer_norm_grad_x",
             ShaderEntry::RmsNormRsqrt => "main",
             ShaderEntry::GroupNorm | ShaderEntry::GroupNormSilu => "main",
+            ShaderEntry::GroupNormApply => "apply",
             ShaderEntry::GroupNormGradInput => "grad_input",
             ShaderEntry::GroupNormGradWeightBias => "grad_weight_bias",
             ShaderEntry::Concat => "main",
@@ -630,6 +634,51 @@ pub enum PrologueLoadKind {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MatMulPrologue {
     pub factors: Vec<(BufferRef, PrologueLoadKind)>,
+}
+/// Slices to split each GroupNorm group into, so the normalisation's
+/// parallelism follows the image instead of the batch.
+///
+/// The single-pass kernel launches `batch * num_groups` workgroups, which at
+/// inference is a handful however large the image is. Enough slices to fill
+/// the device, but not so many that a workgroup has less than a few thousand
+/// elements to chew on, nor that combining the partials costs more than
+/// splitting saved.
+pub fn group_norm_chunks(batch: u32, channels: u32, spatial: u32, num_groups: u32) -> u32 {
+    const TARGET_WORKGROUPS: u32 = 1024;
+    const MIN_PER_WORKGROUP: u32 = 2048;
+    let group_size = (channels / num_groups.max(1)) * spatial;
+    let by_occupancy = TARGET_WORKGROUPS.div_ceil((batch * num_groups).max(1));
+    let by_work = (group_size / MIN_PER_WORKGROUP).max(1);
+    let mut chunks = by_occupancy.min(by_work).clamp(1, 256);
+    // The generated reduction archetype treats every row as the same length.
+    // Pick the closest exact divisor so each chunk is one contiguous row and
+    // no bespoke ragged-tail statistics kernel is needed.
+    while !group_size.is_multiple_of(chunks) {
+        chunks -= 1;
+    }
+    chunks
+}
+
+fn group_norm_stats_kernel() -> crate::schedule::ReductionKernel {
+    use crate::schedule::{PointwiseDAG, Pw, ReduceOp, ReductionKernel};
+    ReductionKernel {
+        op: ReduceOp::Sum,
+        prologue: PointwiseDAG {
+            n_inputs: 1,
+            ops: vec![Pw::LoadInput(0)],
+            output: 0,
+        },
+        extra_prologues: vec![PointwiseDAG {
+            n_inputs: 1,
+            ops: vec![Pw::LoadInput(0), Pw::Mul(0, 0)],
+            output: 1,
+        }],
+        epilogue: None,
+        n_per_elem: 1,
+        n_per_row: 0,
+        workgroup_size: 256,
+        gather_elem: Vec::new(),
+    }
 }
 
 /// A single GPU dispatch in the execution plan.
@@ -2759,17 +2808,65 @@ impl<'a> Compiler<'a> {
                 let bias = self.get_buffer(node.inputs[2]);
                 let total = node.ty.shape[0] as u32;
                 let batch = total / (channels * spatial);
-                self.plan.dispatches.push(Dispatch {
-                    shader: ShaderEntry::GroupNorm,
-                    workgroups: [batch * num_groups, 1, 1],
-                    input_buffers: vec![x, weight, bias],
-                    output_buffer: out_buf,
-                    extra_outputs: vec![],
-                    params: vec![batch, channels, spatial, num_groups, eps.to_bits(), 0, 0, 0],
-                    use_coop: false,
-                    use_small_tiles: false,
-                    ..Default::default()
-                });
+                // Two passes so the parallelism scales with the image: one
+                // workgroup per slice of a group, rather than one per group.
+                let chunks = group_norm_chunks(batch, channels, spatial, num_groups);
+                if chunks == 1 {
+                    // On small tensors the original kernel is already busy
+                    // enough. Keep its single dispatch instead of paying for
+                    // an intermediate buffer, another full tensor pass, and a
+                    // global barrier merely to split the group once.
+                    self.plan.dispatches.push(Dispatch {
+                        shader: ShaderEntry::GroupNorm,
+                        workgroups: [batch * num_groups, 1, 1],
+                        input_buffers: vec![x, weight, bias],
+                        output_buffer: out_buf,
+                        extra_outputs: vec![],
+                        params: vec![batch, channels, spatial, num_groups, eps.to_bits(), 0, 0, 0],
+                        use_coop: false,
+                        use_small_tiles: false,
+                        ..Default::default()
+                    });
+                } else {
+                    let group_size = (channels / num_groups) * spatial;
+                    let slices = batch * num_groups * chunks;
+                    let partials = self.alloc_buffer(slices as usize * 2 * 4);
+                    let params = vec![
+                        batch,
+                        channels,
+                        spatial,
+                        num_groups,
+                        eps.to_bits(),
+                        chunks,
+                        0,
+                        0,
+                    ];
+                    self.plan.dispatches.push(Dispatch {
+                        // Generated-reduction routing takes priority over the
+                        // sentinel entry in pipeline selection and binding.
+                        shader: ShaderEntry::GroupNorm,
+                        workgroups: [slices, 1, 1],
+                        input_buffers: vec![x],
+                        output_buffer: partials,
+                        extra_outputs: vec![],
+                        params: vec![slices, group_size / chunks, 0, 0],
+                        use_coop: false,
+                        use_small_tiles: false,
+                        reduction: Some(group_norm_stats_kernel()),
+                        ..Default::default()
+                    });
+                    self.plan.dispatches.push(Dispatch {
+                        shader: ShaderEntry::GroupNormApply,
+                        workgroups: [slices, 1, 1],
+                        input_buffers: vec![x, partials, weight, bias],
+                        output_buffer: out_buf,
+                        extra_outputs: vec![],
+                        params,
+                        use_coop: false,
+                        use_small_tiles: false,
+                        ..Default::default()
+                    });
+                }
             }
 
             Op::GroupNormSilu {
@@ -2783,17 +2880,59 @@ impl<'a> Compiler<'a> {
                 let bias = self.get_buffer(node.inputs[2]);
                 let total = node.ty.shape[0] as u32;
                 let batch = total / (channels * spatial);
-                self.plan.dispatches.push(Dispatch {
-                    shader: ShaderEntry::GroupNormSilu,
-                    workgroups: [batch * num_groups, 1, 1],
-                    input_buffers: vec![x, weight, bias],
-                    output_buffer: out_buf,
-                    extra_outputs: vec![],
-                    params: vec![batch, channels, spatial, num_groups, eps.to_bits(), 0, 0, 0],
-                    use_coop: false,
-                    use_small_tiles: false,
-                    ..Default::default()
-                });
+                // Two passes so the parallelism scales with the image: one
+                // workgroup per slice of a group, rather than one per group.
+                let chunks = group_norm_chunks(batch, channels, spatial, num_groups);
+                if chunks == 1 {
+                    self.plan.dispatches.push(Dispatch {
+                        shader: ShaderEntry::GroupNormSilu,
+                        workgroups: [batch * num_groups, 1, 1],
+                        input_buffers: vec![x, weight, bias],
+                        output_buffer: out_buf,
+                        extra_outputs: vec![],
+                        params: vec![batch, channels, spatial, num_groups, eps.to_bits(), 0, 0, 0],
+                        use_coop: false,
+                        use_small_tiles: false,
+                        ..Default::default()
+                    });
+                } else {
+                    let group_size = (channels / num_groups) * spatial;
+                    let slices = batch * num_groups * chunks;
+                    let partials = self.alloc_buffer(slices as usize * 2 * 4);
+                    let params = vec![
+                        batch,
+                        channels,
+                        spatial,
+                        num_groups,
+                        eps.to_bits(),
+                        chunks,
+                        1,
+                        0,
+                    ];
+                    self.plan.dispatches.push(Dispatch {
+                        shader: ShaderEntry::GroupNorm,
+                        workgroups: [slices, 1, 1],
+                        input_buffers: vec![x],
+                        output_buffer: partials,
+                        extra_outputs: vec![],
+                        params: vec![slices, group_size / chunks, 0, 0],
+                        use_coop: false,
+                        use_small_tiles: false,
+                        reduction: Some(group_norm_stats_kernel()),
+                        ..Default::default()
+                    });
+                    self.plan.dispatches.push(Dispatch {
+                        shader: ShaderEntry::GroupNormApply,
+                        workgroups: [slices, 1, 1],
+                        input_buffers: vec![x, partials, weight, bias],
+                        output_buffer: out_buf,
+                        extra_outputs: vec![],
+                        params,
+                        use_coop: false,
+                        use_small_tiles: false,
+                        ..Default::default()
+                    });
+                }
             }
 
             Op::GroupNormGradInput {
@@ -4809,5 +4948,34 @@ mod tests {
                 .filter(|dispatch| dispatch.reduction.is_some())
                 .all(|dispatch| dispatch.profile_family() == "normalization_reduction")
         );
+    }
+
+    #[test]
+    fn group_norm_only_splits_when_there_is_parallel_work_to_gain() {
+        let make_plan = |spatial: u32| {
+            let mut graph = Graph::new();
+            let channels = 8;
+            let groups = 8;
+            let input = graph.input("input", &[(channels * spatial) as usize]);
+            let weight = graph.parameter("weight", &[channels as usize]);
+            let bias = graph.parameter("bias", &[channels as usize]);
+            let output =
+                graph.group_norm(input, weight, bias, 1, channels, spatial, groups, 1.0e-5);
+            graph.set_outputs(vec![output]);
+            compile(&graph)
+        };
+
+        let small = make_plan(256);
+        assert_eq!(small.dispatches.len(), 1);
+        assert_eq!(small.dispatches[0].shader, ShaderEntry::GroupNorm);
+
+        let large = make_plan(8202);
+        assert_eq!(large.dispatches.len(), 2);
+        assert!(large.dispatches[0].reduction.is_some());
+        assert_eq!(large.dispatches[1].shader, ShaderEntry::GroupNormApply);
+        let chunks = large.dispatches[1].params[5];
+        assert_eq!(chunks, 3);
+        assert_eq!(8202 % chunks, 0);
+        assert_eq!(large.dispatches[0].params[..2], [8 * chunks, 8202 / chunks]);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,6 +147,8 @@ registry! {
         "Keep all buffers host-visible instead of device-local.";
     SERIAL_DISPATCH: "MEGANEURA_SERIAL_DISPATCH", Bool, Diagnostic,
         "One compute pass per dispatch — guarantees serial execution for bisection.";
+    NO_WINOGRAD: "MEGANEURA_NO_WINOGRAD", Bool, Diagnostic,
+        "Skip the Conv2d-to-Winograd rewrite; the selection heuristic weighs channel counts only, so this measures which side of it a workload belongs on.";
     PIN_BUFS: "MEGANEURA_PIN_BUFS", Text, Diagnostic,
         "Force-pin logical buffers by id/range (e.g. \"3,17,25-40\") to bisect aliasing bugs.";
     DUMP_PLAN: "MEGANEURA_DUMP_PLAN", Bool, Diagnostic,
@@ -191,9 +193,13 @@ impl OptimizeConfig {
     /// - `MEGANEURA_OPTIMIZER=off|greedy|egglog-windowed|egglog-outlined|egglog-whole`
     /// - `MEGANEURA_EGRAPH_COST=ast-size|tensor-traffic`
     /// - `MEGANEURA_EGRAPH_CUTOFF=<positive integer>`
+    /// - `MEGANEURA_NO_WINOGRAD`
     pub fn from_env() -> Self {
         log_overrides();
-        let mut config = Self::default();
+        let mut config = Self {
+            no_winograd: NO_WINOGRAD.bool_or(false),
+            ..Self::default()
+        };
         if let Some(value) = OPTIMIZER.text() {
             config.mode = match value.as_str() {
                 "off" => OptimizeMode::Off,
@@ -450,6 +456,19 @@ mod tests {
             "README.md does not mention: {missing:?} — document them \
              in the environment-variable table"
         );
+    }
+
+    #[test]
+    fn no_winograd_reaches_the_typed_option() {
+        // Not set: the rewrite stays on.
+        unsafe { std::env::remove_var("MEGANEURA_NO_WINOGRAD") };
+        assert!(!crate::optimize::OptimizeConfig::from_env().no_winograd);
+        // Set: it turns off, and "0" means off in the uniform semantics.
+        unsafe { std::env::set_var("MEGANEURA_NO_WINOGRAD", "1") };
+        assert!(crate::optimize::OptimizeConfig::from_env().no_winograd);
+        unsafe { std::env::set_var("MEGANEURA_NO_WINOGRAD", "0") };
+        assert!(!crate::optimize::OptimizeConfig::from_env().no_winograd);
+        unsafe { std::env::remove_var("MEGANEURA_NO_WINOGRAD") };
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -86,6 +86,12 @@ pub struct OptimizeConfig {
     pub extraction_cost: ExtractionCost,
     /// Maximum nodes in an outlined region or residual window.
     pub saturation_cutoff: usize,
+    /// Skip the Conv2d-to-Winograd rewrite.
+    ///
+    /// The selection heuristic weighs channel counts only, so a workload
+    /// with few channels over a large image sits near its boundary; this
+    /// makes which side it should be on measurable without a rebuild.
+    pub no_winograd: bool,
 }
 
 impl Default for OptimizeConfig {
@@ -94,6 +100,7 @@ impl Default for OptimizeConfig {
             mode: OptimizeMode::Greedy,
             extraction_cost: ExtractionCost::TensorTraffic,
             saturation_cutoff: SATURATION_CUTOFF,
+            no_winograd: false,
         }
     }
 }
@@ -1602,7 +1609,15 @@ pub fn apply_group_norm_silu_fusions(graph: &mut Graph, fusions: &mut Vec<(Strin
 ///
 /// For each matching Conv2d node, creates a derived parameter for the Winograd-transformed
 /// weights and rewrites the node to WinogradConv2d.
-pub fn apply_winograd_conv_fusions(graph: &mut Graph, fusions: &mut Vec<(String, u32)>) {
+pub fn apply_winograd_conv_fusions(
+    graph: &mut Graph,
+    fusions: &mut Vec<(String, u32)>,
+    config: &OptimizeConfig,
+) {
+    if config.no_winograd {
+        log::info!("Winograd convolution disabled by OptimizeConfig::no_winograd");
+        return;
+    }
     let node_ids: Vec<usize> = (0..graph.nodes().len()).collect();
     for &id in &node_ids {
         let node = &graph.nodes()[id];
@@ -2039,6 +2054,7 @@ mod tests {
                         mode,
                         extraction_cost,
                         saturation_cutoff: 3,
+                        ..OptimizeConfig::default()
                     },
                 );
                 assert!(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -420,6 +420,17 @@ struct GroupNormData {
     params: GroupNormParams,
 }
 
+/// Normalisation pass: reads the tensor and the partials, writes the result.
+#[derive(blade_macros::ShaderData)]
+struct GroupNormApplyData {
+    src: blade_graphics::BufferPiece,
+    src_b: blade_graphics::BufferPiece,
+    bias: blade_graphics::BufferPiece,
+    dst: blade_graphics::BufferPiece,
+    partials: blade_graphics::BufferPiece,
+    params: GroupNormParams,
+}
+
 #[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
 #[repr(C)]
 struct GroupNormParams {
@@ -428,8 +439,10 @@ struct GroupNormParams {
     spatial: u32,
     num_groups: u32,
     eps_bits: u32,
-    _pad0: u32,
-    _pad1: u32,
+    /// Slices each group is split into, so the parallelism follows the image
+    /// rather than the batch. One for the legacy single-pass kernels.
+    chunks: u32,
+    apply_silu: u32,
     _pad2: u32,
 }
 
@@ -1683,6 +1696,7 @@ pub fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayo
         ShaderEntry::LayerNormGradWB | ShaderEntry::LayerNormGradX => FourBufData::layout(),
         ShaderEntry::RmsNormRsqrt => UnaryData::layout(),
         ShaderEntry::GroupNorm | ShaderEntry::GroupNormSilu => GroupNormData::layout(),
+        ShaderEntry::GroupNormApply => GroupNormApplyData::layout(),
         ShaderEntry::GroupNormGradInput => GroupNormGradInputData::layout(),
         ShaderEntry::GroupNormGradWeightBias => GroupNormGradWeightBiasData::layout(),
         ShaderEntry::Concat => BinaryData::layout(),
@@ -3714,6 +3728,27 @@ impl Session {
         None
     }
 
+    /// Return the underlying blade `BufferPiece` for a graph output.
+    ///
+    /// Graph outputs are pinned by the memory planner, so the returned handle
+    /// remains stable for the lifetime of the session. This lets a sibling
+    /// compute pipeline on the same [`blade_graphics::Context`] consume a
+    /// prediction directly, without a device-to-host readback followed by an
+    /// upload.
+    ///
+    /// # Ordering
+    ///
+    /// Call [`Session::step`] before recording or submitting the consumer.
+    /// Submissions to the shared context's queue are ordered, so the consumer
+    /// can be submitted after `step()` without a host-side [`Session::wait`].
+    /// The handle must not be used after the session is destroyed.
+    pub fn output_buffer(&self, index: usize) -> Option<blade_graphics::BufferPiece> {
+        let &buf_ref = self.plan.output_buffers.get(index)?;
+        Some(blade_graphics::BufferPiece::from(
+            self.buffers[buf_ref.0 as usize],
+        ))
+    }
+
     /// Upload u32 input data (e.g. token IDs for embedding lookup).
     pub fn set_input_u32(&mut self, name: &str, data: &[u32]) {
         self.wait();
@@ -5444,8 +5479,31 @@ impl Session {
                             spatial: p[2],
                             num_groups: p[3],
                             eps_bits: p[4],
-                            _pad0: 0,
-                            _pad1: 0,
+                            chunks: 1,
+                            apply_silu: 0,
+                            _pad2: 0,
+                        },
+                    },
+                );
+            }
+            ShaderEntry::GroupNormApply => {
+                let p = &dispatch.params;
+                pc.bind(
+                    0,
+                    &GroupNormApplyData {
+                        src: buf(dispatch.input_buffers[0]),
+                        src_b: buf(dispatch.input_buffers[2]),
+                        bias: buf(dispatch.input_buffers[3]),
+                        dst: buf(dispatch.output_buffer),
+                        partials: buf(dispatch.input_buffers[1]),
+                        params: GroupNormParams {
+                            batch: p[0],
+                            channels: p[1],
+                            spatial: p[2],
+                            num_groups: p[3],
+                            eps_bits: p[4],
+                            chunks: p[5],
+                            apply_silu: p[6],
                             _pad2: 0,
                         },
                     },
@@ -5466,8 +5524,8 @@ impl Session {
                             spatial: p[2],
                             num_groups: p[3],
                             eps_bits: p[4],
-                            _pad0: 0,
-                            _pad1: 0,
+                            chunks: 1,
+                            apply_silu: 0,
                             _pad2: 0,
                         },
                     },
@@ -5488,8 +5546,8 @@ impl Session {
                             spatial: p[2],
                             num_groups: p[3],
                             eps_bits: p[4],
-                            _pad0: 0,
-                            _pad1: 0,
+                            chunks: 1,
+                            apply_silu: 0,
                             _pad2: 0,
                         },
                     },

--- a/src/shaders/group_norm.wgsl
+++ b/src/shaders/group_norm.wgsl
@@ -10,8 +10,8 @@ struct Params {
     spatial: u32,       // H * W
     num_groups: u32,
     eps_bits: u32,
-    _pad0: u32,
-    _pad1: u32,
+    chunks: u32,
+    apply_silu: u32,
     _pad2: u32,
 }
 
@@ -19,8 +19,10 @@ var<storage> src: array<f32>;
 var<storage> src_b: array<f32>;     // weight[C]
 var<storage> bias: array<f32>;      // bias[C]
 var<storage, read_write> dst: array<f32>;
+var<storage> partials: array<f32>;  // (sum, sumsq) per slice
 var<uniform> params: Params;
 var<workgroup> wg_data: array<f32, 256>;
+var<workgroup> wg_data_sq: array<f32, 256>;
 
 @compute @workgroup_size(256)
 fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
@@ -102,6 +104,75 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
         let idx = ((n * params.channels + c) * params.spatial) + hw;
         let normalized = (src[idx] - mean) * inv_std;
         dst[idx] = normalized * src_b[c] + bias[c];
+        j += 256u;
+    }
+}
+
+// Parallel-image GroupNorm, second of two passes. The generated reduction
+// writes a (sum, sumsq) pair for every slice; each workgroup combines its
+// group's pairs and normalises the slice it owns.
+// Dispatch: [N * num_groups * chunks, 1, 1]
+@compute @workgroup_size(256)
+fn apply(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
+    let chunks = params.chunks;
+    let total_slices = params.batch * params.num_groups * chunks;
+    if wgid.x >= total_slices { return; }
+
+    let chunk = wgid.x % chunks;
+    let ng = wgid.x / chunks;
+    let n = ng / params.num_groups;
+    let group = ng % params.num_groups;
+    let tid = lid.x;
+    let eps = bitcast<f32>(params.eps_bits);
+
+    let channels_per_group = params.channels / params.num_groups;
+    let group_size = channels_per_group * params.spatial;
+    let c_start = group * channels_per_group;
+
+    var sum_val = 0.0;
+    var sumsq_val = 0.0;
+    var p = tid;
+    loop {
+        if p >= chunks { break; }
+        sum_val += partials[(ng * chunks + p) * 2u];
+        sumsq_val += partials[(ng * chunks + p) * 2u + 1u];
+        p += 256u;
+    }
+    wg_data[tid] = sum_val;
+    wg_data_sq[tid] = sumsq_val;
+    workgroupBarrier();
+
+    var stride = 128u;
+    loop {
+        if stride == 0u { break; }
+        if tid < stride {
+            wg_data[tid] += wg_data[tid + stride];
+            wg_data_sq[tid] += wg_data_sq[tid + stride];
+        }
+        workgroupBarrier();
+        stride >>= 1u;
+    }
+
+    let count = f32(group_size);
+    let mean = wg_data[0] / count;
+    let variance = max(wg_data_sq[0] / count - mean * mean, 0.0);
+    let inv_std = inverseSqrt(variance + eps);
+
+    let chunk_size = group_size / chunks;
+    let begin = chunk * chunk_size;
+    let end = begin + chunk_size;
+    var j = begin + tid;
+    loop {
+        if j >= end { break; }
+        let c_local = j / params.spatial;
+        let hw = j % params.spatial;
+        let c = c_start + c_local;
+        let idx = ((n * params.channels + c) * params.spatial) + hw;
+        var v = (src[idx] - mean) * inv_std * src_b[c] + bias[c];
+        if params.apply_silu != 0u {
+            v = v / (1.0 + exp(-v));
+        }
+        dst[idx] = v;
         j += 256u;
     }
 }

--- a/src/shaders/winograd_input_transform.wgsl
+++ b/src/shaders/winograd_input_transform.wgsl
@@ -24,8 +24,15 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let total = params.total_tiles * params.in_channels;
     if idx >= total { return; }
 
-    let tile_idx = idx / params.in_channels;
-    let ci = idx % params.in_channels;
+    // Channel-major, so that neighbouring threads walk neighbouring tiles.
+    //
+    // The other way round — tile_idx = idx / in_channels — puts consecutive
+    // threads on consecutive channels, which are H*W apart in the input and
+    // total_tiles apart in V. At any real resolution that is a megabyte of
+    // stride per lane, so every wave scatters across memory on both the load
+    // and the store. This way the store is contiguous and the load walks a row.
+    let ci = idx / params.total_tiles;
+    let tile_idx = idx % params.total_tiles;
 
     // Decompose tile_idx → (n, tile_r, tile_c)
     let tiles_per_batch = params.tiles_h * params.tiles_w;

--- a/src/shaders/winograd_output_transform.wgsl
+++ b/src/shaders/winograd_output_transform.wgsl
@@ -23,8 +23,11 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let total = params.total_tiles * params.out_channels;
     if idx >= total { return; }
 
-    let tile_idx = idx / params.out_channels;
-    let co = idx % params.out_channels;
+    // Channel-major, for the same reason as the input transform: this way
+    // neighbouring threads read neighbouring entries of M and write
+    // neighbouring output pixels, instead of striding a megabyte per lane.
+    let co = idx / params.total_tiles;
+    let tile_idx = idx % params.total_tiles;
 
     // Decompose tile_idx → (n, tile_r, tile_c)
     let tiles_per_batch = params.tiles_h * params.tiles_w;

--- a/src/train.rs
+++ b/src/train.rs
@@ -360,7 +360,7 @@ pub fn build(forward_graph: &Graph, cfg: SessionConfig<'_>) -> (Session, Optimiz
             let mut g = optimized_forward;
             let mut fusions = Vec::new();
             optimize::apply_group_norm_silu_fusions(&mut g, &mut fusions);
-            optimize::apply_winograd_conv_fusions(&mut g, &mut fusions);
+            optimize::apply_winograd_conv_fusions(&mut g, &mut fusions, &cfg.optimize);
             for (name, count) in fusions.iter().fold(
                 std::collections::BTreeMap::<&str, usize>::new(),
                 |mut acc, entry| {


### PR DESCRIPTION
Make Winograd transforms access tiles contiguously and route the diagnostic disable switch through the typed OptimizeConfig registry instead of reading the environment from optimizer internals.

Split large inference GroupNorm workloads across image slices. Generate the sum and sum-of-squares pass with the reduction scheduler, and extend the existing GroupNorm shader module with an apply entry point; retain the original single-pass kernels for small tensors.

Expose pinned session output buffers so clients sharing the Blade graphics context can consume predictions without a host round trip.