### PR TITLE
feat: Q4 projections for SmolLM2 decode and prefill

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1883,10 +1883,18 @@ pub fn fuse_rmsnorm_into_gemv(plan: &mut ExecutionPlan) {
         let Some(consumers) = readers.get(&normed) else {
             continue;
         };
+        // `generate_module_gemv_rmsnorm` derives from the f32 GEMV, and the
+        // fused pipeline is a `Variant::GemvRmsNorm`, which does not compose
+        // with `Variant::Weight`. Folding the norm into a GEMV whose weight
+        // is not f32 would therefore run the f32 kernel over packed blocks —
+        // and under a binding layout with an extra buffer, so the damage
+        // lands in neighbouring buffers rather than just the result.
         if consumers.is_empty()
             || consumers.iter().any(|&c| {
                 let d = &plan.dispatches[c];
-                d.shader != ShaderEntry::MatMulGemv || d.input_buffers.first() != Some(&normed)
+                d.shader != ShaderEntry::MatMulGemv
+                    || d.input_buffers.first() != Some(&normed)
+                    || d.weight_format != WeightFormat::F32
             })
         {
             continue;

--- a/src/models/smollm2.rs
+++ b/src/models/smollm2.rs
@@ -5,6 +5,41 @@
 
 use crate::graph::{Graph, NodeId};
 
+/// How the large projection weights are stored on the GPU.
+///
+/// This is a deployment choice, not a model hyperparameter, so it is a
+/// builder argument rather than a [`SmolLM2Config`] field — that struct
+/// mirrors the published `config.json`.
+///
+/// Only the seven per-layer projections (q/k/v/o, gate/up/down) and an
+/// untied `lm_head` are affected. The embedding table stays f32: it is
+/// read by `embedding`, which has no Q4 gather, and a tied `lm_head`
+/// shares it. Norm weights are one-dimensional and not worth packing.
+/// On SmolLM2-135M the projections are ~106M of the 135M parameters.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum ProjectionWeights {
+    /// Full precision.
+    #[default]
+    F32,
+    /// Asymmetric Q4 (~5 bits/element), dequantized in the matmul.
+    Q4,
+}
+
+/// A projection weight in the requested format.
+///
+/// Q4 blocks 32 elements along K, and `quantize_q4_0` drops a trailing
+/// partial block, so a K that is not a multiple of 32 would corrupt the
+/// weight rather than fail. Such a projection stays f32; every SmolLM2
+/// shape in this file satisfies the constraint, so this only guards
+/// hand-written configs.
+fn projection(g: &mut Graph, weights: ProjectionWeights, name: &str, shape: &[usize]) -> NodeId {
+    if weights == ProjectionWeights::Q4 && shape[0].is_multiple_of(32) {
+        g.parameter_q4(name, shape)
+    } else {
+        g.parameter(name, shape)
+    }
+}
+
 /// Hyperparameters for a SmolLM2 model instance.
 ///
 /// Values correspond to the `config.json` published alongside the
@@ -217,6 +252,19 @@ pub fn build_prefill_graph(
     config: &SmolLM2Config,
     seq_len: usize,
 ) -> (NodeId, Vec<NodeId>, Vec<NodeId>) {
+    build_prefill_graph_with(g, config, seq_len, ProjectionWeights::F32)
+}
+
+/// [`build_prefill_graph`] with the projection weight format chosen.
+///
+/// Prefill runs `seq_len` rows, so its matmuls take the tiled path,
+/// which has had a Q4 variant all along.
+pub fn build_prefill_graph_with(
+    g: &mut Graph,
+    config: &SmolLM2Config,
+    seq_len: usize,
+    weights: ProjectionWeights,
+) -> (NodeId, Vec<NodeId>, Vec<NodeId>) {
     let hidden = config.hidden_size;
     let kv_dim = config.kv_dim();
     let ffn = config.intermediate_size;
@@ -236,15 +284,21 @@ pub fn build_prefill_graph(
         let ln1_w = g.parameter(&format!("{}.input_layernorm.weight", prefix), &[hidden]);
         let h = g.rms_norm(x, ln1_w, eps);
 
-        let wq = g.parameter(
+        let wq = projection(
+            g,
+            weights,
             &format!("{}.self_attn.q_proj.weight", prefix),
             &[hidden, hidden],
         );
-        let wk = g.parameter(
+        let wk = projection(
+            g,
+            weights,
             &format!("{}.self_attn.k_proj.weight", prefix),
             &[hidden, kv_dim],
         );
-        let wv = g.parameter(
+        let wv = projection(
+            g,
+            weights,
             &format!("{}.self_attn.v_proj.weight", prefix),
             &[hidden, kv_dim],
         );
@@ -269,7 +323,9 @@ pub fn build_prefill_graph(
             config.head_dim(),
         );
 
-        let wo = g.parameter(
+        let wo = projection(
+            g,
+            weights,
             &format!("{}.self_attn.o_proj.weight", prefix),
             &[hidden, hidden],
         );
@@ -282,9 +338,24 @@ pub fn build_prefill_graph(
         );
         let h = g.rms_norm(x, ln2_w, eps);
 
-        let w_gate = g.parameter(&format!("{}.mlp.gate_proj.weight", prefix), &[hidden, ffn]);
-        let w_up = g.parameter(&format!("{}.mlp.up_proj.weight", prefix), &[hidden, ffn]);
-        let w_down = g.parameter(&format!("{}.mlp.down_proj.weight", prefix), &[ffn, hidden]);
+        let w_gate = projection(
+            g,
+            weights,
+            &format!("{}.mlp.gate_proj.weight", prefix),
+            &[hidden, ffn],
+        );
+        let w_up = projection(
+            g,
+            weights,
+            &format!("{}.mlp.up_proj.weight", prefix),
+            &[hidden, ffn],
+        );
+        let w_down = projection(
+            g,
+            weights,
+            &format!("{}.mlp.down_proj.weight", prefix),
+            &[ffn, hidden],
+        );
 
         let gate = g.matmul(h, w_gate);
         let up = g.matmul(h, w_up);
@@ -300,7 +371,7 @@ pub fn build_prefill_graph(
     let logits = if config.tie_word_embeddings {
         g.matmul_bt(x, embed_weight)
     } else {
-        let lm_head = g.parameter("lm_head.weight", &[hidden, config.vocab_size]);
+        let lm_head = projection(g, weights, "lm_head.weight", &[hidden, config.vocab_size]);
         g.matmul(x, lm_head)
     };
 
@@ -318,6 +389,20 @@ pub fn build_decode_graph(
     g: &mut Graph,
     config: &SmolLM2Config,
     max_seq_len: usize,
+) -> (NodeId, Vec<NodeId>, Vec<NodeId>) {
+    build_decode_graph_with(g, config, max_seq_len, ProjectionWeights::F32)
+}
+
+/// [`build_decode_graph`] with the projection weight format chosen.
+///
+/// Decode is a single row, which `compile.rs` sends to the K-split GEMV;
+/// that shader has a Q4 variant, so quantized projections stay on the
+/// fast path here.
+pub fn build_decode_graph_with(
+    g: &mut Graph,
+    config: &SmolLM2Config,
+    max_seq_len: usize,
+    weights: ProjectionWeights,
 ) -> (NodeId, Vec<NodeId>, Vec<NodeId>) {
     let hidden = config.hidden_size;
     let kv_dim = config.kv_dim();
@@ -342,15 +427,21 @@ pub fn build_decode_graph(
         let ln1_w = g.parameter(&format!("{}.input_layernorm.weight", prefix), &[hidden]);
         let h = g.rms_norm(x, ln1_w, eps);
 
-        let wq = g.parameter(
+        let wq = projection(
+            g,
+            weights,
             &format!("{}.self_attn.q_proj.weight", prefix),
             &[hidden, hidden],
         );
-        let wk = g.parameter(
+        let wk = projection(
+            g,
+            weights,
             &format!("{}.self_attn.k_proj.weight", prefix),
             &[hidden, kv_dim],
         );
-        let wv = g.parameter(
+        let wv = projection(
+            g,
+            weights,
             &format!("{}.self_attn.v_proj.weight", prefix),
             &[hidden, kv_dim],
         );
@@ -388,7 +479,9 @@ pub fn build_decode_graph(
             config.head_dim(),
         );
 
-        let wo = g.parameter(
+        let wo = projection(
+            g,
+            weights,
             &format!("{}.self_attn.o_proj.weight", prefix),
             &[hidden, hidden],
         );
@@ -401,9 +494,24 @@ pub fn build_decode_graph(
         );
         let h = g.rms_norm(x, ln2_w, eps);
 
-        let w_gate = g.parameter(&format!("{}.mlp.gate_proj.weight", prefix), &[hidden, ffn]);
-        let w_up = g.parameter(&format!("{}.mlp.up_proj.weight", prefix), &[hidden, ffn]);
-        let w_down = g.parameter(&format!("{}.mlp.down_proj.weight", prefix), &[ffn, hidden]);
+        let w_gate = projection(
+            g,
+            weights,
+            &format!("{}.mlp.gate_proj.weight", prefix),
+            &[hidden, ffn],
+        );
+        let w_up = projection(
+            g,
+            weights,
+            &format!("{}.mlp.up_proj.weight", prefix),
+            &[hidden, ffn],
+        );
+        let w_down = projection(
+            g,
+            weights,
+            &format!("{}.mlp.down_proj.weight", prefix),
+            &[ffn, hidden],
+        );
 
         let gate = g.matmul(h, w_gate);
         let up = g.matmul(h, w_up);
@@ -419,7 +527,7 @@ pub fn build_decode_graph(
     let logits = if config.tie_word_embeddings {
         g.matmul_bt(x, embed_weight)
     } else {
-        let lm_head = g.parameter("lm_head.weight", &[hidden, config.vocab_size]);
+        let lm_head = projection(g, weights, "lm_head.weight", &[hidden, config.vocab_size]);
         g.matmul(x, lm_head) // [1, vocab]
     };
 

--- a/tests/gpu_smoke.rs
+++ b/tests/gpu_smoke.rs
@@ -3274,6 +3274,160 @@ fn q4_matmul_single_row_matches_reference() {
     );
 }
 
+/// Roadmap: "quantized matmul, required before E4B". A decode graph is
+/// all m=1 matmuls, so this is the shape the Q4 GEMV was for.
+///
+/// Only the seven per-layer projections are packed. The embedding table
+/// stays f32 (`embedding` has no Q4 gather, and a tied `lm_head` shares
+/// it), as do the norms and the KV cache.
+#[test]
+fn smollm2_q4_projections_match_f32_decode() {
+    use meganeura::models::smollm2::{self, ProjectionWeights, SmolLM2Config};
+
+    fn decode(config: &SmolLM2Config, weights: ProjectionWeights) -> (Vec<f32>, usize) {
+        let mut g = Graph::new();
+        let (logits, _k, _v) = smollm2::build_decode_graph_with(&mut g, config, 16, weights);
+        g.set_outputs(vec![logits]);
+        let mut s = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
+        let mut param_bytes = 0usize;
+        for (name, buf) in s.plan().param_buffers.clone() {
+            let bytes = s.plan().buffers[buf.0 as usize];
+            param_bytes += bytes;
+            if name.contains("kv_cache") {
+                s.set_parameter(&name, &vec![0.0f32; bytes / 4]);
+                continue;
+            }
+            // A packed buffer is smaller than its logical element count, so
+            // size the upload from the weight shape, not the buffer.
+            let n = s
+                .plan()
+                .weight_buffers
+                .get(&buf)
+                .map(|&(_, r, c)| r * c)
+                .unwrap_or(bytes / 4);
+            let seed = name.bytes().fold(2166136261u32, |h, b| {
+                h.wrapping_mul(16777619) ^ u32::from(b)
+            });
+            let data: Vec<f32> = (0..n)
+                .map(|i| {
+                    let x = seed.wrapping_add((i as u32).wrapping_mul(2654435761)) as f32
+                        / (1u32 << 31) as f32;
+                    (x - 1.0) * 0.2
+                })
+                .collect();
+            s.set_parameter(&name, &data);
+        }
+        let mut logits = Vec::new();
+        for (pos, tok) in [1u32, 2, 3, 4, 5].iter().enumerate() {
+            s.set_input_u32("token_ids", &[*tok]);
+            s.set_input_u32("kv_pos", &[pos as u32]);
+            s.step();
+            s.wait();
+            logits = s.read_output(config.vocab_size);
+        }
+        (logits, param_bytes)
+    }
+
+    let config = SmolLM2Config::small_test();
+    let (f32_logits, f32_bytes) = decode(&config, ProjectionWeights::F32);
+    let (q4_logits, q4_bytes) = decode(&config, ProjectionWeights::Q4);
+
+    assert!(
+        q4_logits.iter().all(|v| v.is_finite()),
+        "Q4 decode produced non-finite logits"
+    );
+    let scale = f32_logits
+        .iter()
+        .cloned()
+        .fold(0.0f32, |m, v| m.max(v.abs()));
+    let err = f32_logits
+        .iter()
+        .zip(&q4_logits)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+    let argmax = |v: &[f32]| {
+        v.iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    };
+    // Measured 0.5% of the logit range on lavapipe; the margin is for other
+    // adapters, not for a second bug.
+    assert!(
+        err / scale < 0.05,
+        "Q4 decode diverged from f32: max_abs_err={err} (logit range {scale})"
+    );
+    assert_eq!(
+        argmax(&f32_logits),
+        argmax(&q4_logits),
+        "Q4 decode would generate a different token"
+    );
+    assert!(
+        q4_bytes * 2 < f32_bytes,
+        "Q4 parameters should be far smaller: {q4_bytes} vs {f32_bytes} bytes"
+    );
+}
+
+/// RmsNorm folds into a following GEMV, and that fused pipeline is a
+/// `Variant::GemvRmsNorm` which does not compose with `Variant::Weight`.
+/// Folding it into a Q4 GEMV therefore ran the f32 kernel over packed
+/// blocks, under a binding layout carrying an extra buffer — so the
+/// corruption landed in neighbouring buffers (a KV cache, in the graph
+/// that found this) rather than only in the result.
+///
+/// Unreachable until Q4 gained a GEMV variant, since Q4 was kept off that
+/// path entirely before then.
+#[test]
+fn q4_matmul_after_rms_norm_matches_reference() {
+    let (k, n) = (576usize, 1536usize);
+    let x: Vec<f32> = (0..k).map(|i| ((i % 13) as f32 - 6.0) * 0.05).collect();
+    let nw: Vec<f32> = (0..k).map(|i| 1.0 + ((i % 5) as f32 - 2.0) * 0.1).collect();
+    let w: Vec<f32> = (0..k * n)
+        .map(|i| ((i % 97) as f32 - 48.0) * 0.01)
+        .collect();
+    let eps = 1e-5f32;
+
+    let mut g = Graph::new();
+    let x_in = g.input("x", &[1, k]);
+    let norm_w = g.parameter("norm_w", &[k]);
+    let h = g.rms_norm(x_in, norm_w, eps);
+    let w_q4 = g.parameter_q4("w", &[k, n]);
+    let out = g.matmul(h, w_q4);
+    g.set_outputs(vec![out]);
+    let mut session = meganeura::build(&g, meganeura::SessionConfig::inference_from_env()).0;
+    session.set_input("x", &x);
+    session.set_parameter("norm_w", &nw);
+    session.set_parameter("w", &w);
+    session.step();
+    session.wait();
+    let gpu = session.read_output(n);
+
+    let ms = x.iter().map(|v| v * v).sum::<f32>() / k as f32;
+    let inv = (ms + eps).sqrt().recip();
+    let normed: Vec<f32> = x.iter().zip(&nw).map(|(v, g)| v * inv * g).collect();
+    let w_deq =
+        meganeura::runtime::dequantize_q4_0(&meganeura::runtime::quantize_q4_0(&w, k, n), k, n);
+    let mut max_err = 0.0f32;
+    let mut scale = 0.0f32;
+    for col in 0..n {
+        let mut want = 0.0f32;
+        for i in 0..k {
+            want += normed[i] * w_deq[i * n + col];
+        }
+        scale = scale.max(want.abs());
+        max_err = max_err.max((gpu[col] - want).abs());
+    }
+    assert!(
+        gpu.iter().all(|v| v.is_finite()),
+        "Q4 matmul after RmsNorm produced non-finite values"
+    );
+    assert!(
+        max_err / scale < 1e-3,
+        "Q4 matmul after RmsNorm diverged: max_abs_err={max_err} (scale {scale})"
+    );
+}
+
 /// Incrementally build a 1-layer transformer with Q4 weights.
 /// Output each intermediate result to find where NaN first appears.
 #[test]


### PR DESCRIPTION
Roadmap: "quantized matmul (int4/Q4), required before E4B". The GEMV kernel landed last; this is the model side that uses it.

`build_decode_graph_with` / `build_prefill_graph_with` take a `ProjectionWeights`, and the existing entry points delegate with F32, so callers are unchanged. It is a builder argument rather than a `SmolLM2Config` field because quantization is a deployment choice and that struct mirrors the published config.json.

Only the seven per-layer projections and an untied lm_head are packed — ~106M of SmolLM2-135M's 135M parameters. The embedding table stays f32 (`embedding` has no Q4 gather, and a tied lm_head shares it), as do the norms and the KV cache. `set_parameter` already quantizes on upload, so loading is unchanged. A K that is not a multiple of 32 stays f32: `quantize_q4_0` drops a trailing partial block, so it would corrupt the weight rather than fail.

Wiring it up exposed a second gap of the same kind as the missing GEMV shader. RmsNorm folds into a following GEMV as a `Variant::GemvRmsNorm`, which does not compose with `Variant::Weight`, so a Q4 GEMV fed by a norm ran the f32 kernel over packed blocks — under a binding layout with an extra buffer, which put the wreckage in neighbouring buffers rather than only the result. In the decode graph it corrupted a KV cache and came out as NaN logits several ops later. The fusion now requires an f32 weight, which also covers f16 and Q8; those have no fused variant either.

Q4 keeps the GEMV path and gives up that fusion for now, so it pays an extra dispatch per norm. Composing the two variants would win it back.

On small_test the decode logits land within 0.5% of the f32 range with the same argmax, and parameter storage drops 3.8x.


Claude-Session: https://claude.ai/code/session_013ideyDUCBLvwgAiaTjqgiC