### PR TITLE
Align shader IR with merged Blade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ hub = ["dep:hf-hub"]
 profiler = ["dep:tracing-subscriber"]
 
 [dependencies]
-blade-graphics = { version = "0.8.4", git = "https://github.com/kvark/blade", rev = "a6ae6a73219762f63efb4e5be4550fbc0d301b2f" }
-blade-macros = { version = "0.3", git = "https://github.com/kvark/blade", rev = "a6ae6a73219762f63efb4e5be4550fbc0d301b2f" }
+blade-graphics = { version = "0.8.4", git = "https://github.com/kvark/blade", rev = "95f5004fb02785a792c883a5312ca5ac37872a75" }
+blade-macros = { version = "0.3", git = "https://github.com/kvark/blade", rev = "95f5004fb02785a792c883a5312ca5ac37872a75" }
 # `default-features = false` drops egglog's `bin` stack (clap, mimalloc,
 # env_logger, chrono, graphviz). Greedy mode never constructs an EGraph
 # but the crate is still linked for the optional equality-saturation


### PR DESCRIPTION
Align Meganeura's Blade and Naga revisions with the now-merged Blade split-radiance work. This is dependency-only: it adds no shader groups or operations.

Validated locally with Rust 1.92 formatting, Clippy (`-D warnings`), and the full test suite.