### PR TITLE
Add bounded tuning, training-state hardening, and compact audit evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,11 @@ jobs:
       - run: cargo check --lib --tests
 
   msrv:
-    name: Rust 1.88 MSRV
+    name: Rust MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@1.92.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --lib
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,46 @@
 # Unreleased
 
+- Allocate Adam/LaProp moments only on configuration, explicit state write/step
+  or applicable restore. Read-only uninitialized moments return zeros without
+  allocation; switching optimizers retains existing moments and counters.
+  SGD/F+L+B sessions avoid the unused storage. Optimizer/clip/accumulation
+  paths explicitly reject non-F32 trainable parameter storage.
+- Checkpoint format 3 retains named logical shapes/storage types and omits
+  device padding. Validate the full restore before writes or moment allocation;
+  restore reduced-weight CPU staging too. Inference validates/ignores moments,
+  and missing saved moments reset existing state. Formats 1/2 remain readable
+  under their legacy physical/partial-load contract. This is not a complete
+  training-loop snapshot or rollback after device/allocation failure.
+- Preserve logical parameter types in execution plans; build-cache format 5
+  invalidates older plans. `param_size` now counts logical elements independent
+  of storage/padding, batched F32 reads omit padding, and parameter uploads
+  accept logical-sized data while zero-filling larger slots.
+- Use logical lengths for optimizer, clipping and accumulation loops, including
+  CPU helpers; allocation padding must not affect norms or updates. Reject
+  oversized raw F32 reads and non-F32 parameter reads before copying.
+- Correct gradient-accumulator accounting and report resident graph, moment,
+  accumulator and auxiliary buffer requests in `MemorySummary` and profiles.
+  Add checkpoint/memory study material and GPU regression coverage; these
+  quantities do not establish driver peak-memory usage or a timing gain.
+
 - Replace the state-mutating family-wide tuner with bounded exact-class
   32/64 scalar-f32 matmul tile search on private scratch. Adds `TuneOptions`,
   `tune_with` and serializable evidence, numerical qualification, interleaved
   trials and a noise guard. Both tile sizes are candidates regardless of the
   initial occupancy cutoff; small-tile geometry uses exact ceil division.
-  Default-off and CPU-validated only; GPU qualification and whole-step gains
-  remain unmeasured. Cooperative/fused/GEMV search and persistence are deferred.
+  Default-off; scalar GPU qualification passes on RTX 5070, including state
+  preservation and subsequent optimizer updates against an untuned control.
   `TuneOutcome`'s former family/coop/scalar timing fields are replaced by
   class/tile/sample/decision fields; callers reading them must migrate.
+- Extend the same search to advertised, smoke-tested native-f32 cooperative
+  tiles when padding fits existing bindings. Occupancy/large-shape thresholds
+  are initial choices, not challenger vetoes. Reports expose each comparison,
+  binding capacities, shader rejection and qualification failures. Native-f32
+  GPU coverage remains due; RTX 5070 advertises only f16 matrix tiles. F16-input,
+  complex-fusion/GEMV search and persistence remain deferred.
+- Add a Rust whole-step tuning experiment with paired trials, output parity,
+  search evidence and revision/device/driver/hash metadata; frozen paper
+  results remain untouched.
 - Add a dedicated observability/debugging study chapter, eager-PyTorch
   comparison, probe coverage caveats, bisection ladder and rehearsal questions.
 
@@ -126,8 +158,7 @@
   (column-axis reductions), and LogSoftmax.
 - Historical Track F first cut measured cooperative-family demotion on live
   steps and retained scalar fallbacks. Superseded by the state-isolated
-  scalar-tile search above; cooperative tuning is deferred until equivalent
-  safe candidate contracts are implemented.
+  f32-matmul search above; f16-input cooperative tuning remains deferred.
 - Kernel-variant selection has a single owner (roadmap A2, scoped):
   cooperative promotion (incl. generated conv kernels and output padding),
   the RmsNorm→matmul prologue fusion, and small-tile demotion moved from

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Dzmitry Malyshau"]
 repository = "https://github.com/kvark/meganeura"
 categories = ["science"]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.92"
 description = "Portable GPU training and inference through Vulkan and Metal"
 license = "MIT"
 
@@ -22,18 +22,16 @@ hub = ["dep:hf-hub"]
 profiler = ["dep:tracing-subscriber"]
 
 [dependencies]
-blade-graphics = { version = "0.8.4", git = "https://github.com/kvark/blade", rev = "b208f3b1f97196c2971436b5726e61e71b149c37" }
-blade-macros = { version = "0.3", git = "https://github.com/kvark/blade", rev = "b208f3b1f97196c2971436b5726e61e71b149c37" }
+blade-graphics = "0.9"
+blade-macros = "0.3"
 # `default-features = false` drops egglog's `bin` stack (clap, mimalloc,
 # env_logger, chrono, graphviz). Greedy mode never constructs an EGraph
 # but the crate is still linked for the optional equality-saturation
 # modes.
 egglog = { version = "2.0", default-features = false }
 bytemuck = { version = "1", features = ["derive"] }
-# Pinned to the same wgpu/naga rev as blade-graphics so the `naga::Module`
-# we build unifies with the one blade's SPIR-V backend consumes. This rev
-# carries `spv::Options::emit_int_div_checks`, which blade sets to false.
-naga = { version = "29.0.0", git = "https://github.com/gfx-rs/wgpu", rev = "cefd48f6cff61d64abe1cdb4002c4e39bfc2c728", default-features = false, features = ["wgsl-in", "wgsl-out", "spv-out"] }
+# Match Blade's Naga major: generated modules cross the public API boundary.
+naga = { version = "30", default-features = false, features = ["wgsl-in", "wgsl-out", "spv-out"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ron = "0.8"
@@ -52,6 +50,8 @@ tracing-subscriber = { version = "0.3", optional = true, features = ["registry"]
 # pulls in a C library, which is a needless build-script burden for
 # downstream crates that just want the inference runtime.
 [dev-dependencies]
+# Replay small paired timing differences without lossy f64 JSON parsing.
+serde_json = { version = "1", features = ["float_roundtrip"] }
 env_logger = "0.11"
 tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For the detailed, source-backed comparison, read the
 [study guide](docs/study/README.md) and [alternatives](docs/study/alternatives.md).
 The [September audit](docs/audit-2026-09.md) separates current implementation
 status from the frozen results; the [performance plan](docs/study/performance-plan.md)
-describes the first bounded scalar-tile search and the remaining qualification
+describes bounded f32-matmul tile search and the remaining qualification
 and broader-search work.
 
 ## Install
@@ -108,10 +108,9 @@ and broader-search work.
 cargo add meganeura
 ```
 
-Development HEAD pins Blade APIs newer than its published dependency version.
-Use this checkout for current development; assembling a package with
-`--no-verify` does not establish that HEAD builds against crates.io-only
-dependencies. A release needs a matching published Blade/Naga dependency set.
+Development HEAD uses published Blade 0.9 and Naga 30 with Rust 1.92 or newer.
+CI verifies the assembled package against registry dependencies. This does not
+publish a new Meganeura release; use this checkout for unreleased changes.
 
 Hub downloads (`SafeTensorsModel::download`) need the optional `hub` feature:
 
@@ -126,6 +125,13 @@ Worked examples live in [`examples/`](https://github.com/kvark/meganeura/tree/ma
 - [`mnist.rs`](https://github.com/kvark/meganeura/blob/main/examples/mnist.rs) — MNIST training end to end.
 - [`train_deploy.rs`](https://github.com/kvark/meganeura/blob/main/examples/train_deploy.rs) — optimizer-backed training, checkpoint save, and reload into a fresh inference session.
 - [`smollm2.rs`](https://github.com/kvark/meganeura/blob/main/examples/smollm2.rs) — LLM inference with HuggingFace weights.
+
+Current checkpoints store logical tensors without device padding and preflight
+the restore before mutation. Adam/LaProp moments are allocated only when
+requested; SGD and forward/backward-only sessions avoid that unused storage.
+See [checkpoints and memory](docs/study/checkpoints-and-memory.md) for format
+compatibility, resume limits and the distinction between buffer counts and
+driver peak memory.
 
 Pretrained models can be loaded from ONNX or NNEF via `meganeura::load_onnx(...)` / `meganeura::load_nnef(...)`. Both lower through Meganeura’s IR, so the same graph rewrites apply to imported graphs and hand-built ones.
 
@@ -181,7 +187,7 @@ win, so explicit code always has the last word.
 | `MEGANEURA_OPTIMIZER` | Rewrite mode: `off` \| `greedy` \| `egglog-windowed` \| `egglog-outlined` \| `egglog-whole`. |
 | `MEGANEURA_EGRAPH_COST` | Extraction objective: `ast-size` \| `tensor-traffic`. |
 | `MEGANEURA_EGRAPH_CUTOFF=<n>` | Saturation segment-size ceiling (default 300). |
-| `MEGANEURA_TUNE` | Opt-in bounded scalar-f32 matmul tile searches at build (`SessionConfig { tune: true }`), using private scratch. |
+| `MEGANEURA_TUNE` | Opt-in bounded f32 matmul tile searches at build (`SessionConfig { tune: true }`), using private scratch. |
 | `MEGANEURA_FLASH_EPT_CAP=<n>` | Flash forward elements-per-thread cap (power of two ≥ 2). |
 | `MEGANEURA_FLASH_GRAD_Q_EPT_CAP=<n>` | EPT cap for flash dQ backward. |
 | `MEGANEURA_FLASH_GRAD_KV_EPT_CAP=<n>` | EPT cap for fused flash dK/dV backward. |
@@ -189,12 +195,21 @@ win, so explicit code always has the last word.
 | `MEGANEURA_DEVICE_ID=0x744c` | Adapter selection by numeric device id. |
 | `MEGANEURA_GPU_TIMING` | Enable hardware timestamp pools (set before context creation). |
 
-`Session::tune_with(TuneOptions)` searches 32/64 scalar tiles for exact dense
-matmul classes, qualifies nonzero scratch outputs, interleaves measurements,
+`Session::tune_with(TuneOptions)` searches 32/64 scalar and legal native-f32
+cooperative tiles for exact dense matmul classes, qualifies nonzero scratch outputs, interleaves measurements,
 and returns raw samples and decisions. It never runs the live graph or advances
-optimizer/KV state. Default-off: GPU qualification and end-to-end confirmation
-are still due. Cooperative/fused/GEMV candidates and persistent winners are not
-included yet. See the [search contract](docs/study/performance-plan.md).
+optimizer/KV state. Default-off: scalar GPU qualification passed on RTX 5070;
+native-f32 hardware coverage and automatic whole-step confirmation remain due.
+F16-input/complex-fusion/GEMV candidates and persistent winners are not included.
+Reports separate qualification's CPU preparation/copies/checks from
+transfer/dispatch/wait costs. Private tuning staging defaults to read-optimized
+Download; `TuneOptions::staging = TuneStaging::Shared` retains the original
+policy. Neither setting changes candidate bindings or numerical validation.
+One exact-size staging buffer is reused within a tuning call and released on
+size changes or return. `TuneOptions::staging_reuse = TuneStagingReuse::Fresh`
+disables reuse; reports include preparation, cleanup and scratch byte accounting.
+See the [search contract](docs/study/performance-plan.md) and
+[whole-step experiment](examples/tune_session.rs).
 
 ## Debugging
 

--- a/docs/audit-2026-09.md
+++ b/docs/audit-2026-09.md
@@ -3,10 +3,23 @@
 Audited development base: `bd6be08`. The working tree was initially clean.
 The separate `../blade` and `../inferena` checkouts were inspected read-only;
 the pre-existing untracked `../blade/paper/` was preserved. Followed
-`/mnt/data/GUIDELINES.md`. No GPU context was initialized, no GPU tests or
-benchmarks were run during the audit. A subsequent user-requested follow-up
-prepares the audit and changes on `codex/audit-observability-tuning`; no merge
-or publication is authorized or performed.
+`/mnt/data/GUIDELINES.md`. The initial audit initialized no GPU context and ran
+no GPU tests or benchmarks. Subsequent user-requested work on
+`codex/audit-observability-tuning` adds tuning, device qualification and a
+separate transfer experiment after the GPU was released. No merge or paper
+publication is authorized or performed.
+
+September 6 follow-up: rebased the branch onto `8069cf3`, preserving the
+upstream batched partial cooperative-convolution fix. Checkpoint and optimizer
+memory findings now have implementations and GPU regression coverage, as
+recorded below; the opening source audit remains a historical assessment.
+A further rebase onto `a455409` retains upstream Q4 fixes and the all-test-target
+CI policy. The six-case whole-step holdout experiment below is measured on
+that newer base; earlier results retain their own source identities.
+The later crossover source rebases onto `230cab0`, preserving upstream Q4
+SmolLM2 projection support. All measured-source tags remain fixed.
+The readback follow-up moves development to published Blade 0.9/Naga 30,
+restores full package verification and measures private staging separately.
 
 This is a broad source/infrastructure/evidence audit, not a formal proof of
 correctness, a full fuzz/security review, or new hardware qualification.
@@ -69,27 +82,62 @@ speedup is claimed. Existing matrix records and generated numeric tables were
 not changed. Python changes extend the existing paper tooling; core runtime
 and compiler changes remain Rust.
 
+## Convolution selection follow-up — September 6
+
+Bounded search now includes the existing scalar dX/dW tiles, with exact NCHW
+shapes, physical scratch sizes, batch-aware references, checked indexing and
+complete shader/geometry swaps. The [corrected six-process crossover](experiments/conv-tiles-corrected-2026-09-06/README.md)
+observes ResNet 17.5808→16.7293 ms, ratio 1.05056×, but no result clears the
+unchanged whole-step guard. Four dX classes change eight dispatches; the small
+Adam/SGD cases keep their tiles. All 84 isolated comparisons qualify and full
+state is bit-exact with actual optimizer updates through age 178. ResNet's
+eight-class structural budget leaves 37 classes unvisited. Split-K dW and
+explicit direction/coverage policies remain next, not larger ad hoc budgets.
+
+The original small-case builder violated the documented flat convolution
+operand contract. A zero-workgroup forward dispatch yielded matching zero
+loss/gradients/moments, which the original runner accepted. All twelve invalid
+controls are retained/disqualified. Public helper shape checks, full f64
+forward/derivative oracles, nonzero prefix checks, real-update requirements
+and CPU replay/mutations now cover this failure. No original records, evidence
+tags or frozen paper tables were rewritten.
+
 ## Open findings, ranked by the next decision they affect
 
 Follow-up: the old state-mutating tuner has been replaced with private-scratch
-exact-class scalar-tile search. The [implementation contract](study/performance-plan.md)
-and [observability chapter](study/observability.md) distinguish its CPU-checked
-invariants from pending GPU/end-to-end evidence. This is outside the frozen
-paper result set.
+exact-class scalar/native-f32 matmul search. After the user released the GPU,
+four scalar qualification tests passed on RTX 5070 (driver 595.71.05), including
+training-state preservation and subsequent control-session updates. The device
+reports f32 tile 0 / f16 tile 16, so native-f32 execution remains unqualified.
+The [implementation contract](study/performance-plan.md) and
+[observability chapter](study/observability.md) separate this engineering from
+the frozen paper result set.
+
+The subsequent [five-process transfer pilot](experiments/tuning-2026-09-05/README.md)
+retains all raw samples and its lockfile: two larger synthetic chains improve
+by median 1.151×/1.127× end to end; two smaller chains keep their initial tiles.
+This supports further holdout testing, not a new PyTorch or publication claim.
+
+The physical-checkpoint/partial-mutation finding and eager Adam allocation
+have now been addressed. Format 3 stores logical identities and validates
+before writes; moments are lazy and memory reports reflect actual buffer
+requests. Remaining qualification and broader state-management limits are
+listed below and explained in [checkpoints and memory](study/checkpoints-and-memory.md).
 
 P1 means address before relying on the affected feature/release claim, not
 that an exploit or observed end-user failure was reproduced in every case.
 
 | Priority / finding | Evidence and consequence | Exit criterion |
 |---|---|---|
-| P1: new tuner needs hardware qualification | Live-step family tuning is removed. Scalar 32/64 search uses private nonzero scratch, exact keys/geometry, numerical screens and bounded paired measurements. | Run deferred state-preservation and precision tests, then whole-step confirmation and holdouts; no claim of measured gains yet. |
-| P1: incomplete variant contract | `Pipelines::candidates` still has a fallback hierarchy; heuristic promotion removes candidates from search. Packed fallback bug illustrates the boundary. | Complete candidate owns pipeline/bindings/geometry/padding; exact lookup; legal bidirectional alternatives. |
-| P1: checkpoint physical layout and partial restore | `save_checkpoint` writes physical padded buffers; `load_checkpoint` validates/writes tensor by tensor and handles later metadata afterward. | Versioned logical shapes/dtypes; validate all fields before mutation; cross-padding/device roundtrip and malformed-late-field tests. |
-| P1: dependency/release qualification | Git Blade APIs exceed the published dependency version used by packaging; RustSec findings below. | Matching published Blade/Naga set; clean crates.io-only consumer build, MSRV and advisory triage. |
-| P1: large-model numerical evidence is incomplete | Matrix compares 256 output samples and parameter-gradient norms, not full gradients or optimizer trajectories. | Next protocol adds seeded gradient samples/projections, independent small references and trajectory tests. |
+| Addressed: convolution reciprocal indexing | A full GPU oracle reproduced wrong dW at width 41. Exact division repaired shared scalar/generated indexing and removed the tuner-only f32 filter. The subsequent all-integer high-multiply/correction helper covers full-u32 numerators with four derived integer uniforms; raw-u32 and full f64 oracles pass with unchanged gates. | The first repair cost about 23% on ResNet. A [fresh six-process follow-up](experiments/conv-divisor-2026-09-06/README.md) recovers only about 2% versus exact division, with full-state identity. Most cost, short-case timing stability, native-f32 cooperative execution and cross-backend profitability remain open. Never restore approximate addressing for speed. |
+| P1: new tuner needs transfer/fleet qualification | Holdouts show state parity but no whole-step gain. Six-process crossover confirms one dense shape, not MLP+Adam; two MLP A/A controls are noisy. Native-f32 remains offline-only. | Broader end-to-end confirmation, native-f32 hardware and fleet evidence before default-on. |
+| P1: incomplete variant contract outside the new search | Exact scalar/native-f32 matmul and scalar convolution-derivative candidates carry geometry and challenge profitability vetoes. Other families still use fallback hierarchies and heuristic promotion. | Extend complete pipeline/bindings/geometry/padding contracts to additional measured, legal families. |
+| P2: checkpoint qualification and broader snapshot contract | Logical format 3 and whole-file preflight are implemented; cross-padding, malformed-late-field and next-update tests pass on RTX. Legacy files retain partial-load compatibility. | Metal↔Vulkan qualification; crash-atomic file replacement and a separately specified complete training-loop snapshot, if required. |
+| P1: dependency/release qualification | Published Blade 0.9, blade-macros 0.3 and Naga 30; Rust minimum 1.92. Full `cargo package` passes and is restored in CI, closing the historical git-pin gap. | Review/publish Meganeura separately; maintain consumer, MSRV, advisory and cross-backend qualification. |
+| P1: large-model numerical evidence is incomplete | Frozen matrix compares sampled outputs and gradient norms. New synthetic holdouts compare full control-session gradients/moments through step 78, not an independent engine. | Independent small references, broader distributions and cross-engine trajectories before stronger numerical/convergence claims. |
 | P1: real-device coverage is incomplete | CI uses software Vulkan and hosted Metal; MHA smoke backprop skipped; no continuous NVIDIA/AMD lane. | Scheduled/manual release matrix exercising legal cooperative, precision, alias, optimizer and checkpoint paths. |
 | P2: untrusted import robustness | Raw ONNX parsing has unchecked slices/length assumptions and dimension conversion; not fuzzed in this audit. | Bounded parsing, checked arithmetic, structured failures and malformed-input fuzz corpus. |
-| P2: optimizer allocation/lifecycle | Trainable sessions allocate Adam state even for SGD/F+L+B; host budget guard cannot guarantee runtime availability. | Lazy state allocation, measured peak-memory basis, structured allocation failure instead of broad panic. |
+| P2: optimizer memory qualification/failure handling | Moments are now lazy and accumulators correctly counted once; an RTX regression avoids 8 MiB of unused moment allocations. Host budget guard still cannot guarantee runtime availability. | Large-workload driver-peak measurements and structured allocation failure instead of broad panic. |
 | P2: `TrainConfig.learning_rate` alias | Public field is documented as an alias, but training reads the optimizer's own learning rate. | One documented source of truth or explicit compatibility rule with a CPU configuration test. |
 | P2: advertised generality exceeds operator coverage | Depthwise conv and several inference/cache/fused ops lack derivatives; no unrestricted shapes, CPU engine or distributed runtime. | Explicit support matrix and early validation; add primitives only for demonstrated workloads. |
 | P2: optimizer complexity without established benefit | Required egglog dependency despite greedy default; current rule-set ablation selects same graph. | Feature-gate/replace dependency only with compatibility and footprint evidence; give e-graph new useful choices before expanding it. |
@@ -99,6 +147,244 @@ optimizer/clip work. That is correct and should not be "optimized away" by
 reasoning only about compiled-plan consumers. Conversely, a pinned buffer
 need not be shared/host-visible. Those distinctions have already caused
 historical bugs and belong in regression tests.
+
+## Rebase and checkpoint/memory follow-up — September 6
+
+The rebase skips the two audit/tuning commits already present on `main` and
+replays the remaining tuning/evidence work above `8069cf3`. The original
+measured source `0e27b68e92bfb72745eb2f582107236cd541c409` is retained as
+`evidence/tuning-2026-09-05`. No raw experiment hash or result is relabeled as
+a measurement of the rebased code.
+
+Implemented in Rust:
+
+- retain logical parameter shapes/storage types separately from padded slots;
+  invalidate older build plans with cache format 5;
+- write format-3 logical checkpoints, preflight complete restore data before
+  mutation/allocation, zero destination padding, and refresh reduced-weight
+  CPU staging used by later constituent-parameter updates;
+- allocate Adam/LaProp moments on demand, preserve initialized state across
+  optimizer switches, and keep read-only inspection allocation-free;
+- report actual graph/moment/accumulator/auxiliary buffer requests, fixing
+  accumulator overcounting and excluding shared diagnostics from device-local
+  totals;
+- use logical lengths in optimizer, clipping and accumulation loops, so
+  poisoned allocation padding neither affects norms/updates nor overruns a
+  logical-sized grouped diagnostic buffer; bound raw F32 reads and reject
+  non-F32 parameter reads before copying.
+
+At that checkpoint, CI's enumerated regression job was extended with the memory,
+Adam/LaProp, accumulation and clipping suites. The subsequent `a455409` rebase
+supersedes that list with upstream's `cargo test --tests` policy, retaining the
+backprop/bit-exact exceptions on hosted adapters. Local RTX checks do not imply
+that hosted Metal/software-Vulkan jobs have already run.
+
+Validation: 241 CPU library tests, all-feature clippy and strict rustdoc,
+Rust 1.88 library check, retained tuning-record replay, and the six-test/50-cell
+frozen-artifact replay pass. On RTX 5070 / NVIDIA 595.71.05, 85 selected GPU
+tests pass: Adam state (3), cache inference (2), checkpoint validation (8),
+cooperative convolution (4), GPU smoke (44; two long cases ignored), gradient
+accumulation (2), clipping (4), LaProp (1), optimizer memory/bounds (5), scalar tuning
+(4; native-f32 excluded), and training correctness (8). The train/deploy
+example reaches 8/8 reloaded inference accuracy with decreasing loss. The
+focused checkpoint/optimizer suites also pass in debug builds with API validation.
+
+The memory test verifies an 8 MiB moment-buffer allocation difference for
+1,048,576 F32 elements. It does not measure driver peak memory or runtime
+speed. Checkpoint preflight is failure-atomic for validation/I/O errors, not
+for device loss or allocation failure; optimizer configuration, accumulation
+windows and application state are not saved. Cross-padding tests on one
+backend do not replace cross-device qualification. No frozen paper results
+or numeric tables were changed.
+
+## Inference/training holdouts — September 6
+
+Measured source `8bcd6b9`, retained as `evidence/holdouts-2026-09-06`, adds a
+Rust harness and precommitted protocol without changing the tuner/generators.
+The [complete experiment](experiments/holdouts-2026-09-06/README.md) retains all
+five processes and all six cases: nonlinear MLP and SmolLM2 inference, MLP and
+SmolLM2 Adam, Whisper SGD, and folded-BN ResNet F+L+B without an optimizer.
+
+All 140 isolated comparisons qualify; 31 accept challengers. All 30 whole-step
+case runs preserve the declared state and full control-session tensor parity,
+including optimizer trajectories through update 78. **None clears the
+predeclared whole-step gain or regression guard.** MLP Adam's median ratio is
+0.977×; MLP inference's is 1.052×. This is stronger state/coverage evidence,
+not a PyTorch comparison or demonstrated training improvement. The frozen
+paper files and the positive dense-chain pilot are unchanged.
+
+The unchanged ResNet control exposes the need to retain paired samples:
+one process's 1.071× ratio of medians has only 0.01470 ms median paired gain,
+and is correctly rejected. Only its classifier weight-gradient dispatch is
+eligible (1/512); search costs median 1.12 s without changing a tile. The
+SmolLM2/Whisper training cases hit the eight-class cap. These observations
+prioritize confirmation controls, phase profiling and broader reusable kernel
+families, not threshold fitting. Stage accounting confirms no moments for
+SGD/F+L+B but is not a driver-peak measurement.
+
+Validation on the rebased source: full release `--tests` suite passes, including
+242 library tests and the upstream Q4 single-row test, with default ignored
+cases unchanged and no local bit-exact/backprop skip flags. Fixture-dependent
+ResNet/Whisper PyTorch-reference tests return early for absent files; hub-only
+SmolLM2 reference tests are not enabled. These are explicit coverage gaps,
+not new cross-engine qualifications. Six holdout prefixes and four scalar-tuner
+tests pass separately. CPU evidence replay validates all 30 case records and
+mutation rejection and is added to quality CI. All-feature clippy, strict
+rustdoc, Rust 1.88 library and frozen-artifact checks pass locally.
+
+The immediate engineering follow-up adds `TuneOutcome.phase_times`, prompted
+by ResNet's search-cost gap: preparation, qualification, warmup and sampling
+wall times, with early-exit accounting and `None` for unmeasured historical
+reports. It changes reporting, not the candidate space or numerical/selection
+policy. The 244 library tests, both retained cohorts' CPU replay, all-feature
+clippy, MSRV/rustdoc and four scalar GPU tests pass after instrumentation.
+The recorded holdouts still refer to the earlier tagged source, not these
+new timers.
+
+## Controlled confirmation and search-cost localization
+
+The [separate crossover cohort](experiments/crossover-2026-09-06/README.md)
+retains six fresh processes from tagged source `c789bfa`, rebased onto
+`230cab0`. The new `Session::swap_tuning_with` preflights compatible layouts,
+prepares exact pipelines and swaps only legal f32 tile choices on one GPU
+context. It never transplants weights, buffers or optimizer history. A GPU
+regression with distinct inputs/Adam ages and accumulation checks bitwise
+preservation and subsequent updates against independent controls.
+
+All 18 case runs and 54 isolated comparisons qualify; declared state remains
+bit-exact through Adam step 178. The dense chain passes the predeclared guard
+in both role orientations in all six processes (median 1.177×). MLP+Adam has
+four inconclusive results and two unstable A/A controls; its all-process
+median ratio is 0.984×. ResNet changes no selection. No regression guard
+passes, which is not a claim of zero harm. This is not a new engine comparison,
+new unseen-workload set, or automatic runtime confirmation/rollback feature.
+
+That cohort's phase timers put 98.26–98.65% of ResNet search wall time in
+qualification: median 538 ms out of 546 ms total, versus 7 ms sampling.
+At that point staging was a source-based hypothesis; the follow-up below
+separates and tests it without changing numerical gates or frozen results.
+Telemetry records substantial clock/temperature changes
+over each process but cannot attribute every short pair or explain MLP noise.
+
+The rebased full release test suite, both workload preflights, swap regression
+and four scalar GPU tuner tests pass. Default/data-gated coverage limits above
+remain. CPU replay checks the crossover's identities, full pair roster, roles,
+counter/summary arithmetic, exact pipeline changes, phase accounting and all
+decisions, with mutation tests in quality CI. Frozen-artifact replay remains
+50 cells / 165 files and byte-identical tables.
+
+## Published Blade and qualification readback — September 6
+
+Registry Blade 0.9.0 requires Rust 1.92 and Naga 30. The migration updates
+Meganeura's MSRV/CI and uses published blade-macros 0.3.0, with one shared
+Naga 30.0.1 module type across the shader API boundary. No sibling checkout
+change or patch override is needed. Full `cargo package`, all-target/all-feature
+checks, strict Clippy/rustdoc and the Rust 1.92 library check pass. Package
+verification now runs in CI instead of `--no-verify`; Meganeura publication
+is still a separate user-reviewed action.
+The new lockfile's advisory scan also exits successfully, with the same six
+maintenance/unsoundness warnings described below; it is not warning-free.
+
+A fresh Rust 1.92 consumer of the assembled package also builds and runs with
+a new compatible registry resolution and one Naga 30.0.1. It verifies the
+Download option default and historical Shared deserialization without creating
+a GPU context. This tests the checkout's assembled package, not a newly
+published Meganeura release.
+
+The [readback protocol and six raw processes](experiments/readback-2026-09-06/README.md)
+retain measured source `2abeff93` at `evidence/readback-2026-09-06` and the exact
+registry lockfile. Both arms use Blade 0.9, changing only one private staging
+buffer from Shared to Download. Nested qualification times separate input
+preparation, CPU upload copy, upload transfer/wait, dispatch/wait, readback
+transfer/wait, CPU readback allocation/copy and CPU numerical checks. Timers
+accumulate on repeated calls and preserve partial/absent measurement semantics.
+
+All 108 class comparisons qualify; the 18 case runs retain bit-exact full
+state through Adam step 178 and identical buffer allocation requests. Median
+ResNet search falls from 606.46 to 38.85 ms, with CPU readback allocation/copy
+falling from 582.24 to 2.03 ms; unchanged validation takes about 6 ms. Dense
+and MLP median searches fall from 73.20 to 43.98 ms and 175.44 to 63.53 ms.
+Preparation and upload transfer cost more with Download, as does ResNet's
+readback transfer; the first dense Download search is slower and is retained.
+
+The predeclared guards allow Download as the default for private tuning
+staging. Shared remains available, missing historical settings retain Shared,
+and tuning itself stays opt-in. CPU replay and mutation tests join CI. Both
+staging modes pass all-bit round trips over odd/rectangular/large outputs and
+the four-entry and optimizer/accumulation regressions. The full release suite
+passes on Blade 0.9; native-f32 hardware and absent reference fixtures remain
+outside this coverage. The frozen verifier still passes six tests and all
+50 cells / 165 files without changing tables.
+
+This is a search-cost improvement on one GPU, not a model/PyTorch/Blade-version
+performance comparison. Full validation remains; no physical memory/cache
+properties were measured. The subsequent allocation/reuse work is below.
+Metal maps both staging policies to shared storage, and cross-backend
+performance remains unmeasured.
+
+## Exact-size staging reuse — September 6
+
+The [separate resource experiment](experiments/staging-reuse-2026-09-06/README.md)
+first tags an instrumentation-only profile at `42fda56`, then the reuse cohort
+at `875c501`. New nested preparation timers separate checks, pipeline setup,
+binding-buffer allocation, staging management, encoder creation and binding
+construction; comparison and final retained-staging cleanup are explicit.
+Absent historical timings remain absent. The profile locates about 94% of
+Download preparation in staging allocation for dense and MLP workloads.
+
+The implemented scope is one exact-size staging slot per tuning call. It is
+released before size changes and at return; candidate buffers/encoders and
+all ordinary/tiny qualification work remain fresh. Reports expose requests,
+allocation/reuse/release counts, peak simultaneous scratch requests and zero
+retained staging bytes. Both byte caps and new-allocation device preflight
+remain enforced. No persistent session pool or physical peak-VRAM claim is added.
+
+All six processes and 18 case runs complete; 108 comparisons qualify with
+bit-exact state checks through Adam step 178. Dense/MLP staging allocations
+fall 3→1 and 5→2; median total searches fall 44.01→31.84 ms and 64.27→45.46 ms. Per-comparison
+and peak scratch requests match. The no-reuse ResNet control is order-sensitive
+and passes neither gain nor regression guard. The first slower dense run and
+first unusually large MLP ratio remain in the cohort. Predeclared gates permit
+SameSize as the new option default, while Fresh and historical deserialization
+remain available and tuning itself stays default-off.
+
+GPU regressions cover exact-size hits, growing/shrinking replacements, stale
+NaN payloads, early-return cleanup, a later scratch-budget skip after a completed
+comparison, and ordinary optimizer/accumulation state with both policies.
+Shared CPU replay checks the old/new record identities and all numerical,
+coverage, timing and resource invariants, with mutation tests in CI. This is
+cheaper search on the RTX 5070, not new training/engine/fleet performance evidence.
+The next priority is whole-step localization and reusable kernel-family coverage,
+not widening memory retention or lowering numerical acceptance margins.
+
+## Whole-step localization and convolution correctness — September 6
+
+The [three-process profile cohort](experiments/training-profile-2026-09-06/README.md),
+source `48e2315` and tag `evidence/training-profile-2026-09-06`, captures
+ResNet/SmolLM2/Whisper F+L+B with no optimizer. All 45 profiled full states
+match ordinary execution before ring advancement, and requested memory is
+unchanged. Backward convolution contributes 60.66–60.77% of instrumented
+ResNet dispatch time; backward attention contributes 36.25–40.58% for SmolLM2.
+Whisper's normal before/after drift reaches 99.55%; all cases and samples remain.
+These are localization profiles, not new optimization or cross-engine results.
+
+Reviewing dX uncovered an indexing error in both scalar and generated cooperative
+stride-1 paths: they used transposed padding without flipping the weight indices.
+An independent f64 scatter oracle reproduces it on unpadded/asymmetric cases;
+both implementations now use the forward padding when inverting the address
+map. New full dX/dW regressions cover eight shapes, both scalar tile sizes and
+ordinary/tiny gradients. The generated path also executes on three shapes with
+bounded f16-representable operands on this GPU; native-f32 hardware remains due.
+All stride-1 dX cases in the retained profile happen to satisfy same padding,
+where the old and corrected expressions agree. Neither that fact nor perfect
+same-engine parity proves general derivative correctness.
+
+The next implementation is exact-class convolution-derivative tile selection,
+then bounded split-K dW with explicit partial storage/final reduction and
+whole-step confirmation. No performance threshold, precision allowance or
+tuning default changes with this correctness repair. Study-guide questions
+now distinguish profiling perturbation, shared-baseline parity and independent
+operator oracles. Frozen paper records and measured-source tags stay unchanged.
 
 ## Dependency audit and provenance
 
@@ -134,13 +420,14 @@ our unsafe host/GPU boundary or in driver code.
 
 ## Verification performed
 
-All execution below is CPU-only. Shader generation/validation/SPIR-V
-translation does not create a GPU context.
+The original audit/scalar-slice checks below were CPU-only. Subsequent GPU
+qualification is recorded above. Shader generation/validation/SPIR-V
+translation alone does not create a GPU context.
 
 | Check | Result |
 |---|---|
-| `cargo test --lib -- --test-threads=1` | 219 in the initial audit; 232 after the scalar-tuner follow-up; zero measured. |
-| `cargo test --test tune --no-run` | GPU qualification target compiles; both timing tests remain ignored and unexecuted. |
+| `cargo test --lib -- --test-threads=1` | 219 in the initial audit; 232 after the scalar slice; 236 after native-f32 candidate support; zero measured. |
+| `cargo test --test tune --no-run` | Initially compile-only; current scalar execution and native-f32 exclusion are recorded below. |
 | `cargo check --all-targets --all-features` | Pass. |
 | `cargo clippy --all-targets --all-features -- -D warnings` | Pass after the two lint fixes. |
 | `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features` | Pass. |
@@ -153,10 +440,18 @@ translation does not create a GPU context.
 | P3HPC PDF | 10 pages, embedded Type 1 fonts, all pages visually reviewed; no undefined citations/references or overfull boxes. |
 | Companion paper PDF | Builds successfully; no LaTeX warnings or overfull boxes in the final log. |
 
-The latest source inventory is roughly 40.2 K physical Rust lines and 4.4 K
-WGSL lines under `src/`; this is not the frozen paper's 34.5 K/6.1 K basis.
-Dependencies, examples, tests and documentation are separate. No current
-binary-footprint or runtime performance measurement was collected.
+GPU-release follow-up: four scalar tuning tests and 19 related GPU regression
+tests passed (`debug_session`, `grad_accumulate`, `horizontal_matmul`,
+`matmul_param_order`, `training_correctness`). The native-f32 tuning test was
+explicitly excluded because RTX 5070 advertises no f32 cooperative tiles.
+All-feature clippy, rustdoc with denied warnings, Rust 1.88 library check,
+and the six-test/50-cell frozen-artifact replay also pass after the extension.
+
+The scalar-slice source inventory was roughly 40.2 K physical Rust lines and
+4.4 K WGSL lines under `src/`, before the native-f32 extension; this is not
+the frozen paper's 34.5 K/6.1 K basis. Dependencies, examples, tests and
+documentation are separate. No new binary-footprint measurement was collected.
+The later runtime transfer experiment is recorded separately above.
 
 ## Infrastructure priorities
 
@@ -169,8 +464,8 @@ bug or establish numeric behavior on matrix units.
 The current workflow contains a software-Vulkan latency job. This audit did
 not run that job or launch remote CI. Hardware benchmark automation should
 explicitly record device isolation and reject interfered runs rather than
-publish unreliable timing. Dependencies are pinned jointly where Naga's
-module type crosses the Blade boundary; update them together and run the
+publish unreliable timing. Blade and Naga majors must stay aligned where Naga's
+module type crosses the dependency boundary; update them together and run the
 cross-backend qualification suite.
 
 For research-object reproducibility, retain exact measured source and
@@ -181,13 +476,40 @@ the distinction between self-replay and independent artifact evaluation.
 
 ## Recommended next work
 
+The author requested a finite stopping point. The tuning-foundation milestone
+is now closed after the [single bounded accumulation attempt](experiments/compensated-dw-2026-09-06/README.md):
+230/240 accuracy rows qualify, but the tiny long-cancellation fixture fails.
+The unqualified production arithmetic is removed, its source/evidence retained,
+and split-K promotion deferred. No conditional whole-step benchmark follows.
+Open audit findings remain honest limitations and future release/research work,
+not a reason to extend this milestone indefinitely.
+
+The [bounded split-K prototype](experiments/split-k-2026-09-06/README.md) now
+provides explicit pre-allocation dW partials plus existing SumRows. It reuses
+exact-class legality and ordinary scheduler/memory lifetime analysis, preserving
+logical gradients and origins. Full f64 partial/final checks and short clipped
+SGD/Adam trajectories pass for the qualified fixtures. A long tiny-gradient
+three-way partial fails the unchanged gate and remains unqualified, despite a
+passing final gradient. No split-K performance measurement or automatic adoption
+was claimed by that initial prototype. The [follow-up sequence cohort](experiments/split-k-sequence-2026-09-06/README.md)
+now uses the shared scratch runner with all partial/staging bytes charged. It
+shows a 6.93× synthetic eight-way sequence ratio but rejects both profiled large
+shapes before timing. Full scans catch unsplit-control accuracy failures; CPU
+sequential FMA reproduces the reported bits. Shared long-reduction accuracy and
+broader qualification fixtures now precede training promotion. Rebuilt-session
+whole-step confirmation is still open; live tile swaps continue rejecting
+incompatible layouts. No default or frozen-paper result changes.
+
 First, finish the accepted paper using the frozen result set and the
 [revision checklist](../paper/p3hpc/REVISION.md). No new benchmark is required
-to make the present claims precise. In parallel with later paper work,
-extend the implemented state-isolated scalar search to complete cooperative
-candidates and implement logical transactional checkpoint restore. Once
-hardware is available, qualify the new scalar tuner before whole-step
-confirmation and profile-motivated convolution/attention changes.
+to make the present claims precise. For a separately scoped later engineering
+phase, qualify native-f32 candidates on supporting hardware, use the retained
+whole-step evidence to prioritize reusable kernel-family work, and
+qualify logical checkpoint restores across backends. The scalar search and lazy-memory/checkpoint
+changes have passed initial RTX qualification; the holdouts establish state
+parity but no training gain. Use profiles to motivate reusable convolution/
+attention changes rather than reducing acceptance margins. Allocation failures
+and peak memory remain separate work, not solved by preflight validation.
 
 The full experiment design and acceptance criteria are in the
 [performance plan](study/performance-plan.md). The main strategic change is

--- a/docs/performance-profiling.md
+++ b/docs/performance-profiling.md
@@ -97,3 +97,22 @@ throughput, occupancy, cache behavior, or tensor-core utilization, use the
 vendor tool for the affected platform (for example Nsight, Radeon GPU
 Profiler, or Xcode GPU capture). Those captures are supporting forensic
 evidence, not portable benchmark artifacts.
+
+## State-checked training localization
+
+`examples/profile_training.rs` provides a fixed, synthetic F+L+B roster with
+normal timing blocks before and after capture, full profiled-result comparisons
+before ordinary ring advancement, exact dispatch contracts, provenance and
+telemetry. It enables timestamp queries through `GpuOptions`, with no environment
+variable required. The [retained protocol and results](experiments/training-profile-2026-09-06/README.md)
+separate localization from optimizer-backed timing and candidate acceptance.
+
+Those records show why both controls matter: all 45 profiled full states match
+bitwise, but short normal timing blocks can still drift badly. Before/after
+normal samples are not interleaved candidate comparisons. Timing-enabled
+contexts also do not reproduce the profiler-disabled production configuration.
+
+The current phase label is the scheduled prefix/suffix around the last loss
+dispatch. Independent gradient seeds can be hoisted into the prefix. Use shader
+direction, `requires_full_precision` and node origins for semantic attribution;
+do not assume everything labeled forward belongs to the undifferentiated graph.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,14 @@ ongoing.
 
 ## September 2026 priorities
 
+The current tuning-foundation milestone is **closed**. The final
+[bounded accumulation attempt](experiments/compensated-dw-2026-09-06/README.md)
+passes 230/240 accuracy rows but fails tiny cancellation cases, so its arithmetic
+change is not retained and split-K promotion is deferred. No conditional
+whole-step cohort follows the failed gate. The next active milestone is
+[paper finalization](../paper/p3hpc/REVISION.md). The engineering tracks below
+are a deferred research backlog, not additional requirements for this freeze.
+
 The [study guide](study/README.md), [audit](audit-2026-09.md) and
 [performance plan](study/performance-plan.md) are the current decision record.
 The detailed tracks below retain earlier motivation and experiment notes;
@@ -19,18 +27,85 @@ still loses to eager MPS. Intel is compared with a labeled CPU fallback.
 See [results](study/results.md) for denominators and numerical gates. Do not
 mix exploratory Inferena history with publication-grade results.
 
-The first state-isolated exact-class search is implemented for the existing
-32/64 scalar-f32 matmul tiles. It is default-off and CPU-validated only;
-cooperative/fused search and whole-step/fleet qualification remain ahead.
+State-isolated exact-class search is implemented for the existing 32/64 scalar
+and legal native-f32 cooperative matmul tiles. It is default-off. Scalar GPU
+qualification passed on RTX 5070; native-f32 hardware and fleet qualification
+remain ahead. A separate harness checks transfer to whole-step time;
+automatic confirmation, f16-input/complex-fusion search and persistence remain open.
 See the [implementation contract](study/performance-plan.md).
+The [five-process synthetic transfer pilot](experiments/tuning-2026-09-05/README.md)
+shows repeatable 1.15×/1.13× whole-step gains on two larger chains, with no
+selection change on two smaller ones. It is not model/fleet qualification.
+
+The subsequent [six-case inference/training holdouts](experiments/holdouts-2026-09-06/README.md)
+retain five processes, full control-session gradients/moments and matched Adam
+updates through step 78. All numerical checks pass, but no whole-step gain or
+regression clears the predeclared guard. The unchanged ResNet control exposes
+timing drift, and only 1/512 of its plan dispatches is eligible for matmul search.
+The [controlled six-process crossover](experiments/crossover-2026-09-06/README.md)
+now confirms the dense chain in both session orientations (median 1.177×),
+but not MLP+Adam; two MLP A/A controls fail the noise screen. ResNet remains
+unchanged, with 98.26–98.65% of search time spent in qualification. A checked
+selection-only swap preserves tensor/optimizer state through role reversal.
+The [readback follow-up](experiments/readback-2026-09-06/README.md) now separates
+qualification's CPU copies/checks from transfer/dispatch/wait, using published
+Blade 0.9/Naga 30 (Rust 1.92). Across six paired processes, read-optimized
+private staging lowers median ResNet search from 606 to 39 ms: CPU readback
+allocation/copy falls from 582 to 2 ms while unchanged validation stays about
+6 ms. All 108 class comparisons qualify and full state is bit-exact through
+Adam step 178. Download becomes the private staging default; Shared remains
+available. Preparation and transfers cost more, and one dense search is slower
+overall; every attempt is retained. This is not a whole-step speed result.
+The [allocation/reuse follow-up](experiments/staging-reuse-2026-09-06/README.md)
+locates that preparation cost in staging allocation and tests one exact-size
+slot retained only within a tuning call. Six process pairs lower median dense
+search 44.01→31.84 ms and MLP 64.27→45.46 ms; ResNet has no reuse opportunity
+and no guarded change. SameSize becomes the option default, with identical
+scratch requests, zero retention at return and all validation intact.
+The [whole-step profiles](experiments/training-profile-2026-09-06/README.md)
+now consistently put 60.66–60.77% of ResNet's instrumented dispatch time in
+backward convolution, and 36.25–40.58% of SmolLM2's in backward attention.
+All 45 profiled full states match, but short-case timing drift is substantial;
+these optimizer-free profiles are not whole-step speedup evidence. The follow-up
+also fixes dX indexing outside same padding and adds full f64 derivative oracles.
+Exact-class scalar convolution-derivative tile selection is now implemented,
+with full NCHW keys, physical scratch sizes, batch-aware references and unchanged
+precision/budgets. The [corrected six-process crossover](experiments/conv-tiles-corrected-2026-09-06/README.md)
+observes ResNet 17.5808→16.7293 ms (median ratio 1.05056×), but all six decisions
+remain inconclusive under the unchanged 5%+noise guard. Four dX classes change
+eight dispatches; the small Adam/SGD chains keep their tiles and make real updates.
+Original malformed flat-layout controls are retained/disqualified; public
+operand checks, full forward oracles and nonzero training preflights prevent
+their zero-data success from becoming evidence. Sampling now dominates search
+cost, and the eight-class structural prior visits only 8/45 ResNet classes.
+The [indexing repair](experiments/conv-indexing-2026-09-06/README.md) replaces
+unsafe f32 reciprocal decomposition with integer division in the shared scalar
+and generated cooperative kernels. Adversarial full forward/dX/dW GPU oracles
+reproduce the old width-41 error and pass at widths/kernel sizes 41/47/55 after
+repair. Four uniforms and the obsolete tuner-only filter are removed, without
+weakening numerical or overflow checks. The separate cost check retains bit-exact
+full states across revisions but observes ResNet 17.55→21.55 ms, about 23% slower.
+Recover that cost with a qualified, reusable exact indexing implementation;
+do not restore approximate addresses. Then add bounded split-K weight gradients,
+reusing SumRows with charged partial storage, complete dispatch-sequence accounting
+and whole-step confirmation;
+attention schedules remain a separate device-qualified family.
+Keep tuning opt-in; do not fit a smaller margin or model rule.
+
+The [checkpoint/memory follow-up](study/checkpoints-and-memory.md) implements
+logical format-3 saves and preflighted restores, lazy Adam/LaProp state, and
+resident tensor-buffer accounting. RTX tests cover malformed late fields,
+different allocation padding, the next optimizer update, and an 8 MiB unused
+moment allocation avoided for 1,048,576 F32 elements. Peak driver memory and
+cross-backend restore behavior still need qualification.
 
 The next sequence is:
 
 1. State-safe tuning, exact variant contracts and stronger numerical evidence.
 2. Bounded bidirectional shape-level search; thresholds become search priors.
 3. Reusable convolution-derivative and Metal attention schedules.
-4. Persistent winners with device/driver/compiler provenance; lazy optimizer
-   state and logical checkpoint serialization.
+4. Persistent winners with device/driver/compiler provenance; fleet/peak-memory
+   qualification of the implemented lazy optimizer and logical checkpoints.
 5. Layout/rematerialization and new precision formats only with an observed
    need, capability support, correctness evidence and an amortization budget.
 
@@ -40,8 +115,9 @@ acceptance and profiles for localization. Cooperative backward is experimental
 and default-off; compensated f16 is not a safe automatic derivative path.
 General dynamic shape replanning is not yet exposed by the session API.
 
-No GPU benchmarking was performed during this audit; measurements below are
-historical and future experiments remain deferred until the device is free.
+The initial audit performed no GPU benchmarking. The user subsequently
+released the device for qualification and experiments. Timings in the older
+tracks below remain historical, not rerun results.
 
 ---
 
@@ -241,9 +317,31 @@ touching the clip path.
 SmolLM2/SmolVLA train, before any code is final — if the win isn't
 real, close the item with a note in `rejected-optimizations.md`.
 
+### B2a. Lazy optimizer state and logical persistence  ← *implemented, RTX qualified*
+
+Keep logical parameter types separate from physical capacities. Format-3
+checkpoints omit padding and validate every record before writes or moment
+allocation. Cache format 5 invalidates plans lacking the metadata. Legacy
+files keep physical/partial-load compatibility with preflighted writes.
+
+Adam/LaProp moments are allocated on first configuration, write, explicit
+step or applicable restore. SGD/F+L+B sessions no longer reserve them; reads
+of uninitialized state return zeros without GPU allocation. Clearing the
+optimizer retains existing state. Memory reports separately count graph,
+moments, accumulators and auxiliary buffers; the previous accumulator total
+incorrectly multiplied by the parameter count. Update, clip and accumulation
+loops use logical lengths; poisoned tails cannot affect optimizer results or
+overrun logical-sized grouped diagnostics. Raw F32 reads are capacity-checked.
+
+**Still open:** driver-peak sampling on larger workloads, Metal↔Vulkan restore
+qualification, structured allocation failures, crash-atomic checkpoint file
+replacement, and a separately designed complete training-loop snapshot.
+See the [contract and tests](study/checkpoints-and-memory.md). This does not
+implement activation rematerialization or reduce Adam's required moment size.
+
 ### B3. [research] E-graph rematerialization (activation checkpointing)
 
-**Problem.** No checkpointing exists; trainable model size is bounded
+**Problem.** No activation checkpointing exists; trainable model size is bounded
 by storing every activation. Classic checkpointing APIs (manual block
 annotations) are against the project's grain.
 
@@ -415,18 +513,20 @@ measured choice among them:
 
 **Landed.** Variant decisions have one owner (`select_variants`) and codegen
 knobs travel as `TuningKnobs` plan data. The September first cut of
-`Session::tune` / `tune_with` measures 32↔64 scalar-f32 tiles per exact eligible
+`Session::tune` / `tune_with` measures scalar and native-f32 cooperative tiles per exact eligible
 class, with private scratch, numerical qualification, interleaved samples and
 explicit budgets/reports. It replaces the earlier family-wide cooperative
 demotion tuner, which ran live steps and mutated training/cache state.
-Default-off, with CPU validation only; real-device qualification remains due.
+Default-off. Scalar correctness/state GPU tests passed on RTX 5070. Native-f32
+shaders pass offline validation; that device cannot qualify their execution.
 
 **Remaining plan.**
 1. *Fleet qualification and whole-step confirmation* before default-on;
    preserve the implemented scratch-state isolation contract.
-2. *Broader exact-class candidates:* cooperative, packed/fused and GEMV
-   implementations need complete precision/padding/binding contracts. The
-   scalar slice does not yet replace their profitability thresholds.
+2. *Broader exact-class candidates:* f16-input cooperative, packed/complex-fused
+   and GEMV implementations need complete precision/padding/binding contracts.
+   Native-f32 matmul already challenges profitability thresholds where its
+   complete candidate fits existing allocations.
 3. *Recompiling knobs:* EPT caps / tile sizes / generated-kernel
    workgroup sizes are plan data now, so a candidate is a plan rebuild
    (~seconds). Bound the space per shape-class (2–4 values per knob).

--- a/docs/study/README.md
+++ b/docs/study/README.md
@@ -1,10 +1,24 @@
 # Meganeura: study and workshop preparation
 
-Prepared 2026-09-05 against development base `bd6be08`, with the audit and
-scalar-tuning follow-up on `codex/audit-observability-tuning`. Performance
-statements refer to the separately frozen
-paper revision, not today's code. No new GPU execution or benchmarking was
-performed for this audit.
+Prepared 2026-09-05 against development base `bd6be08`, subsequently rebased
+onto `8069cf3` with checkpoint/memory work, `a455409` for training holdouts,
+then `230cab0` for controlled crossover confirmation
+on `codex/audit-observability-tuning`.
+Measured sources are retained as `evidence/tuning-2026-09-05`,
+`evidence/holdouts-2026-09-06`, `evidence/crossover-2026-09-06` and
+`evidence/readback-2026-09-06`, `evidence/allocation-profile-2026-09-06` and
+`evidence/staging-reuse-2026-09-06` and `evidence/training-profile-2026-09-06`;
+rebasing does not relabel those measurements as results of newer code. Paper
+performance statements refer to the separately frozen revision. The initial audit was
+CPU-only; subsequent GPU qualification is described separately in the
+[performance plan](performance-plan.md), after the device was released.
+
+The tuning-foundation milestone is now closed. Its final
+[bounded accuracy attempt](../experiments/compensated-dw-2026-09-06/README.md)
+resolved the original fixtures but failed broader tiny cancellation checks
+(230/240 rows qualify). The arithmetic change is not retained; split-K promotion
+is deferred without another performance experiment. The remaining engineering
+roadmap is future research. Paper review, rehearsal and packaging are next.
 
 ## The one-minute explanation
 
@@ -26,9 +40,77 @@ PyTorch replacement.
 The next engineering opportunity is to replace performance thresholds with
 small, reusable, measured searches over legal kernel implementations. That
 means specializing to tensor structure and hardware, not recognizing model
-names. The first implementation now searches two scalar-f32 matmul tile sizes
-in isolated scratch; cooperative/fused search and whole-step confirmation
-remain future work. It has CPU validation, not new GPU performance evidence.
+names. The implementation searches scalar-f32 and legal native-f32 cooperative
+matmul tiles in isolated scratch. Scalar GPU qualification passed; native-f32
+hardware coverage is still due. F16-input/complex-fusion search and persistent
+winners remain future work. The whole-step experiment harness is separate
+from the frozen publication evidence. Its [first five-process experiment](../experiments/tuning-2026-09-05/README.md)
+found repeatable 1.15×/1.13× gains on two synthetic dense chains; two smaller
+cases retained their initial tiles. This is not a new PyTorch comparison.
+
+The [broader five-process holdouts](../experiments/holdouts-2026-09-06/README.md)
+now cover nonlinear inference and optimizer-backed trajectories: full control-
+session gradients/moments and update counts pass, but none of the 30 case runs
+clears the whole-step gain/regression guard. This is why tuning remains opt-in
+and why controlled confirmation and wider kernel-family coverage matter.
+
+The [six-process crossover](../experiments/crossover-2026-09-06/README.md)
+now confirms a median 1.177× dense-chain gain with the selected plan on either
+session. MLP+Adam has no confirmed gain; two untuned/untuned controls are noisy.
+ResNet is unchanged, and its new phase timers put roughly 98% of search time
+in qualification. Read this as a lesson in separating numerical correctness,
+kernel selection, search cost and whole-step acceptance—not as a new paper result.
+
+The [staging follow-up](../experiments/readback-2026-09-06/README.md), on published
+Blade 0.9, separates CPU readback copies from numerical checks and transfer/wait.
+Across six paired processes, ResNet's median total search falls from 606 to
+39 ms: CPU readback allocation/copy falls from 582 to 2 ms, while the same
+validation takes about 6 ms. All 108 comparisons qualify and state remains
+bit-exact through Adam step 178. Private tuning staging now defaults to
+Download, with Shared still available; tuning itself remains opt-in. Added
+preparation/transfer costs and the first slower dense run are retained. This
+is cheaper search on one device, not faster ResNet execution or a Blade-version
+comparison. Development now requires Rust 1.92.
+
+The [allocation/reuse follow-up](../experiments/staging-reuse-2026-09-06/README.md)
+then locates the remaining preparation cost in staging allocation. One exact-size
+buffer now survives between comparisons within a tuning call, never after return.
+Across six paired processes this lowers median dense search 44.01→31.84 ms and
+MLP+Adam 64.27→45.46 ms. ResNet has no reuse opportunity and no guarded change.
+All validation and scratch byte bounds remain intact. This is another search-cost
+result, not a reversal of the earlier inconclusive MLP whole-step result.
+
+The [whole-step localization follow-up](../experiments/training-profile-2026-09-06/README.md)
+prioritizes backward convolution in ResNet and backward attention in SmolLM2.
+All 45 profiled full states match ordinary execution, but short-model timing
+drift and instrumented pass overhead remain visible. These are F+L+B profiles,
+not optimizer-backed or cross-engine speedups. Reviewing convolution then found
+and repaired a non-same-padding dX indexing bug using an independent f64 oracle;
+read [the design lesson](design-decisions.md#9-a-shared-baseline-is-not-an-independent-oracle).
+
+The subsequent [exact-indexing follow-up](../experiments/conv-divisor-2026-09-06/README.md)
+replaces costly integer division with one shared, all-integer reciprocal and
+exact correction. Its full-u32 proof and GPU oracles do not depend on model
+names or special widths. A fresh six-process cohort lowers ResNet F+L+B time
+by only about 2%; most of the preceding correctness-repair cost remains.
+Short-case instability, including two much slower Whisper after-blocks, is
+retained. This is neither a new paper result nor a reason to weaken validation.
+
+The [split-K prototype](../experiments/split-k-2026-09-06/README.md) adds an
+explicit bounded plan transformation: shared scalar dW partials followed by
+existing SumRows. The normal memory planner handles their lifetime. Full f64
+oracles and short optimizer trajectories cover qualified fixtures; a long tiny
+partial fails and remains rejected. The [isolated sequence follow-up](../experiments/split-k-sequence-2026-09-06/README.md)
+now measures both passes with all scratch charged: eight-way splitting gives a
+6.93× synthetic long-reduction ratio, but both profiled large shapes fail
+qualification before timing. Full scans expose control accumulation errors missed
+by sampled dots. No whole-step gain is established, and no live installation or
+default change is made.
+
+The memory/restore follow-up removes unused Adam allocations, reports actual
+resident tensor-buffer requests, and restores logical checkpoints only after
+whole-file preflight. Read the [checkpoint and memory chapter](checkpoints-and-memory.md)
+for the failure boundary, resume limitations and real-device qualification.
 
 ## Reading paths
 
@@ -41,12 +123,14 @@ For a two-hour technical pass, read in this order:
 1. [Architecture](architecture.md): follow one graph all the way to execution.
 2. [Observability and debugging](observability.md): inspect values and plans;
    understand the eager-PyTorch tradeoff and probe limitations.
-3. [Design decisions](design-decisions.md): understand why the design changed.
-4. [Results and evidence](results.md): know exactly what each number means.
-5. [Alternatives](alternatives.md): compare layers and scope, not slogans.
-6. [Performance plan](performance-plan.md): the implemented first slice and
+3. [Checkpoints and memory](checkpoints-and-memory.md): understand state,
+   portable serialization, lazy optimizer allocation and honest memory metrics.
+4. [Design decisions](design-decisions.md): understand why the design changed.
+5. [Results and evidence](results.md): know exactly what each number means.
+6. [Alternatives](alternatives.md): compare layers and scope, not slogans.
+7. [Performance plan](performance-plan.md): the implemented first slice and
    the minimal, general route forward.
-7. [Questions and exercises](p3hpc-questions.md): practice defending the claims.
+8. [Questions and exercises](p3hpc-questions.md): practice defending the claims.
 
 For the engineering backlog, use the [September audit](../audit-2026-09.md).
 For camera-ready work, use the [revision plan](../../paper/p3hpc/REVISION.md)
@@ -64,15 +148,16 @@ and [paper source](../../paper/p3hpc/main.tex).
 | Minimal latency | Small, stateless shapes; the LLM cell is one token without KV cache, not production autoregressive decoding. |
 | Valid | Passes sampled-output/loss and gradient-norm gates; not proof of elementwise gradients or convergence. |
 | Strict f32 | A controlled arithmetic permission contract, not bitwise identity across engines. |
-| Current code | Development base plus audit changes; no newly established performance numbers. |
+| Current code | Rebased audit/tuning/checkpoint/memory changes; qualification and tuning experiments must be distinguished from the frozen model results. |
 
 ## Claims to avoid
 
 Do not say that all Apple/AMD/Intel training is faster, that the paper tests
 an RTX 5080 (it tests a 5070), that equality saturation provides the measured
 speedups, that all kernel choices are autotuned, or that compensated f16
-preserves the exponent range of f32. Do not describe the validation as full
-gradient comparison, the Intel CPU ratios as GPU-to-GPU speedups, or the
+preserves the exponent range of f32. Do not describe the frozen matrix's
+validation as full gradient comparison (the newer control-session holdouts
+are separate), the Intel CPU ratios as GPU-to-GPU speedups, or the
 Quest demonstration as on-device training. LoRA/QLoRA on Apple is not unique
 to Meganeura. Compiler specialization and automatic tuning are established
 ideas; the particular implementation and validity-gated portability evidence

--- a/docs/study/architecture.md
+++ b/docs/study/architecture.md
@@ -37,10 +37,10 @@ lower-level graph/compiler routines can still be exercised without a GPU.
 | [optimize.rs](../../src/optimize.rs), [outline.rs](../../src/outline.rs) | Semantic rewrites; optional e-graph extraction and repeated-region detection. |
 | [compile.rs](../../src/compile.rs), [schedule.rs](../../src/schedule.rs) | Buffer references, dispatches, pointwise/reduction schedules, fusions and barrier grouping. |
 | [codegen.rs](../../src/codegen.rs), [shaders/](../../src/shaders/) | WGSL/Naga modules and parameterized kernel implementations. |
-| [runtime.rs](../../src/runtime.rs) | Hardware discovery, variant selection, pipeline keys, allocation, execution, readback, optimizer and checkpoints. |
+| [runtime.rs](../../src/runtime.rs) | Hardware discovery, variant selection, pipeline keys, allocation, execution, readback and optimizer; checkpoint preflight/serialization lives in [runtime/checkpoint.rs](../../src/runtime/checkpoint.rs). |
 | [memplan.rs](../../src/memplan.rs) | Logical lifetimes, pinned values, physical allocation reuse. |
 | [train.rs](../../src/train.rs), [config.rs](../../src/config.rs), [cache.rs](../../src/cache.rs) | Public build/training workflow, explicit configuration and cached plans. |
-| [Blade](https://github.com/kvark/blade/tree/b208f3b1f97196c2971436b5726e61e71b149c37) | Native GPU API objects, commands, synchronization and allocation semantics. |
+| [Blade 0.9](https://github.com/kvark/blade/tree/866de2c37acbcf1e54c3a21f3213dae4f2f45746) | Native GPU API objects, commands, synchronization and allocation semantics. Published registry dependency, sharing Naga 30 with Meganeura; Rust 1.92 minimum. |
 
 ## 1. What the graph knows
 
@@ -57,6 +57,14 @@ historical name for the project's asymmetric scale-plus-minimum representation
 not a promise of GGML byte-format compatibility. Arithmetic, storage and
 matrix-input precision are separate choices: an f32 tensor can be staged
 through f16 matrix operands while accumulating into f32.
+
+Upstream `230cab0` adds explicit `ProjectionWeights::Q4` arguments to SmolLM2
+prefill/decode builders. Per-layer projections and an untied output head can
+use Q4; embeddings, normalization weights and a tied head remain f32. Custom
+projection K sizes not divisible by 32 fall back to f32. This is a deployment
+storage choice, not a changed model hyperparameter or newly demonstrated
+quantized-training path. The f32 RMSNorm/GEMV fusion excludes packed weights;
+the Q4 and fused-f32 pipeline layouts cannot be combined implicitly.
 
 Views, indexing, broadcasting and materialization are represented through
 specific supported operators, not an unrestricted strided tensor language.
@@ -137,7 +145,7 @@ still real specialization work. "No per-model kernels" must not be shortened
 to "no handcrafted kernels."
 
 Naga parses and validates generated shaders and supplies the representation
-Blade consumes. The pinned implementation uses native extensions including
+Blade consumes. The published Blade 0.9/Naga 30 implementation uses native extensions including
 cooperative matrices: WGSL is an authoring/debugging boundary here, not a
 claim that every shader runs in a standard browser WebGPU implementation.
 
@@ -190,7 +198,7 @@ cross-step/read-modify-write state are pinned as appropriate. Pinning prevents
 alias reuse; it does not require host-visible memory.
 
 Parameters use shared storage. Intermediates, gradients and optimizer state
-can be device-local; the current Blade pin supplies `DeviceTransient` for
+can be device-local; Blade 0.9 supplies `DeviceTransient` for
 that allocation path. Diagnostics and checkpoints use staging when necessary.
 Metal private memory must never be treated as a host pointer. Buffer padding
 must be included in physical allocation and alias-safety reasoning.
@@ -199,8 +207,12 @@ The planner preallocates tensor storage; this is not a guarantee of zero CPU
 heap allocation during a step. Memory-budget checks reserve headroom when a
 budget is available, but cannot prevent another process consuming memory
 after the check. There is no general rematerialization, paging, distributed
-execution or multi-GPU memory planner. Adam state is currently created for
-trainable sessions even when the immediate workload does not need Adam.
+execution or multi-GPU memory planner. Adam/LaProp moments are allocated only
+when configured, explicitly written/stepped, or restored from a checkpoint;
+SGD and forward+loss+backward sessions no longer reserve unused moments.
+Read-only moment inspection returns zeros without allocation. Switching away
+from Adam retains already allocated state. Gradient accumulators are separate,
+and the memory summary counts their actual storage once.
 
 ## 7. Session execution, training and embedding
 
@@ -231,20 +243,29 @@ debug configuration, incomplete post-step anomaly scans and profiler overhead.
 The core uses typed configuration; `from_env` is the explicit environment
 boundary. The semantic build cache stores a pre-runtime plan. Its key includes
 the graph and relevant build configuration, now including rewrite mode, cost,
-cutoff and Winograd policy. Cache format 4 invalidates older entries.
+cutoff and Winograd policy. Cache format 5 also requires retained logical
+parameter types, independent of runtime padding, and invalidates older entries.
 
 This cache is not a persistent performance database. Measured winners need
 stronger device/driver/compiler identity and validation provenance. The current
-opt-in `Session::tune` / `tune_with` searches 32/64 scalar tiles for exact
-eligible dense-f32 classes using private scratch. It never executes the live
+opt-in `Session::tune` / `tune_with` searches 32/64 scalar tiles and legal,
+advertised native-f32 cooperative tiles for exact dense-f32 classes using
+private scratch. Complete candidate geometry/padding must fit the existing
+bindings; capacities and placement are part of the key. It never executes the live
 graph, so it does not advance optimizer, accumulation or KV state. The previous
 family-wide cooperative demotion tuner did execute real steps and was removed.
-Cooperative/fused search, persistent choices and whole-step confirmation remain
-unimplemented. Selection is default-off, and real-device qualification is still
-due. See the [bounded search contract](performance-plan.md).
+F16-input cooperative/complex-fusion search, persistent choices and automatic
+whole-step confirmation remain unimplemented. Selection is default-off; scalar
+GPU qualification passed on the RTX 5070, while native-f32 hardware coverage
+remains due. See the [bounded search contract](performance-plan.md).
 
-Checkpoints serialize current physical buffers, including padding. Load
-validation has improved, but restoring is not transactional and cross-plan
-padding can differ. Stable logical-tensor serialization and validate-all-
-before-write restore are still needed for a robust cross-device deployment
-contract. See the [audit](../audit-2026-09.md) for concrete exit criteria.
+Checkpoint format 3 stores logical shapes/storage types and omits allocation
+padding. All tensors and metadata are validated before mutation or moment
+allocation; malformed late fields cannot partially restore the session.
+Matching logical parameter sets can restore across padding differences, and
+inference validates but ignores saved moments. Formats 1/2 retain their
+legacy physical/partial-load contract with preflighted writes. This is neither
+a complete training-loop snapshot nor rollback after device failure; optimizer
+configuration and accumulation state remain caller-owned. See
+[checkpoints and memory](checkpoints-and-memory.md) for the exact guarantees
+and remaining cross-backend qualification.

--- a/docs/study/checkpoints-and-memory.md
+++ b/docs/study/checkpoints-and-memory.md
@@ -1,0 +1,186 @@
+# Checkpoints, optimizer lifecycle and memory
+
+This chapter describes the September 6 follow-up after rebasing onto `8069cf3`.
+It is current runtime behavior, not a change to the frozen paper experiments.
+The two changes share one principle: a tensor's logical identity must not be
+confused with the buffers currently allocated to execute it.
+
+## What a checkpoint promises
+
+New saves use SafeTensors checkpoint format **3**. A logical manifest records
+each compiled parameter's name, shape and storage type. The payload contains
+only that tensor's data, not backend-dependent allocation padding. Adam and
+LaProp use the same `adam_m.*` / `adam_v.*` tensor names, accompanied by the
+step counter and an explicit list of parameters with saved moments.
+
+F32, F16 and U32 use their actual dtype and logical shape in the SafeTensors
+header. Packed Q4/Q8 remain U8 byte payloads; the manifest distinguishes the
+quantization format and original logical shape. Loading does not silently
+convert storage types or change the numerical contract.
+
+The compiler now retains `ExecutionPlan::param_types` independently of buffer
+capacities. Build-cache format **5** invalidates older cached plans without
+that metadata. Directly constructed plans must supply it to use checkpoints.
+`param_size` reports logical elements, and batched F32 `read_params` omits
+padding. `set_parameter` accepts a logical-sized payload and zero-fills any
+larger destination slot; existing full-slot uploads still work.
+
+Optimizer updates, clipping, accumulation and grouped diagnostics now use
+logical element counts too. Allocation padding is not a gradient: even finite
+nonzero tail data must not affect norms or updates. Tests poison parameter
+and gradient tails independently and compare SGD, Adam, LaProp and CPU
+fallback results with unpadded controls. F32 parameter reads reject other
+storage types, and raw F32 buffer reads reject oversized views before copying.
+
+[Compiler metadata](../../src/compile.rs), [cache](../../src/cache.rs),
+[checkpoint implementation](../../src/runtime/checkpoint.rs)
+
+## Why validate the whole file first?
+
+Previously a valid first tensor could be copied before a malformed later
+moment or step counter was discovered. The caller received an error but had
+already lost the old parameter state. The new boundary is:
+
+```text
+read + parse
+    → validate version, complete logical layout, tensors and step counter
+    → prepare derived-weight CPU staging and check destination compatibility
+    → wait, allocate required moments, reset absent moments
+    → apply tensors with zero padding, restore counter and staging
+```
+
+All validation happens before writes or optimizer allocation. A malformed or
+unreadable file leaves parameters, gradients, moments, counters and moment
+allocation unchanged. This is **preflight failure atomicity**, not rollback
+after a GPU allocation failure or device loss. Backend allocation still has
+panic/failure paths; the memory-budget guard is not a reservation.
+
+Format 3 rejects mismatched parameter sets, same-byte-count wrong shapes,
+wrong dtypes, missing tensors, unexpected tensors, duplicate moment
+declarations, name collisions, bad metadata and unsupported format versions.
+Every declared moment is validated even when the destination is inference
+and will not allocate or use it. A parameter without saved moments starts
+with zero moments: a reused training session does not retain stale values.
+If the destination has no moments and the file supplies none, it stays lazy.
+
+Derived reduced-storage weights have a CPU staging cache used when updating
+one constituent parameter. Restore now refreshes that cache too, preventing
+a later source update from resurrecting another source's pre-load values.
+The cache is reconstructed from the saved reduced-storage values; it cannot
+recover precision discarded before saving.
+
+## Portability and resume limits
+
+Different destination padding is allowed; different named logical parameter
+shapes or storage types are not. Training-to-inference restore works when
+both compiled plans have the same parameter set. This includes materialized
+derived parameters, so it is not arbitrary migration between graphs or
+optimization policies.
+
+Formats 1/2 remain readable with their legacy same-physical-size, partial-load
+contract. All applicable legacy writes are preflighted, but missing parameters
+still warn and remain unchanged. Re-save as format 3 to obtain the new strict
+logical contract. Older Meganeura versions are not forward-compatible format-3
+readers; use the updated loader.
+
+A checkpoint is not a complete training-loop snapshot. It does not save:
+
+- optimizer choice, learning rate, beta/epsilon, decay or per-parameter rates;
+- gradient accumulation contents/window, clipping cadence or diagnostics;
+- inputs, KV state, data-loader position, or application RNG state.
+
+Use a fresh session, configure the same optimizer and training-loop settings,
+and load at an update boundary for a controlled resume. Successful load into
+a reused session leaves accumulation/clip/diagnostic configuration and state
+alone; manage those explicitly. Saving is not yet a crash-atomic file replace.
+Do not confuse persistence checkpoints with activation checkpointing: the
+latter trades backward recomputation for activation memory and remains open.
+
+The RTX qualification deliberately changes allocation capacities while
+retaining logical types, then checks the next Adam update against a control.
+This establishes a cross-padding invariant on one backend, not completed
+Metal↔Vulkan or fleet qualification. Odd F16 tails and Q4/Q8 storage round
+trips are covered; arbitrary import conversion is a separate concern.
+
+## Lazy optimizer state
+
+A trainable graph needs gradients even for forward+loss+backward inspection
+or SGD. It does not need Adam's two moment buffers until an adaptive optimizer
+or explicit state restore requests them.
+
+`set_adam`, `set_laprop`, explicit `adam_step`, moment writes, or a checkpoint
+with applicable moments initialize and zero those buffers once. Initialization
+preserves device-local placement unless debug/no-device-local configuration
+requests shared storage. Runtime optimizer/clip/accumulation kernels require
+F32 trainable parameter storage.
+Read-only `read_adam_m/v` and `read_adam_states` return correctly sized zeros
+before initialization without allocating GPU moments. Saving also stays lazy.
+
+`clear_optimizer` and switching to SGD retain previously allocated moments
+and counters, so switching back does not silently reset training. This is
+allocation on first use, not an allocator that continually shrinks. Gradient
+accumulators are independently lazy and remain allocated when disabled. The
+four-byte clipping scalar still exists for a trainable session; optional
+grouped-gradient diagnostics have their own shared allocation.
+
+For 1,048,576 unpadded F32 trainable elements, two moments require
+`1,048,576 × 4 × 2 = 8,388,608` bytes, or **8 MiB**. A GPU regression verifies
+that this allocation is absent initially and appears exactly once when Adam
+is selected. This saves unused storage in SGD/F+L+B sessions; it does not
+reduce the moments required by an actual Adam run or establish a speedup.
+
+## Read memory reports correctly
+
+| Quantity | Meaning |
+|---|---|
+| `total_buffer_bytes` | Sum of plan buffer capacities before aliasing; includes runtime padding, despite often being labeled “logical.” |
+| `allocated_buffer_bytes` | Graph buffers after aliasing, with minimum allocation sizes; excludes optimizer storage. |
+| `adam_state_bytes` | Actually allocated moment buffer requests; zero before initialization. |
+| `grad_accumulator_bytes` | Each allocated gradient accumulator counted once, not multiplied by the parameter count. |
+| `optimizer_aux_bytes` | Clip scalar and optional grouped-gradient diagnostic buffer. |
+| `total_allocated_bytes()` | Graph + moments + accumulators + auxiliary buffer requests currently held by this session. |
+| `device_local_bytes` | Device-local subset, including resident optimizer buffers but excluding the shared grouped diagnostic buffer. |
+| `device_memory_stats()` | Optional API-reported process usage/budget, broader than the session's tensor buffers. |
+
+The structured profile adds `resident_buffer_bytes`, moments, accumulators
+and auxiliary bytes alongside its existing graph-memory fields. “Resident”
+here describes retained buffer allocation requests, not physical-page
+residency or a driver peak measurement. Staging, pipelines, command buffers,
+driver allocation granularity, other sessions and CPU memory are outside this
+sum. Query API-level statistics separately and use a defined peak-sampling
+protocol before comparing VRAM use with another engine.
+
+[Runtime accounting and lifecycle](../../src/runtime.rs),
+[structured profile](../../src/profiler.rs),
+[observability comparison](observability.md)
+
+## Qualification and rehearsal
+
+The follow-up passed 241 CPU library tests and 85 selected GPU tests on RTX
+5070 / NVIDIA 595.71.05, including eight checkpoint regressions, five
+memory/bounds regressions, four scalar tuning tests and eight training-correctness tests.
+The focused checkpoint/optimizer suites also pass in debug builds with GPU API validation.
+The native-f32 tuner test remains excluded on this f16-tile-only device.
+The train/deploy example decreases loss from 0.693147 to 0.026063 and reloads
+into fresh inference with 8/8 accuracy. These are correctness/accounting
+checks, not a new latency benchmark or large-model convergence study.
+
+CPU-only preflight and cache checks:
+
+```sh
+cargo test --lib
+```
+
+Focused real-device checks (require an available GPU):
+
+```sh
+cargo test --release --test checkpoint_validation --test optimizer_memory -- --test-threads=1
+cargo run --release --example train_deploy
+```
+
+Practice answering: “If the last tensor is wrong, what changed?”, “Can I
+resume halfway through an accumulation window?”, “Why does this file load
+into differently padded inference?”, and “Does the 8 MiB figure mean the
+driver's peak fell by 8 MiB?” The answers are respectively: no checkpoint
+state mutation; not from this snapshot alone; matching logical identity;
+and no, the checked quantity is retained buffer requests.

--- a/docs/study/design-decisions.md
+++ b/docs/study/design-decisions.md
@@ -112,6 +112,10 @@ Large-graph host-memory and allocation hardening followed on August 28
 Blade pin adds the `DeviceTransient` allocation path
 ([`bd6be08`](https://github.com/kvark/meganeura/commit/bd6be08)). None of
 these post-freeze changes can inherit the paper's performance numbers.
+The September 6 migration replaces the git pins with published Blade 0.9,
+blade-macros 0.3 and Naga 30, raises the Rust minimum to 1.92, and restores
+full `cargo package` verification. This closes the registry-dependency gap;
+it is not a new publication or cross-backend performance result.
 
 ## 6. The precision turn: accurate forward was not enough
 
@@ -162,3 +166,54 @@ Do not turn [rejected experiments](../rejected-optimizations.md) into eternal
 prohibitions. Driver versions, shapes, dependency behavior and precision
 contracts change. Retesting needs a reason and a controlled protocol, but an
 old failure is evidence about that experiment, not a proof of impossibility.
+
+## 9. A shared baseline is not an independent oracle
+
+The [September 6 whole-step profiles](../experiments/training-profile-2026-09-06/README.md)
+prioritize convolution derivatives. Reviewing their indexing then uncovered
+a stride-1 dX bug outside same padding. Forward cross-correlation uses
+`ih = oh*stride + kh - padding_h`; inversion requires
+`oh = (ih + padding_h - kh)/stride`, with divisibility/bounds checks. Both
+scalar and generated cooperative paths incorrectly used `kernel_h-1-padding_h`
+while leaving the weight indices unflipped. Width had the same error.
+
+Same padding satisfies `2*padding == kernel-1`, masking this substitution.
+The model profiles' full-state parity therefore passed while a newly added
+unpadded 3×3 f64 oracle failed. The oracle scatters forward contributions
+directly, independently of the kernels' implicit-GEMM gather indexing. Fixing
+the padding expression preserves bindings, geometry, precision and budgets;
+it is not a new performance schedule or a justification to loosen validation.
+
+The regression covers eight shapes, both scalar tiles, full dX/dW and tiny
+upstream derivatives. A separate test requires actual generated cooperative
+execution. On f16-only hardware it uses bounded, exactly representable operands
+to isolate indexing, not to certify f32 derivative range. Native-f32 modules
+validate offline; that is different evidence from native-f32 device execution.
+
+Lesson: full control-session comparisons establish preservation against that
+control, not absolute operator correctness. Independent oracles and unaligned,
+asymmetric, tiny and otherwise uncovered cases are complementary requirements
+before an automatic search can safely choose a faster implementation.
+
+## 10. Exact arithmetic is shared machinery, not a model exception
+
+Replacing floating-point index reciprocals with integer division fixed a
+width-41 batch-boundary error, but added about 23% to a retained ResNet F+L+B
+cohort. The next implementation precomputes `floor(2^32/d)` for each positive
+invariant divisor greater than one, multiplies to obtain the high word, then
+corrects by at most one. A short proof covers all u32 numerators, and a shared
+WGSL implementation uses only 32-bit integer operations. It needs neither
+special widths nor approximate-addressing fallbacks. Division by one is the
+identity; zero is rejected.
+
+This is semantic strength reduction, not a learned performance threshold or
+a new runtime search space. The four derived integer uniforms and their host
+binding work are real costs. Raw-u32 GPU tests exercise the same shared helper;
+full f64 convolution oracles and state-preservation checks remain unchanged.
+The [six-process follow-up](../experiments/conv-divisor-2026-09-06/README.md)
+finds only about 2% lower ResNet step time on RTX 5070, leaving most of the
+earlier regression. Two candidate Whisper after-blocks worsen substantially.
+Retain those observations: exactness, backend profitability, timing stability
+and whole-model generality are separate questions. A growing arithmetic-variant
+menu is not yet justified. Split-K remains a distinct, explicitly budgeted
+dispatch-sequence experiment using the existing SumRows reduction.

--- a/docs/study/observability.md
+++ b/docs/study/observability.md
@@ -8,9 +8,9 @@ dumps, numerical probes and structured profiles. These are real facilities,
 but they are not a Python debugger, an arbitrary backward-hook system, or a
 complete GPU anomaly detector.
 
-This chapter describes current source, including the September scalar-tile
-tuner. It is not a result from the frozen paper. GPU examples below are for
-later: **do not run them while the GPU is reserved by another process.**
+This chapter describes current source, including the September f32-matmul
+tuner. It is not a result from the frozen paper. Run GPU examples only on an
+available device; instrumented/tuning executions can disturb other timings.
 
 ## Compare the debugging models, not just the feature names
 
@@ -227,8 +227,21 @@ backend exposes them, are supporting diagnostics, not a timing model.
 [profiling protocol](../performance-profiling.md),
 [GPU example](../../examples/profile_session.rs)
 
-`MemorySummary` separates logical bytes from actual aliased allocations and
-optimizer state. `device_memory_stats` reports a broader API-level process
+`MemorySummary` separates plan capacities (including padding), graph
+allocations after aliasing, and actually allocated moments, accumulators and
+auxiliary buffers. `total_allocated_bytes()` sums those retained buffer
+requests; structured profiles expose the same total as `resident_buffer_bytes`.
+Lazy moment reads return zeros without creating GPU state, so inspection
+does not turn an SGD/F+L+B session into an Adam-sized allocation.
+F32 parameter reads reject reduced/integer storage instead of reinterpreting
+it, and raw F32 buffer reads check capacity before copying. Bulk parameter
+norm inspection remains F32-only; logical sizes do not imply automatic
+dequantization in every diagnostic API.
+These fields are not a driver allocation or peak measurement. See the
+[checkpoint/memory chapter](checkpoints-and-memory.md) for the field map,
+restore-error guarantees and qualification tests.
+
+`device_memory_stats` reports a broader API-level process
 view; it does not establish system-wide pressure, fragmentation or peak
 allocation history. Compare the same quantity and measurement boundary across
 engines. PyTorch's profiler can record shapes, stacks and memory activity,
@@ -244,22 +257,227 @@ box. Trace bundles can contain model source: review them before sharing.
 
 ## Make autotuning explainable from its first version
 
+Convolution-derivative searches add `TuneOptions.scope` and the optional
+`TuneClass.conv2d` shape. Inspect all twelve NCHW convolution parameters, not
+just M/N/K: dX also has batch in dispatch Z. Scalar convolution tiles appear
+as distinct Small/large shader entries, unlike dense `use_small_tiles`.
+The [convolution crossover](../experiments/conv-tiles-2026-09-06/README.md)
+archives complete before/after dispatches and declared buffer sizes so a
+selection can be traced back to its exact class. Missing historical scope is
+Dense; missing convolution shape means a dense class, not an unknown batch.
+
+Those full dispatch records exposed a vacuous benchmark: the first small-case
+builder supplied nonflat operands to the flat convolution API, producing zero
+forward workgroups. Matching zero gradients/moments had passed the original
+runner. The [corrected cohort](../experiments/conv-tiles-corrected-2026-09-06/README.md)
+rejects zero-workgroup plans, records `prefix_training_signal` and
+`parameters_updated`, and validates nonzero gradients/moments and actual
+parameter changes. Public convolution helpers reject malformed operand shapes
+early; independent tests read full forward outputs as well as derivatives.
+The original twelve controls are retained/disqualified, not overwritten.
+This is an example of observability finding invalid work, not merely locating
+slow work. Full state agreement alone cannot establish workload validity.
+
 `Session::tune_with(TuneOptions)` returns a serializable `TuneReport` rather
-than only logging a winner. Inspect exact `(shader,M,N,K,precision,placement)`
-classes, counts, initial/selected tile, qualification status, raw paired
+than only logging a winner. Inspect exact
+`(shader,M,N,K,precision,binding capacity,placement)` classes, eligible/visited
+counts, incumbent/challenger/selected implementation, qualification status, raw paired
 samples, medians, the noise guard and budget/validation rejection decisions.
-Reports retain resolved options, total/class elapsed time and pipeline setup
+Reports retain resolved options, total/comparison elapsed time and pipeline setup
 time, so a winner's search cost remains visible.
 `serde_json::to_string_pretty(&report)` can preserve the evidence. The selected
 pipeline keys remain visible in `dispatch_pipeline_keys()`.
 
-This initial scalar search never runs a live step or binds live tensors. Its
-scratch data exercises ordinary and tiny nonzero operands, both variants are
+The follow-up prompted by the holdouts adds `TuneOutcome.phase_times`:
+preparation (including pipeline setup and scratch allocation), qualification
+(data/uploads/dispatches/readbacks/CPU checks), warmup (including input reset),
+and the paired sampling loop. These are non-overlapping host wall times, not
+GPU timestamps. `compile_time` is a subset of preparation; do not add it again.
+The original four-phase sum excluded final decision bookkeeping and scratch
+destruction. The allocation follow-up below measures cleanup separately; always
+compare phase sums with total `elapsed` rather than forcing equality.
+An early exit retains partial time for the active phase; an unreached phase
+is `None`. Entire `phase_times` is `None` for historical reports written before
+instrumentation, including the first pilot and six-case holdouts—not zero
+measured cost. The later crossover records contain measured phases.
+
+The readback follow-up adds `qualification_breakdown` within those phases:
+input preparation, CPU upload copy, upload transfer/wait, dispatch/wait,
+readback transfer/wait, CPU allocation/copy from mapped staging, and CPU
+validation. Repeated operations accumulate, early exits retain partial times,
+and absent historical/unreached measurements remain `None`. The enclosing
+qualification timer already contains these costs. Transfer/dispatch fields
+include host encoding/submission and waiting; they are not GPU timestamps.
+CPU validation still scans complete outputs and compares sampled f64 dots.
+`TuneOptions::staging` controls only the one private copy buffer: Shared and
+Download keep its capacity and all candidate bindings/validation unchanged.
+New options default to Download after the measured promotion gates passed;
+missing settings in historical reports still deserialize as Shared. See the
+[separate staging protocol and results](../experiments/readback-2026-09-06/README.md).
+
+There may be two comparisons per class; the second challenges the last accepted
+winner, not necessarily the original heuristic choice. `failure` identifies
+shader rejection or the implementation/input pattern that failed qualification.
+It is not a full numerical discrepancy trace. Native cooperative candidates
+include complete geometry/padding constraints, and unsupported or policy-disabled
+matrix types are never silently substituted by f16 implementations.
+
+This f32 search never runs a live step or binds live tensors. Its
+scratch data exercises ordinary and tiny full-mantissa operands, both variants are
 checked against sampled f64 dots and each other, and the soft deadline includes
 qualification/compilation. These checks do not prove every input or guarantee
 a whole-model win. Choices are session-local, and scratch timing omits normal
 cross-kernel overlap, cache history and surrounding work. See the
-[implementation contract and deferred validation](performance-plan.md).
+[implementation contract and hardware qualification](performance-plan.md).
+
+The [retained transfer experiment](../experiments/tuning-2026-09-05/README.md)
+is a concrete report-reading exercise: compare the three placement-sensitive
+classes, per-class decisions, final pipeline keys, search cost and independent
+whole-step samples. On this RTX 5070 the native-f32 coverage flag is false;
+positive scalar timings cannot be used as evidence for that unexecuted path.
+
+The [optimizer-backed holdout records](../experiments/holdouts-2026-09-06/README.md)
+add full in-memory parameter/gradient/moment comparisons, expected Adam counts,
+loss trajectories, memory-accounting stages and every timing pair. Read their
+ResNet run 3 as a debugging exercise: identical pipeline keys, a 1.071× ratio
+of medians, but only 0.01470 ms median paired gain. The guard rejects the apparent
+gain. This separates “the kernels changed,” “the numerical state matches,”
+and “whole-step time improved.” The retained summaries are not tensor dumps;
+CPU replay checks their consistency, not the absent full vectors. Validation
+readbacks are outside timers, followed by settling steps, and process memory
+samples with both sessions resident are not peak VRAM.
+
+The [predeclared crossover experiment](../experiments/crossover-2026-09-06/README.md)
+adds an untuned/untuned control, balanced session roles and continuous optional
+GPU telemetry. `Session::swap_tuning_with` exchanges complete legal f32 tile
+choices between compatible sessions sharing one GPU context; it does not
+exchange tensor allocations, weights, moments or training age. It preflights
+the entire layout and prepares missing pipelines before changing choices.
+Preparation and waits stay outside timing. On error, choices and tensor state
+are unchanged, although newly prepared pipelines may remain cached. Callers
+must still match inputs, optimizer settings and age. This is an experimental
+control primitive, not a snapshot, persistent tuning profile, or automatic
+whole-step confirmation/rollback feature.
+
+The retained crossover is another report-reading exercise. Dense inference
+passes both role orientations in all six processes (median 1.177×); MLP+Adam
+has four inconclusive outcomes and two noisy A/A controls; ResNet changes no
+selection. Bit-exact state checks through Adam step 178 do not imply a training
+speedup. That cohort localized ResNet's search to qualification (median 538 of
+546 ms), not sampling (7 ms). Its timers still combined CPU checking,
+transfers and GPU work within that phase; they did not prove a readback cause.
+The 250 ms device telemetry is too coarse to describe every short timing pair.
+
+The subsequent Shared/Download cohort provides the narrower diagnosis. On
+Blade 0.9 and the same RTX 5070, median ResNet qualification falls from 598
+to 21 ms. Its CPU mapped-memory-to-vector allocation/copy falls from 582 to
+2 ms, while complete finite/parity scans and sampled f64 checks remain about
+6 ms. Readback transfer/encode/wait actually rises from 0.54 to 2.33 ms, and
+preparation rises from 0.65 to 10.41 ms; total search still falls from 606 to
+39 ms. The raw records retain all six processes, both search orders, every
+check and the first slower dense run. This supports changing the private
+staging policy, not shortening validation, claiming pure GPU transfer timings,
+or inferring physical heap/cache properties. The Metal backend maps Shared
+and Download to the same storage mode; no Metal performance gain is measured.
+
+The [allocation/reuse follow-up](../experiments/staging-reuse-2026-09-06/README.md)
+adds `preparation_breakdown`: checks, pipeline setup, candidate buffer allocation,
+staging management, encoder creation and binding/geometry work. The pipeline
+field is exactly `compile_time`, already within preparation. `phase_times.cleanup`
+measures comparison resource destruction, including early exits. Reused staging's
+last release is `TuneReport::final_cleanup`, inside total search but outside
+comparison times. Release of a previous size belongs to preparation's staging
+management. Historical missing fields remain `None`; never add nested times twice.
+
+`TuneOutcome.scratch` records actual binding/staging requests and reuse status.
+`TuneReport.scratch` counts staging allocations/reuses/releases, peak simultaneous
+scratch requests and bytes retained at return (zero). These are requested bytes,
+not physical heap sizes or driver peak VRAM. One slot is reused only at the same
+exact size within one call. A size change releases it before new scratch
+allocation; candidate bindings/encoders and every validation operation remain
+fresh. `staging_reuse: Fresh` disables reuse, and missing historical options
+still mean Fresh even though new options now default to SameSize.
+
+Six matched processes reduce dense search from median 44.01 to 31.84 ms and
+MLP+Adam from 64.27 to 45.46 ms. Staging allocations fall 3→1 and 5→2; ResNet
+stays at one. All 108 comparisons qualify with bit-exact state checks through
+Adam step 178 and equal scratch requests. No validation or qualification gain
+guard passes: the improvement is allocation/cleanup, not fewer numerical checks.
+Read the retained first dense slowdown and the ResNet search-order reversal
+before interpreting medians; ResNet passes no gain/regression guard, which
+does not establish zero harm. No whole-step or fleet speedup was measured.
+
+## Profiled-state parity is not stationary timing or an independent oracle
+
+The [whole-step localization runner](../experiments/training-profile-2026-09-06/README.md)
+profiles synthetic ResNet, SmolLM2 and Whisper F+L+B without optimizer/clip
+passes. It compares every retained profiled full state before the collector's
+two ordinary ring-advance steps overwrite it; readbacks use separate encoders,
+outside the retained wall timer. The GPU regression checks this callback order
+and exact timestamp counts. All 45 captured full states match bitwise.
+
+Normal timing blocks still drift: Whisper's first after-block median is nearly
+twice its before-block median. Profiled/normal wall ratios are retained, not
+silently treated as normal step times. Readback interruptions and timestamp
+passes can perturb execution; coarse telemetry does not identify the cause.
+The phase label is the scheduled prefix/suffix at the last loss dispatch, so
+independent gradient seeds may appear in the prefix. Use shader direction and
+origins as well as the phase label.
+
+Source inspection then found a non-same-padding convolution dX bug that both
+control and profiled paths shared. A direct f64 scatter oracle exposed it;
+the scalar and cooperative generators are now fixed. Read the
+[design lesson](design-decisions.md#9-a-shared-baseline-is-not-an-independent-oracle):
+observability helps find where to look, but neither exact same-engine parity
+nor a complete timing trace proves the underlying derivative is correct.
+
+The [indexing cost check](../experiments/conv-indexing-2026-09-06/README.md)
+adds optional full-state SHA-256 digests to the existing profiling runner. Sorted
+tensor names, lengths and f32 bits, plus optimizer counter/allocation, make
+source-to-source parity checks possible without archiving model tensors. Hashing
+and all readbacks stay outside step timers. A digest checks identity, not
+correctness: both implementations could still share an address error. Here the
+independent f64 oracle first reproduced a width-41 dW error; the shared integer
+indexing repair then passes all full-output regressions. Raw digests cannot
+replace missing vectors for numerical reanalysis.
+
+The [split-K plan prototype](../experiments/split-k-2026-09-06/README.md) makes
+another distinction visible: one logical dW now has a partial producer and a
+SumRows consumer. Both retain its origin; labels identify the two passes. The
+logical node still reads the **final** gradient. To inspect partials, retain a
+diagnostic `no_alias` plan and read its producer output buffer after completion;
+ordinary alias reuse can overwrite that temporary later in the step. Do not
+treat its buffer index as a persistent graph-node identity. CPU/GPU profiling
+must include the final reduction even though its family is not convolution.
+Independent f64 checks exposed a long tiny-gradient partial error that final
+gradient parity alone would miss. That partition count remains unqualified;
+observing a plausible final tensor does not make every intermediate correct.
+
+`Session::measure_conv_weight_splits` now returns ordinary TuneReports for an
+explicit class without installing a choice. Read `candidate_split_k` as well as
+the tile: baseline/challenger tile fields are identical, but the challenger has
+two passes. `FasterCandidate` describes that isolated comparison, not a live-plan
+change. Scratch bindings are upstream/input/**final output**/partials, with the
+largest binding charged again for staging; the last buffer is no longer implicitly
+the final result. Timed repetitions include both passes and their barrier.
+
+The [retained cohort](../experiments/split-k-sequence-2026-09-06/README.md) contains
+32 rejections with no warmup/sampling observations, not zero-cost measurements.
+Full f64 scans expose two control errors that sampled dots missed. A subsequent
+CPU FMA diagnostic reproduces those GPU bits, separating accumulation error from
+addressing error. Future generic failure messages also identify the variant;
+the four older pointwise two-way records lack that attribution and stay unchanged.
+The pointwise probe spends about three seconds in CPU validation before rejecting:
+the phase breakdown prevents mistaking this for a return of the old readback-copy
+bottleneck. Full-vector checks are executed but vectors are not archived; replay
+cannot retrospectively change their tolerance or inspect an unrecorded element.
+
+The [bounded accumulation reporting test](../experiments/compensated-dw-2026-09-06/README.md)
+illustrates another distinction: a successful test process means all declared
+rows were recorded, not that the candidate qualified. Read JSON `status`, the
+`qualified` count and each row's errors. Its 230/240 pass count still means
+rejection, and no performance samples are collected. The failed candidate's
+source tag remains separate from the active, unchanged arithmetic.
 
 ## What we should improve next
 

--- a/docs/study/p3hpc-questions.md
+++ b/docs/study/p3hpc-questions.md
@@ -124,15 +124,33 @@ extend the relevant physical/lifetime contract.
 
 ### 12. How much autotuning exists now?
 
-Short: a new opt-in exact-shape search over two scalar-f32 matmul tiles, using
-private scratch. CPU-validated implementation, not yet GPU-qualified results.
+Short: an opt-in exact-shape search over scalar and legal native-f32
+cooperative matmul tiles, using private scratch. Scalar GPU qualification has
+passed; this is new engineering, not part of the frozen paper's results.
 
-Detail: both sizes can win regardless of the initial occupancy threshold;
+Detail: legal implementations can win regardless of the initial occupancy or
+native-8 large-shape profitability threshold;
 qualification, paired samples, a noise guard and resource bounds are explicit.
-It replaces the state-mutating family demotion tuner. Cooperative/fused/GEMV
-search, persistent winners and whole-step confirmation remain future work.
+It replaces the state-mutating family demotion tuner. Native padding must fit
+existing allocations. F16-input/complex-fusion/GEMV search, persistent winners
+and automatic whole-step confirmation remain future work. Native-f32 GPU
+qualification needs a different device: our RTX 5070 advertises f16 tiles only.
 Capability probing is named `auto_tune` but does not time kernels. Neither
 this new search nor new speedups are part of the frozen paper evidence.
+
+The [separate five-process transfer pilot](../experiments/tuning-2026-09-05/README.md)
+shows 1.15×/1.13× whole-step gains on two synthetic chains and unchanged choices
+on two smaller ones. Search amortizes over roughly 1,600–2,850 steps in the
+winning cases; do not turn that into a general model or PyTorch claim.
+
+The [six-case holdouts](../experiments/holdouts-2026-09-06/README.md) then tested
+inference, Adam, SGD and F+L+B across five processes. All full control-session
+tensor/state comparisons passed through step 78, but none cleared the whole-step
+guard. An unchanged ResNet control even showed a misleading 1.071× ratio of
+medians, rejected by the paired-gain gate. The honest conclusion is stronger
+state evidence and limited transfer, not “automatic tuning makes training
+faster.” More representative kernel families and controlled confirmation come
+before default-on or persistent winners.
 
 ## Numerical behavior
 
@@ -326,6 +344,263 @@ execution. Reset state for the timestamp-ring advance runs too. The structured
 collector cannot assign appended optimizer passes to graph metadata, so capture
 without those passes and time full optimizer-backed training separately.
 Likewise, the new tuner's isolated scratch result needs whole-step confirmation.
+
+### 32. Can a bad checkpoint corrupt a running session, and is it portable?
+
+Short: format 3 validates the entire logical restore before writing anything.
+Matching parameter names, shapes and storage types can use different padding.
+
+Detail: malformed files leave parameters, gradients, moments and counters
+unchanged and do not allocate moments. This is not rollback after device loss
+or allocation failure. Training-to-inference validates and ignores moments;
+legacy files retain partial-load behavior. Optimizer configuration, in-flight
+accumulation windows, clipping cadence and application RNG are not saved.
+Cross-padding GPU tests pass; cross-backend qualification is still due.
+
+### 33. What memory did lazy optimizer state actually save?
+
+Short: two unused F32 moment buffers: 8 MiB for the tested 1,048,576-element
+parameter. Adam itself still needs that storage when selected.
+
+Detail: the regression checks retained buffer allocation requests, not peak
+driver VRAM. Graph buffers, moments, accumulators and diagnostics are reported
+separately; staging and driver objects are outside that sum. Reads of
+uninitialized moments return zeros without allocating; clearing the optimizer
+retains initialized state for later reuse. See
+[checkpoint and memory contracts](checkpoints-and-memory.md).
+
+### 34. How do you distinguish a tuning gain from a lucky session or timing drift?
+
+Short: compare untuned sessions first, then reverse which session owns the
+selected kernels while keeping buffers and training history in place.
+
+Detail: the new six-process experiment uses four symmetric crossover blocks
+and balanced starting roles. It requires a quiet A/A control and the same
+5% + twice-MAD guard in both orientations and pooled pairs. Dense inference
+passes all six processes (median 1.177×); MLP+Adam has four inconclusive results
+and two unstable controls; ResNet never changes selection. Keep every attempt.
+This is descriptive counterbalancing, not randomized causal proof or a
+confidence interval. A/A runs before search only, and telemetry is coarse.
+
+### 35. Why can search be expensive when the candidate kernels are fast?
+
+Short: correctness qualification, transfers and host work cost time too.
+
+Detail: the first phase profile put 98% of ResNet's search in qualification.
+The follow-up separates CPU work and transfer/dispatch/wait, then changes
+only the private staging allocation. With Blade 0.9 on RTX 5070, median CPU
+readback allocation/copy falls from 582 to 2 ms; unchanged CPU validation
+still takes about 6 ms. Total search falls from 606 to 39 ms despite increased
+preparation and transfer costs. Keep the ordinary/tiny patterns, full scans
+and sampled f64 checks: they were not the dominant cost. See the
+[six-process protocol and results](../experiments/readback-2026-09-06/README.md).
+
+### 36. Does read-optimized staging mean faster kernels or faster ResNet?
+
+Short: neither. It means cheaper kernel search on the tested device.
+
+Detail: candidate code, bindings, precision and selection guards are identical.
+Download is the default for one private upload/readback buffer, not the live
+model's allocations. All 108 comparisons qualify, with bit-exact state checks
+through Adam step 178; continuation was untimed. Both arms used Blade 0.9,
+so this is not a Blade-version benchmark either. The original Shared option
+remains available and tuning remains opt-in. Source policies differ on Vulkan,
+but Shared and Download map to the same Metal storage mode; fleet performance
+and automatic whole-step confirmation are still open.
+
+### 37. What exactly is reused, and can it change validation or the memory budget?
+
+Short: one private staging allocation, at the same exact size, within one
+tuning call. Not model buffers, qualified outputs, inputs or selected winners.
+
+Detail: a size change releases the old buffer before allocation; all binding
+buffers and encoders remain fresh. Every ordinary/tiny input upload, NaN poison,
+readback, finite/parity scan and sampled f64 check still runs. Full simultaneous
+requests count against the same byte cap, and nothing is retained on return.
+Reports expose allocation/reuse/release counts and both comparison/final cleanup.
+Six process pairs reduce dense and MLP search costs by median paired ratios
+1.378× and 1.414×, with bit-exact state checks through Adam step 178. Tuning
+remains opt-in; these are not model or cross-engine gains.
+
+### 38. Why does a no-reuse control still show timing differences?
+
+Short: equal implementations do not guarantee equal observed times.
+
+Detail: ResNet uses one allocation in each arm. Fresh-first process ratios have
+median 1.105×; reuse-first ratios have median 0.914×. All six are retained,
+and the overall gain/regression guards both reject a claim. Even the ratio of
+cost medians (0.981×) and median process ratio (1.007×) differ in direction.
+Balanced order is a control, not proof of constant clocks or causal isolation;
+the 250 ms telemetry cannot explain every short operation. See the
+[complete resource protocol and results](../experiments/staging-reuse-2026-09-06/README.md).
+
+### 39. Can all full-state comparisons pass while a gradient is still wrong?
+
+Short: yes, if both executions share a bug or the cases miss its domain.
+
+Detail: the new profiler preserved all 45 full states exactly. Reviewing the
+convolution family still found dX using the wrong padding outside same padding.
+A direct f64 oracle failed where same-padding models could not expose the
+error. Both scalar and generated cooperative indexing are fixed, with full
+odd/asymmetric/batched/tiny derivative checks. Control-session parity measures
+preservation; an independent oracle addresses correctness. Neither replaces
+domain coverage or convergence evidence.
+
+### 40. What do the new whole-step profiles justify doing next?
+
+Short: broaden reusable derivative implementations and measured selection,
+not the matmul search budget or the numerical tolerance.
+
+Detail: ResNet backward convolution accounts for 60.66–60.77% of instrumented
+dispatch time; SmolLM2 backward attention accounts for 36.25–40.58%. A long
+weight-gradient reduction with ten output workgroups motivates testing split-K
+with charged temporary storage. These are F+L+B-only RTX profiles, not optimizer
+or Metal evidence. Intrusive pass timing and substantial short-case drift mean
+the shares are localization evidence, not guaranteed whole-step speedup bounds.
+Exact convolution classes/qualification now cover the existing scalar
+tiles; accept any new schedule only after independent edge tests and matched
+whole-step confirmation. [Protocol and limitations](../experiments/training-profile-2026-09-06/README.md).
+
+### 41. Why isn't convolution tuning just another M/N/K lookup?
+
+Short: equal contraction dimensions can gather different physical tensors.
+
+Detail: dX uses M=Ci, N=H×W, K=Co×Kh×Kw, with one dispatch plane per batch;
+dW uses M=Co, N=Ci×Kh×Kw, K=batch×Oh×Ow. Kernel aspect ratio, stride and both
+padding dimensions affect addresses even when M/N/K match. Our exact key
+records all of them, plus precision, binding capacity and placement. Scratch
+is physical NCHW data, not an im2col allocation. The existing two scalar tiles
+share one bounded runner and unchanged decision guard; new options expose
+Dense, ConvDerivatives and All scopes. No model name enters selection.
+
+### 42. What does convolution qualification prove, and what doesn't it?
+
+Short: structural legality and numerical testing are separate checks.
+
+Detail: checked extents prevent index overflow, and shared convolution kernels
+now decompose indices with exact integer arithmetic. The earlier reciprocal-domain
+filter only excluded unsafe shapes from tuning; it did not fix ordinary execution.
+Both variants must still produce finite, matching full
+outputs on ordinary/tiny synthetic inputs and match 32 f64 contractions,
+including dX batch edges. Separate full f64 scatter oracles cover padding,
+stride and tile edges. Shared bugs, untested domains and convergence still
+require independent evidence. A qualified isolated winner is not automatically
+a whole-step win. [Contract and experiment](../experiments/conv-tiles-2026-09-06/README.md).
+
+### 43. Can two bit-exact training sessions still be an invalid benchmark?
+
+Short: yes—matching zeros and advancing a counter do not prove useful work.
+
+Detail: the first small convolution-chain builder supplied 4-D operands to
+an API documented for flat NCHW arrays. Its first forward dispatch had zero
+workgroups. Both sessions agreed on zero loss, gradients and Adam moments,
+so the original comparisons passed. We retained/disqualified those twelve
+cases, corrected the builder, added early operand rejection and full forward
+oracles, and required nonzero prefix signals plus actual parameter changes.
+The corrected six-process cohort passes these checks. This is why workload
+validity, independent correctness, state preservation and performance are
+separate gates. [Correction and archive](../experiments/conv-tiles-corrected-2026-09-06/README.md).
+
+### 44. Did convolution autotuning win?
+
+Short: four isolated dX classes win; whole-step confirmation remains inconclusive.
+
+Detail: eight ResNet dispatches change from scalar 64 to 32 tiles in every
+corrected process. The median whole-step ratio is 1.05056×, with observed
+time reductions 4.60–4.85%. That is below our 5% requirement even before the
+noise margin. All six A/A screens pass, but no confirmed gain follows. The
+small Adam/SGD chains make real updates and retain their starting tiles.
+The eight-class structural budget visits only 8/45 ResNet derivative classes;
+it is not a measured cost ranking. The next experiment is bounded split-K dW
+with charged partial storage/reduction and explicit search coverage, not a
+lower threshold or an unconditional performance claim.
+Ordinary convolution indexing is now repaired separately: exact integer arithmetic
+replaces unsafe float reciprocal multiplication, with full adversarial GPU oracles.
+
+### 45. How does exact indexing fit a minimal, general engine?
+
+Short: fix the shared arithmetic, not individual shapes.
+
+Detail: the old f32 reciprocal mapped 41/41 to zero, selecting the wrong batch
+in a weight gradient. Exact division repaired this across scalar and generated
+convolution kernels and removed the tuner-only interval filter. Its retained
+cost check increased ResNet F+L+B from about 17.55 to 21.55 ms.
+
+The follow-up uses an **integer** reciprocal: for `d > 1`, precompute
+`m = floor(2^32/d)`, take the high word of `n*m`, and increment if the remainder
+is still at least `d`. The estimate is at most one low for every u32 numerator;
+`d = 1` returns `n`. One shared WGSL helper and four derived u32 uniforms serve
+all convolution directions. No float addressing, width exceptions or new tuning
+knob is needed. GPU raw-u32 checks and full f64 forward/dX/dW oracles pass.
+
+A new six-process RTX cohort shows only about 2% lower ResNet F+L+B time, with
+bit-identical full states. Most of the old cost remains, and short-case drift
+prevents a no-regression claim. A correctness proof does not prove profitability;
+this local comparison is not a new PyTorch result or paired-MAD tuning decision.
+[Repair](../experiments/conv-indexing-2026-09-06/README.md),
+[proof and follow-up measurements](../experiments/conv-divisor-2026-09-06/README.md).
+
+### 46. Why isn't split-K just another tile size?
+
+Short: it changes both the reduction order and the execution plan.
+
+Detail: splitting a long contraction creates more independent workgroups, but
+also writes partial results and launches a reduction before consumers run.
+Those bytes, barriers and dispatch costs belong to the candidate. The explicit
+prototype now partitions the existing scalar dW template into `[split,M,N]`
+partials and uses existing f32 SumRows to write the original gradient. It runs
+as a plan transformation before allocation, with an all-or-nothing logical-byte
+cap; ordinary scheduling and memory reuse handle the intermediate lifetime.
+Labels/origins preserve attribution, but profiling only the convolution family
+would miss the final generic reduction.
+
+Full independent f64 partial/final oracles and short SGD/Adam trajectories test
+the sequence. A long tiny-gradient three-way partial fails the unchanged accuracy
+gate even though its final gradient passes: it remains unqualified. The live
+tile search still cannot change allocation layouts. Explicit bounded sequence
+probes now reuse its scratch, timers and decision guard without installing a
+choice. A four-process cohort finds an isolated 6.93× eight-way gain on the
+synthetic long case, including SumRows, but both profiled large shapes reject
+before timing. No whole-step training gain is established; defaults are unchanged.
+[Prototype](../experiments/split-k-2026-09-06/README.md),
+[sequence measurements](../experiments/split-k-sequence-2026-09-06/README.md).
+
+### 47. How can the unsplit f32 control fail qualification?
+
+Short: f32 arithmetic does not guarantee a fixed error bound for every long sum.
+
+Detail: two long dW control elements pass the sampled checks but fail the full
+f64 scan, one on ordinary and one on tiny inputs. Independent input-coordinate
+scatter with sequential CPU f32 FMA reproduces their GPU bits exactly. These
+particular failures are accumulation rounding, not an integer-indexing discrepancy.
+We retain the rejections and collect no timings for those comparisons.
+
+The earlier three-way partial failure and a later pass on different synthetic
+inputs of the same shape also coexist. “Qualified” means the executed tests
+passed, not that every possible gradient is covered. Stronger shared accumulation
+and broader input coverage come before training promotion; loosening tolerances
+or claiming two same-order scalar tiles are independent references would not
+resolve this. The probe's full validation can cost seconds, so its cost is reported
+separately from sequence timing. [Evidence and limits](../experiments/split-k-sequence-2026-09-06/README.md).
+
+### 48. Why stop after a mostly successful accuracy improvement?
+
+Short: the acceptance rule was declared before the test, and a deferred feature
+is a valid outcome.
+
+Detail: summing 16-term tiles locally and compensating their outer sum fixes
+the known control and partial failures. But only 230/240 broader rows qualify;
+long tiny cancellation inputs fail for both tiles and every tested count.
+A CPU reproduction confirms the reported error even with compensated outer
+addition. That step cannot recover rounding already lost within the tile.
+
+We remove the unqualified arithmetic, retain the source and rejection evidence,
+and defer split-K promotion without a whole-step benchmark. We do not add a
+shape exception, relax the gate, or turn the next possible algorithm into another
+mandatory deadline item. The tuning foundation is useful without universal
+kernel coverage. This closes the engineering milestone and lets paper review
+proceed; it does not prove split-K can never succeed.
+[Decision and evidence](../experiments/compensated-dw-2026-09-06/README.md).
 
 ## Talk outline
 

--- a/docs/study/performance-plan.md
+++ b/docs/study/performance-plan.md
@@ -1,9 +1,41 @@
 # How to win while staying general
 
-This separates the implemented first slice from the remaining engineering and
-experiment plan. It is not a claim of new speedups. No GPU work was run during
-the September audit or this follow-up. Do not execute the GPU portions until
-the user releases the busy device.
+## Current milestone: closed; split-K promotion deferred
+
+The author agreed to close this phase after one shared long-reduction accuracy
+attempt and, only if it qualifies, one predeclared whole-step acceptance cohort.
+The [bounded experiment](../experiments/compensated-dw-2026-09-06/README.md)
+completed: compensated tile accumulation passes 230/240 rows, but fails the
+long tiny cancellation fixture. Its production change is removed and split-K
+promotion is deferred. The conditional whole-step cohort is not run. This closes
+the milestone without changing tolerances or pretending every research question
+is solved.
+The broader priorities below are a research backlog, not prerequisites for this
+freeze or the accepted paper. Attention, persistent tuning, new precision and
+layout search belong to a later phase. The next active task is paper finalization,
+starting with the author's actual reviews and technical read-through.
+
+This separates the implemented search from the remaining engineering and
+experiment plan. The initial September audit was CPU-only. After the user
+released the GPU, the scalar search passed device qualification on an RTX
+5070 (driver 595.71.05). This does not establish a performance improvement or
+native-f32 cooperative coverage; that device advertises only f16 matrix tiles.
+New tuning experiments are separate from the frozen paper evidence.
+
+The [first whole-step transfer experiment](../experiments/tuning-2026-09-05/README.md)
+now retains five independent processes: two of four synthetic dense chains
+improved by median 1.151× and 1.127×, while the two smaller cases kept their
+initial tiles and showed no benefit. All outputs matched their untuned
+references exactly. This is scoped Meganeura-versus-Meganeura evidence, not a
+PyTorch or model-training result; search amortization takes thousands of steps.
+
+The [six-case holdout follow-up](../experiments/holdouts-2026-09-06/README.md)
+now includes nonlinear MLP/SmolLM2 inference, Adam trajectories, Whisper SGD
+and ResNet F+L+B. All 30 case runs pass full control-session tensor/state parity,
+but **none clears the whole-step guard**. Median ratios range from 0.977× for
+MLP Adam to 1.052× for MLP inference. These are synthetic engineering results,
+not new cross-engine or convergence evidence. This limits the pilot's scope;
+it does not justify default-on tuning or lowering the threshold.
 
 ## The objective
 
@@ -25,9 +57,12 @@ selection are complementary work.
 Graph construction helpers, autodiff, greedy fusion, shader specialization,
 scheduling, allocation aliases and device capability selection already work.
 Measured tuning is optional. The September follow-up replaces the old
-family-wide cooperative demotion tuner with bounded exact-class scalar-tile
-search. Cooperative selection still uses heuristics and is outside this first
-search space. Winners are not persisted. The misleadingly named
+family-wide cooperative demotion tuner with bounded exact-class f32-matmul
+search. Scalar 32/64 tiles and advertised, smoke-tested native-f32 cooperative
+tiles can compete. Cooperative occupancy and native-8 large-shape thresholds
+choose the initial implementation, not the legal challengers in this domain.
+Scalar convolution dX/dW now also expose their existing 32/64 tiles to this
+bounded search. Other kernel families still use heuristics. Winners are not persisted. The misleadingly named
 `runtime::auto_tune` is capability probing.
 
 The CPU-only shape census now exposes the amount of repeated work. A full
@@ -48,7 +83,7 @@ The diagnostic's old fixed barrier-cost estimate was removed. The absence of
 matches in its narrow legacy fusion matcher does not establish absence of
 optimization opportunities.
 
-## Implemented first slice: scalar-f32 tile search
+## Implemented search: dense tiles and scalar convolution derivatives
 
 `Session::tune()` uses defaults; `Session::tune_with(TuneOptions)` returns a
 serializable `TuneReport`. `SessionConfig { tune: true }` invokes the safe
@@ -64,25 +99,91 @@ behind as a second unsafe default path.
 
 | Contract | Current implementation |
 |---|---|
-| Search space | Existing 32×32 and 64×64 scalar-f32 implementations of plain MatMul, MatMulAT, MatMulBT and forward MatMul+Add. |
-| Eligibility | Contiguous row-major f32; fixed supported binding arity; nonzero checked extents; portable workgroup limits; non-overlapping physical bindings. No cooperative, GEMV, horizontal packs, arbitrary prologues/epilogues or reduced storage. |
-| Exact class | Entry/direction, M/N/K, derivative precision requirement and A/B/addend/output placement. Different initial tile choices are separate searches. No device-to-device transfer. |
-| Complete candidate | Exact pipeline key and recalculated X/Y/Z geometry; unchanged logical extents, input/output bindings, access sets and allocation plan. Lazy compilation supplies a missing tile pipeline; no fallback lookup during trials. |
-| State isolation | Private per-class scratch and command encoder. No `Session::step`, no live tensor bindings, no reads/writes of model state. Matching Shared/DeviceTransient placement, with bounded upload/readback staging. |
-| Qualification | Two deterministic signed, nonzero patterns: ordinary magnitudes and tiny `1e-12` A/addend operands. Full finite-output and cross-variant comparisons; 32 f64 reference dots including edge/tile boundaries. NaN output initialization detects unwritten elements. |
+| Search space | Existing 32×32 and 64×64 scalar-f32 implementations, plus the device's native-f32 cooperative 8×8 or 16×16 primitive (2×2 output primitives/workgroup), for plain MatMul, MatMulAT, MatMulBT and forward MatMul+Add. Scalar tiles also cover convolution dX/dW, as detailed below. |
+| Eligibility | Contiguous row-major f32; fixed supported binding arity; nonzero checked extents; portable workgroup limits; non-overlapping physical bindings. Cooperative candidates honor session policy, capability/smoke tests and existing binding capacity. No f16-input/compensated cooperative, GEMV, horizontal packs, arbitrary prologues/epilogues or reduced storage. |
+| Exact class | Entry/direction, M/N/K, derivative precision requirement, declared binding capacities and A/B/addend/output placement. Different initial choices are separate searches. No device-to-device transfer. |
+| Complete candidate | Exact pipeline key, variant flags, scalar fallback and recalculated X/Y/Z geometry together; cooperative and scalar axes differ. Logical extents, bindings, access sets and allocation plan stay fixed. Lazy shader rejection is reported; no fallback lookup during trials. |
+| State isolation | Private per-class scratch and command encoder. No `Session::step`, no live tensor bindings, no reads/writes of model state. Matching Shared/DeviceTransient bindings, with one bounded upload/readback buffer: Download by default, Shared as an explicit control. |
+| Qualification | Two deterministic signed, nonzero, full-mantissa patterns: ordinary magnitudes and tiny `1e-12` A/addend operands. Full logical-output finite and cross-variant comparisons; 32 f64 reference dots including 8/16/32/64 tile edges. Scratch padding is zeroed for inputs and NaN-poisoned for outputs; only logical outputs are checked. |
 | Numerical tolerance | `abs(reference-actual) <= scale*1e-5 + abs(reference)*2e-4`, with scale 1 or `1e-12`. A domain-specific screen, not a proof or training convergence test. |
 | Timing | Default six complete pairs, alternating AB/BA order; each sample encodes/submits/waits for 16 barrier-delimited repeated dispatches. Upload/qualification/readback excluded from samples, included in total cost. |
-| Decision | Candidate median and median paired gain must beat a 5% margin plus twice the MAD of paired differences. Noise guard is not a confidence interval. Invalid or incomplete evidence keeps the original tile. |
+| Decision | Up to two sequential challenger comparisons per class. Each uses the last accepted winner as incumbent. Candidate median and median paired gain must beat a 5% margin plus twice the MAD of paired differences. Noise guard is not a confidence interval. Invalid/incomplete comparisons retain the incumbent, including a completed earlier winner. |
 | Budget | Default eight classes, 64 MiB GPU scratch including staging, two-second soft total deadline, one warmup per variant. An in-flight driver/validation/submission operation can overrun. Pipeline/CPU memory is not charged to the scratch byte cap. |
-| Priority/reporting | Descending repetition×M×N×K structural prior, stable ties; report resolved settings, total/class/pipeline setup costs, exclusions, scratch/time/device-memory skips, qualification and raw timings. This prior orders searches, never declares a winner. |
+| Priority/reporting | Descending repetition×M×N×K×Z structural prior (Z is batch for dX, otherwise 1), stable ties; resolved settings, eligible/visited classes, per-comparison and pipeline costs, exclusions, scratch/time/device-memory skips, qualification/rejection details and raw timings. This prior orders searches, never declares a winner. |
 | Lifetime | Choices affect this session only. Semantic plan cache and frozen results stay untouched. |
+
+The dense contract above now extends to scalar NCHW convolution dX/dW, with
+`TuneScope::{Dense, ConvDerivatives, All}` selecting the experiment domain.
+New options use All; tuning remains default-off. Old missing scope settings
+deserialize as Dense, and historical runners explicitly keep Dense.
+
+`TuneClass.conv2d` records all twelve convolution parameters. Equal M/N/K is
+not enough: kernel aspect ratio, stride and padding change gathered values,
+and batch changes physical NCHW storage. dX uses M=Ci, N=H×W,
+K=Co×Kh×Kw and Z=batch; dW uses M=Co, N=Ci×Kh×Kw, K=batch×Oh×Ow and Z=1.
+Priority includes Z, and scratch/readback sizes use physical tensors without
+allocating im2col. Tile choices change the distinct Small/large shader entry
+and geometry together; dense `use_small_tiles` is not a convolution flag.
+
+Both scalar variants retain f32 arithmetic. The full finite/cross-variant
+scans include all dX batches, while the 32 f64 dots use convolution indexing
+and explicit first/last/scattered batches. Checked integer products and signed
+coordinates and padded K loops reject overflow. Convolution now decomposes
+indices using exact integer arithmetic, including ordinary forward/cooperative
+paths outside the tuner. The earlier f32 reciprocal interval filter and its four
+float uniforms were removed. A subsequent shared helper uses four derived u32
+multipliers with an exact, single remainder correction; it covers every u32
+numerator and positive divisor, not a narrower shape interval. This admits
+formerly excluded shapes without relaxing validation. Forward and cooperative
+convolution remain outside the search, but receive the shared correctness repair.
+
+This distinction matters: multiplying by the rounded f32 reciprocal mapped
+`41 / 41` to zero. A batch-2, width-41 GPU regression produced `dW[0]=0.9391`
+instead of the independent f64 oracle's `0.8370`. Full oracles now cover fourteen
+scalar shapes, both tiles and ordinary/tiny gradients; six generated cooperative
+shapes execute on this GPU with exactly representable f16 operands. Native-f32
+execution still needs hardware qualification. The [separate cost cohort](../experiments/conv-indexing-2026-09-06/README.md)
+retains full-state bit identity across revisions, but ResNet normal F+L+B rises
+17.55→21.55 ms, about 23%. Short-case drift prevents an equivalence claim for
+SmolLM2/Whisper. These untuned, sequential source-level processes are separate
+from the earlier tile crossover and its timings.
+
+The [integer-divisor follow-up](../experiments/conv-divisor-2026-09-06/README.md)
+qualifies one shared WGSL high-multiply/correction implementation against raw-u32
+CPU oracles and all existing full convolution oracles. Its separate six-process
+cohort retains bit-identical full states and requested tensor memory, with 16
+extra uniform bytes per convolution binding. ResNet falls 21.5986→21.1966 ms
+before profiling and 21.6076→21.1521 ms after, a modest 1.86%/2.11% local reduction.
+Most of the original cost remains. Whisper's first two candidate after-blocks
+deteriorate sharply; the cohort does not establish short-case stability or
+no regression. Do not confuse these sequential source pairs with tuned
+interleaved comparisons, or change the 5%+2MAD decision guard to accommodate them.
+Exact-arithmetic lowering and short-case timing stability remain open. The
+[bounded split-K prototype](../experiments/split-k-2026-09-06/README.md) now lowers
+explicit dW selections to partials plus existing SumRows before session allocation.
+Its legality, full/partial f64 oracles and short optimizer trajectories are tested;
+explicit isolated sequence qualification/measurement is now implemented.
+Its [four-process cohort](../experiments/split-k-sequence-2026-09-06/README.md)
+shows synthetic gains but rejects both profiled large shapes on accuracy before
+timing. Automatic installation and whole-step confirmation remain open.
 
 The former small-tile occupancy cutoff is now an **initial choice**, not a
 profitability veto for eligible tuned classes: either tile can win. Untuned,
 unsupported or budget-limited work keeps deterministic selection. The default
 small-tile geometry now uses exact ceil-divided extents instead of doubling
-already-rounded 64-tile counts. Cooperative/GEMV profitability thresholds have
-not been removed, and we do not call the system fully autotuned.
+already-rounded 64-tile counts. Native-f32 cooperative profitability thresholds
+are likewise challenged where the candidate fits. GEMV, f16-input cooperative
+and complex fusion thresholds remain outside this search; the system is not
+fully autotuned.
+
+Cooperative padding is a legality constraint, not a performance veto. N must
+be divisible by 16; normal/add matmuls require K≥4; output and addend need
+full-output-tile capacity. The tuner cannot enlarge a session or borrow unused
+slack from another tenant of an aliased allocation. Thus an unpadded scalar
+class may have only one challenger; an already-padded cooperative class may
+have both scalar challengers. Capacity is part of the class key. The search
+never re-enables cooperative matrices disabled by policy or rejected by the
+session's smoke test.
 
 Why start here? Both scalar variants already share a precision, layout,
 allocation and access contract. This gives useful search/qualification/report
@@ -94,11 +195,11 @@ Limits: scratch input/cache history and isolated barriers are not the live
 graph's context; repeated warm buffers can favor a different implementation
 than streaming weights. Memory-placement matching does not reproduce every
 external allocator property or concurrent workload. The paired noise guard
-cannot prove an idle GPU. Whole-step confirmation, more input distributions,
-GPU state-preservation checks and Vulkan/Metal fleet qualification are still
-required. **This opt-in implementation has only CPU validation so far.**
+cannot prove an idle GPU. More input distributions, native-f32 hardware and
+Vulkan/Metal fleet qualification remain required. The runtime does not yet
+automatically confirm or roll back choices using a whole-step measurement.
 
-Later, on an idle GPU, inspect a report with explicit bounds:
+On an idle GPU, inspect a report with explicit bounds:
 
 ```rust
 let report = session.tune_with(meganeura::TuneOptions {
@@ -111,11 +212,198 @@ println!("{}", serde_json::to_string_pretty(&report)?);
 
 The regression target is intentionally ignored by default because it performs
 timings. Compile it without running: `cargo test --test tune --no-run`.
-Only after the device is released:
-`cargo test --release --test tune -- --ignored --test-threads=1`.
-It checks output preservation and active-training tensor/moment/counter
-preservation, but is not the complete KV/external-buffer/optimizer trajectory
-acceptance matrix. Do not treat a successful compile as a passed GPU test.
+Portable scalar qualification:
+
+```sh
+cargo test --release --test tune -- --ignored --skip tune_native_cooperative_f32 --test-threads=1
+```
+
+All four tests passed on the RTX 5070: output preservation, active-training
+tensor/moment/counter preservation plus subsequent optimizer updates against
+an untuned control, all four entries across three rectangular/edge shapes,
+and budget skips. This is not a complete KV/external-buffer/optimizer matrix.
+
+`cargo run --release --example tune_session -- --device` prints actual matrix
+capabilities. Only on a native-f32 device, run
+`cargo test --release --test tune tune_native_cooperative_f32 -- --ignored --test-threads=1`.
+That test requires real native execution, including below-threshold shapes,
+padded rows and a dimension above the native-8 veto; it deliberately fails on
+unsupported hardware. Native shaders passed offline Naga/SPIR-V checks here,
+but that is not a passed native GPU test.
+
+For an independent whole-step experiment, commit tracked source changes,
+then run `cargo run --release --example tune_session -- new-results.json` on
+an idle device. The Rust harness builds matched untuned/tuned dense chains,
+records the exact revision, lockfile/executable hashes, device and driver,
+search costs/decisions, output parity, and 40 alternating whole-step pairs
+after warmup. Repeat in independent processes. It refuses to overwrite an
+existing file and uses explicit f32 policy, not environment-selected f16
+staging. Synthetic chains are a transfer experiment, not a PyTorch comparison
+or a new result for the paper's model matrix.
+
+## Lessons from optimizer-backed holdouts
+
+The fixed [September 6 protocol and records](../experiments/holdouts-2026-09-06/README.md)
+keep normal optimization and compare complete parameter, gradient and allocated
+moment arrays at matched training ages through step 78. All 140 isolated
+comparisons qualify; 31 choose challengers. Nevertheless no process/case
+clears the descriptive gain or regression guard, and four MLP Adam processes
+have lower whole-step ratios. Kernel qualification and measured isolated
+profitability are necessary screens, not end-to-end acceptance.
+
+Coverage is narrow even for these graphs. Only 1/512 ResNet plan dispatches is
+eligible (the classifier weight gradient); none of its convolutions is searched.
+Its median search cost is 1.12 s for no changed choice. SmolLM2 Adam and Whisper
+SGD reach the eight-class cap. These counts do not measure time shares and do
+not establish that raising the cap would help. Search phase profiling and
+whole-step profiles should precede a larger budget or a new kernel family.
+
+The immediate follow-up adds structured preparation/qualification/warmup/
+sampling wall times to new `TuneOutcome` reports, with partial early-exit
+accounting. This instrumentation postdates the measured source; the old raw
+records remain unchanged and deserialize with `phase_times: None`.
+It does not change selection policy or explain the old ResNet cost after the
+fact. Use it for the next separately recorded profile; see
+[phase boundaries and missing-data semantics](observability.md).
+
+The unchanged ResNet control in one process has a 1.071× ratio of medians but
+only 0.01470 ms median paired gain. The paired guard correctly rejects it.
+This makes A/A controls, randomized/crossover session roles and interference/
+clock telemetry concrete next work for automatic confirmation. Keep every
+attempt and retain one predeclared acceptance policy; do not pick a favorable
+process or quietly loosen the margin. Cross-session bitwise equality here
+does not strengthen the frozen paper's sampled-output/gradient-norm contract.
+
+The [controlled crossover cohort](../experiments/crossover-2026-09-06/README.md)
+is retained separately: six processes, three diagnostic repeat cases, an
+untuned/untuned control and four role-reversed blocks with matched evolving
+states. It uses a checked selection-only swap instead of resetting training
+from an incomplete snapshot. Confirmation requires a stable control and the
+existing guard in both winner-side orientations and pooled pairs. Device
+telemetry and the new search phase timers are retained; this does not change
+runtime selection policy or enable tuning by default. Dense inference passes
+both orientations in all six processes (median 1.177×); MLP+Adam has no
+confirmed gain, with two unstable controls; ResNet remains unchanged. All
+declared tensor comparisons are bit-exact through Adam step 178.
+
+Qualification took 98.26–98.65% of ResNet's search wall time in that cohort
+(median 538 of 546 ms); sampling took about 7 ms. That motivated the separately
+recorded experiment below, not a retrospective change to those measurements.
+
+## Qualification cost: measured readback staging
+
+The [six-process Shared/Download experiment](../experiments/readback-2026-09-06/README.md)
+uses published Blade 0.9 and Naga 30 in both arms. New nested timers separate
+input preparation, CPU upload copy, upload transfer/wait, dispatch/wait,
+readback transfer/wait, CPU readback allocation/copy and numerical validation.
+These are accumulated host wall times, not GPU timestamps. The staging buffer
+alone changes memory policy; candidate bindings, capacities, ordinary/tiny
+patterns, complete finite/parity scans and sampled f64 dots remain identical.
+
+| Diagnostic repeat case | Median total search, Shared → Download | Median qualification, Shared → Download | Median per-process search ratio |
+|---|---:|---:|---:|
+| Dense inference | 73.20 → 43.98 ms | 51.82 → 6.79 ms | 1.661× |
+| MLP+Adam | 175.44 → 63.53 ms | 144.88 → 10.42 ms | 2.803× |
+| ResNet F+L+B | 606.46 → 38.85 ms | 598.38 → 20.59 ms | 15.567× |
+
+ResNet's CPU readback allocation/copy accounts for 582.24 ms with Shared versus
+2.03 ms with Download; its unchanged numerical validation takes 6.03 versus
+6.01 ms. Download is not free: preparation increases from 0.65 to 10.41 ms,
+upload transfer/wait from 1.12 to 3.59 ms and readback transfer/wait from 0.54
+to 2.33 ms. Preparation also increases on both other cases. The first dense
+Download search is slower overall and is included, not discarded.
+
+All 18 case runs and 108 class comparisons qualify. Full tensor/counter checks
+are bit-exact through Adam step 178 and allocation requests match. ResNet's
+total/qualification/readback-copy gain guards pass, and neither other case
+has a total-search regression guard. This meets the predeclared promotion
+rule: `TuneOptions::default()` now selects Download for private staging.
+Explicit Shared and historical missing-field deserialization preserve the
+old policy. Tuning remains default-off. Six process pairs on one GPU do not
+establish fleet behavior; Metal maps both policies to shared storage.
+
+The [allocation and exact-size reuse follow-up](../experiments/staging-reuse-2026-09-06/README.md)
+now splits preparation and times cleanup. A tagged localization profile puts
+19.60/20.79 ms dense preparation and 32.05/33.98 ms MLP preparation in staging
+allocation, while candidate binding allocations cost hundredths of a millisecond.
+That motivates one reusable staging slot, not a broader binding/encoder pool.
+
+`TuneStagingReuse::SameSize` now defaults on **within a tuning call** after a
+separate six-process comparison passes its predeclared gates. Sizes must match
+exactly; a change releases the old buffer before new allocation. Full binding
+plus staging requests still count against the same cap, and nothing remains
+after return. Every input upload, poison, readback and numerical check repeats.
+Fresh remains an explicit control and the historical missing-field policy.
+
+| Case | Median total search, Fresh → SameSize | Staging allocations per search | Median paired process ratio |
+|---|---:|---:|---:|
+| Dense inference | 44.01 → 31.84 ms | 3 → 1 | 1.378× |
+| MLP+Adam | 64.27 → 45.46 ms | 5 → 2 | 1.414× |
+| ResNet F+L+B | 38.51 → 39.24 ms | 1 → 1 | 1.007×; no guarded change |
+
+The ratio column is not a ratio of medians. ResNet is strongly order-sensitive;
+the first dense SameSize run is slower overall. Both remain in the records.
+All 108 comparisons qualify with bit-exact state checks through Adam step 178,
+identical per-comparison/peak scratch requests and zero retained staging at
+return. Cleanup includes the final retained-buffer release; it is not moved
+outside total search. No qualification or validation gain guard passes.
+
+This closes the measured staging-allocation opportunity at this scope. The
+[subsequent whole-step profiles](../experiments/training-profile-2026-09-06/README.md)
+put 60.66–60.77% of instrumented ResNet dispatch time in backward convolution
+and 36.25–40.58% of SmolLM2's in backward attention. Full profiled state agrees,
+but ordinary before/after timing drift is up to 27% for SmolLM2 and 100% for
+Whisper. These F+L+B-only profiles rank work; they neither measure optimizer
+passes nor establish candidate gains. A newly exposed non-same-padding dX bug
+is fixed before widening the search, with full independent f64 derivative tests.
+
+Exact-class qualification and selection for the existing 32/64 convolution
+derivative tiles are implemented. The [corrected crossover](../experiments/conv-tiles-corrected-2026-09-06/README.md)
+retains six ResNet F+L+B and small Adam/SGD convolution-chain processes.
+ResNet changes eight dX dispatches and observes median 17.5808→16.7293 ms,
+ratio 1.05056×, but all six decisions are inconclusive under the unchanged
+5%+noise guard. The small chains keep their original choices. All 84 isolated
+comparisons qualify, full compared state is bit-exact, and both optimizer
+sessions actually update parameters through age 178. Search costs median
+640/37/38 ms respectively; sampling dominates ResNet search. Its structural
+prior visits only 8/45 exact derivative classes, not the expensive stem dW.
+
+The original small-case builder violated the documented flat operand contract;
+both controls agreed on zero loss/gradients after a zero-workgroup forward
+dispatch. Those twelve cases remain archived and disqualified. The public
+helper now rejects malformed operand shapes, and the runner requires nonzero
+training signals and actual parameter updates. Independent full f64 scatter
+oracles now cover forward outputs, fourteen scalar shapes and both tiles
+before/after search, ordinary/tiny gradients, state isolation and budget skips.
+Distinct-state Adam swaps cover subsequent accumulation/clipping updates as well.
+
+The long-reduction, small-output dW classes motivate bounded split-K. An explicit
+plan-before-allocation lowering now shares the scalar template and existing
+SumRows for `[split, M*N]` partials, with all-or-nothing legality/byte preflight.
+Ordinary scheduler edges enforce the final reduction and permit lifetime-based
+partial reuse. It is not a live-tuner choice: the geometry-only swap still promises
+fixed allocations. Explicit isolated candidate-sequence qualification and timing
+now reuse the scratch runner, class keys, options and decision guard, with a named
+final output slot and all partial/staging bytes charged. Whole-step confirmation
+across rebuilt plans and automatic installation remain open. Do not hide partials
+outside the budget or create another tuner. Full f64 checks and short SGD/Adam
+trajectories pass for the tested short fixtures; a long tiny-gradient three-way
+partial fails the unchanged gate even though the final gradient passes. The
+[prototype record](../experiments/split-k-2026-09-06/README.md) retains that rejection;
+the [later measurement cohort](../experiments/split-k-sequence-2026-09-06/README.md)
+is separate. Its 64 comparisons include 32 numerical rejections and no default
+change. The synthetic long case observes a 6.93× eight-way sequence ratio, but
+neither profiled large shape reaches timing. Full f64 scans expose unsplit-control
+errors missed by sampled dots; independent CPU f32 FMA reproduces the reported
+bits. Improve shared long-reduction accumulation and qualification coverage before
+claiming training gains. A passing synthetic pattern does not erase the earlier
+three-way partial failure on different inputs of the same shape.
+
+Keep these choices about algebra, not model names. Do not infer that cross-call
+pools, larger budgets or weaker checks follow from this result. Cheaper search
+by itself provides no new kernel
+algorithms and does not turn MLP's earlier inconclusive whole-step ratios into
+a training gain. Tuning remains opt-in.
 
 ## Target contract for broader tuning
 
@@ -186,9 +474,21 @@ long training run should be able to request different budgets.
 | 1 | Reusable convolution derivative tiling/layout | NVIDIA ResNet profile concentrates in backward convolution. | Correct odd/stride/channel cases, dX/dW parity; F+L+B and optimizer-backed step improve. |
 | 1 | Metal attention backward schedules | Frozen profile identified dK/dV and dQ costs. | Tune EPT/tiles/workgroup layout jointly; several sequence/head widths, end-to-end memory and time. |
 | 2 | Eliminate materializations via existing prologue/epilogue/reduction generators | Common traffic costs; small-kernel populations. | Dispatch/traffic reduction plus wall-time improvement; avoid register-spill and fanout regressions. |
-| 2 | Lazy optimizer state and logical checkpoint layout | Memory limits larger training workloads independently of ALU speed. | Peak allocated bytes drop without changed updates or restore behavior. |
+| 2, implemented; fleet/peak qualification open | Lazy optimizer state and logical checkpoint layout | Memory limits larger training workloads independently of ALU speed. | RTX tests check actual allocation deltas, preflight rejection and next-update parity; measure peak process memory on larger workloads/backends. |
 | 3 | Layout search, rematerialization | May unlock convolution performance or larger models. | Account for conversion/recompute traffic and complete backward dependencies. |
 | Research | bf16, scaled/compensated low-precision derivatives | Scalar f32 can leave matrix hardware idle. | Device/compiler support and exponent-sensitive accuracy, then convergence and speed. |
+
+The checkpoint/memory follow-up now avoids Adam/LaProp moments for SGD and
+F+L+B-only sessions, accounts for accumulators once, and serializes logical
+tensors with whole-file preflight. Optimizer/clip/accumulation lengths ignore
+allocation padding, with poisoned-tail regressions. The 1,048,576-element F32 test verifies
+8 MiB of unused moment allocations are absent. Different-padding restores
+preserve the next Adam update, and eight training-correctness tests pass on
+RTX 5070. These are storage/correctness results, not a speedup or measured
+driver-peak reduction. Detailed contracts and reproduction live in
+[checkpoints and memory](checkpoints-and-memory.md). Remaining work includes
+cross-backend restore qualification, large-workload peak measurements and
+structured allocation failures; it does not require a new kernel family.
 
 For convolution, first reuse the contraction generator with explicit indexing
 maps for forward/dX/dW. Add a small number of tilings and layouts, not separate

--- a/examples/measure_split_k.rs
+++ b/examples/measure_split_k.rs
@@ -1,0 +1,216 @@
+//! Isolated complete-sequence evidence, never installation or whole-step timing.
+#[path = "support/experiment_io.rs"]
+mod experiment_io;
+#[path = "support/gpu_monitor.rs"]
+mod gpu_monitor;
+#[path = "support/tuning_measurement.rs"]
+#[allow(dead_code)]
+mod measurement;
+
+use experiment_io::{command, host_sample, sha256, unix_ms, write_record};
+use measurement::TensorComparison;
+use meganeura::{CoopPolicy, Graph, Session, SessionOptions, TuneOptions, compile::ShaderEntry};
+use serde_json::{Value, json};
+use std::{error::Error, fs::OpenOptions, path::Path, sync::Arc, time::Duration};
+
+const CASES: [(&str, [u32; 10]); 4] = [
+    ("spatial-7x7", [1, 3, 224, 224, 64, 7, 7, 2, 3, 3]),
+    ("pointwise", [1, 256, 56, 56, 64, 1, 1, 1, 0, 0]),
+    ("rectangular-tail", [3, 5, 7, 9, 7, 2, 3, 1, 1, 0]),
+    ("long-tail", [2, 3, 1, 32771, 5, 1, 1, 1, 0, 0]),
+];
+
+fn data(count: usize, seed: u32) -> Vec<f32> {
+    let mut state = seed;
+    (0..count)
+        .map(|_| {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            (state >> 8) as f32 / 16777216.0 - 0.5
+        })
+        .collect()
+}
+
+fn snapshot(session: &Session) -> Vec<(String, Vec<f32>)> {
+    let mut state = Vec::new();
+    for (name, buffer) in &session.plan().input_buffers {
+        let mut values = vec![f32::NAN; session.plan().buffers[buffer.0 as usize] / 4];
+        session.read_buffer(*buffer, &mut values);
+        state.push((format!("input.{name}"), values));
+    }
+    let n = session.param_size("w").unwrap();
+    let mut w = vec![f32::NAN; n];
+    let mut dw = vec![f32::NAN; n];
+    session.read_param("w", &mut w);
+    session.read_param_grad("w", &mut dw);
+    state.push(("parameter.w".into(), w));
+    state.push(("gradient.w".into(), dw));
+    let loss = session.plan().loss_buffer.unwrap();
+    let mut partials = vec![f32::NAN; session.plan().buffers[loss.0 as usize] / 4];
+    session.read_buffer(loss, &mut partials);
+    state.push(("loss_partials".into(), partials));
+    state.push(("loss".into(), vec![session.read_loss()]));
+    state
+}
+
+fn run_case(
+    index: usize,
+    seed: usize,
+    gpu: &Arc<blade_graphics::Context>,
+) -> Result<Value, Box<dyn Error>> {
+    let (name, shape) = CASES[index];
+    let [batch, ci, h, w, co, kh, kw, stride, ph, pw] = shape;
+    let (oh, ow) = (
+        (h + 2 * ph - kh) / stride + 1,
+        (w + 2 * pw - kw) / stride + 1,
+    );
+    let (nx, nw, ny) = (
+        (batch * ci * h * w) as usize,
+        (co * ci * kh * kw) as usize,
+        (batch * co * oh * ow) as usize,
+    );
+    let mut graph = Graph::new();
+    let input = graph.input("x", &[nx]);
+    let weight = graph.parameter("w", &[nw]);
+    let upstream = graph.input("dy", &[ny]);
+    let output = graph.conv2d_hw(input, weight, batch, ci, h, w, co, kh, kw, stride, ph, pw);
+    let weighted = graph.mul(output, upstream);
+    let loss = graph.sum_all(weighted);
+    graph.set_outputs(vec![loss]);
+    let plan = meganeura::compile::compile(&meganeura::autodiff::differentiate(&graph));
+    let mut session = Session::with_context_opts(
+        plan,
+        Arc::clone(gpu),
+        SessionOptions {
+            coop: CoopPolicy::Disabled,
+            ..Default::default()
+        },
+    );
+    session.set_input("x", &data(nx, seed as u32 * 7));
+    session.set_input("dy", &data(ny, seed as u32 * 37));
+    session.set_parameter("w", &data(nw, seed as u32 * 19));
+    session.step();
+    session.wait();
+    let before = snapshot(&session);
+    if before.iter().any(|(_, values)| {
+        values.iter().any(|v| !v.is_finite()) || !values.iter().any(|&v| v != 0.0)
+    }) {
+        return Err("nonfinite or zero preflight signal".into());
+    }
+    let dispatch_index = session
+        .plan()
+        .dispatches
+        .iter()
+        .position(|d| {
+            matches!(
+                d.shader,
+                ShaderEntry::Conv2dGradWeightGemm | ShaderEntry::Conv2dGradWeightGemmSmall
+            )
+        })
+        .ok_or("missing scalar dW")?;
+    let plan_before = serde_json::to_value(session.plan())?;
+    let keys = session.dispatch_pipeline_keys();
+    let memory = session.memory_summary().total_allocated_bytes();
+    let mut splits = [2, 3, 4, 8];
+    splits.rotate_left(seed - 1);
+    let options = TuneOptions {
+        max_time: Duration::from_secs(120),
+        ..Default::default()
+    };
+    let start = host_sample();
+    let report = session.measure_conv_weight_splits(dispatch_index, &splits, options)?;
+    let finish = host_sample();
+    let after = snapshot(&session);
+    let comparisons: Vec<_> = before
+        .iter()
+        .zip(&after)
+        .map(|((name, a), (other, b))| {
+            assert_eq!(name, other);
+            TensorComparison::new(name.clone(), a, b)
+        })
+        .collect();
+    let unchanged = comparisons.iter().all(|c| c.exact && c.passed)
+        && plan_before == serde_json::to_value(session.plan())?
+        && keys == session.dispatch_pipeline_keys()
+        && memory == session.memory_summary().total_allocated_bytes()
+        && session.adam_step_count() == 0
+        && session.memory_summary().adam_state_bytes == 0;
+    eprintln!(
+        "{name}: unchanged={unchanged}; {:?}",
+        report
+            .outcomes
+            .iter()
+            .map(|o| (
+                o.candidate_split_k,
+                o.decision,
+                o.baseline_median_ms,
+                o.candidate_median_ms,
+                &o.failure
+            ))
+            .collect::<Vec<_>>()
+    );
+    Ok(
+        json!({"name": name, "shape": shape, "status": if unchanged {"complete"} else {"state_failed"},
+        "host_start": start, "host_finish": finish, "dispatch_index": dispatch_index,
+        "dispatch": session.plan().dispatches[dispatch_index], "splits": splits, "report": report,
+        "state_comparisons": comparisons, "plan_and_state_unchanged": unchanged,
+        "pipeline_keys": keys, "resident_buffer_requests": memory, "adam_step": session.adam_step_count(),
+        "adam_bytes": session.memory_summary().adam_state_bytes}),
+    )
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+    let mut args = std::env::args_os().skip(1);
+    let path = args
+        .next()
+        .ok_or("usage: measure_split_k <new-output.json> <seed 1..4>")?;
+    let seed: usize = args
+        .next()
+        .ok_or("missing seed")?
+        .to_str()
+        .ok_or("non-UTF8 seed")?
+        .parse()?;
+    if !(1..=4).contains(&seed) || args.next().is_some() {
+        return Err("expected seed 1..4".into());
+    }
+    if !command("git", &["status", "--porcelain", "--untracked-files=no"])?.is_empty() {
+        return Err("commit tracked source before measuring".into());
+    }
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    let monitor = gpu_monitor::Monitor::start();
+    let gpu = Arc::new(meganeura::init_gpu_context()?);
+    let info = gpu.device_information();
+    let mut record = json!({"protocol": "split-k-sequence-v1", "status": "running", "metadata": {
+        "revision": command("git", &["rev-parse", "HEAD"])?, "tracked_source_clean": true,
+        "executable_sha256": sha256(&std::env::current_exe()?)?,
+        "cargo_lock_sha256": sha256(&Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock"))?,
+        "rustc": command("rustc", &["--version"])?, "rustflags": std::env::var("RUSTFLAGS").ok(),
+        "device": info.device_name, "driver": info.driver_info, "seed": seed,
+        "started_unix_ms": unix_ms(), "host_start": host_sample(), "nvidia_smi_before": command("nvidia-smi", &[]).ok(),
+        "contract": "strict f32; synthetic scratch; full final/partial f64; no live installation or whole-step timing"
+    }, "cases": []});
+    write_record(&mut file, &record)?;
+    for position in 0..4 {
+        let index = (position + seed - 1) % 4;
+        let result = run_case(index, seed, &gpu).unwrap_or_else(|error| {
+            json!({
+                "name": CASES[index].0, "status": "error", "error": error.to_string()
+            })
+        });
+        record["cases"].as_array_mut().unwrap().push(result);
+        write_record(&mut file, &record)?;
+    }
+    record["telemetry"] = monitor.finish();
+    record["finished_unix_ms"] = json!(unix_ms());
+    let complete = record["cases"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|c| c["status"] == "complete");
+    record["status"] = json!(if complete { "complete" } else { "failed" });
+    write_record(&mut file, &record)?;
+    if !complete {
+        return Err("failed case retained in record".into());
+    }
+    Ok(())
+}

--- a/examples/profile_training.rs
+++ b/examples/profile_training.rs
@@ -1,0 +1,411 @@
+//! Fixed whole-step localization, not an optimization or cross-engine benchmark.
+#[path = "support/experiment_io.rs"]
+mod experiment_io;
+#[path = "support/gpu_monitor.rs"]
+mod gpu_monitor;
+#[path = "support/tuning_measurement.rs"]
+#[allow(dead_code)] // Shares tensor arithmetic, not the candidate-pair decision rule.
+mod measurement;
+#[path = "support/holdout_workloads.rs"]
+mod workloads;
+
+use experiment_io::{command, host_sample, sha256, unix_ms, write_record};
+use measurement::{TensorComparison, median};
+use meganeura::{
+    CoopPolicy, GpuOptions, Session, TuneOptions,
+    profiler::{CaptureOptions, capture_session_profile},
+};
+use serde_json::{Value, json};
+use std::{
+    error::Error,
+    fs::OpenOptions,
+    io::{BufWriter, Write},
+    path::Path,
+    process::{Command, Stdio},
+    sync::Arc,
+    time::Duration,
+};
+use workloads::*;
+
+const WARMUP: usize = 30;
+const SETTLING: usize = 5;
+const NORMAL_SAMPLES: usize = 20;
+const PROFILE_SAMPLES: usize = 5;
+
+fn profile_cases() -> Vec<Case> {
+    cases()
+        .into_iter()
+        .filter(|case| matches!(case.name, "smollm2-adam" | "whisper-sgd" | "resnet50-flb"))
+        .map(|mut case| {
+            case.name = match case.name {
+                "smollm2-adam" => "smollm2-flb",
+                "whisper-sgd" => "whisper-flb",
+                name => name,
+            };
+            case.work = Work::ForwardLossBackward;
+            case
+        })
+        .collect()
+}
+
+fn advance(session: &mut Session, count: usize) {
+    for _ in 0..count {
+        session.step();
+        session.wait();
+    }
+}
+
+fn normal_samples(session: &mut Session, expected_loss: f32) -> Value {
+    advance(session, SETTLING);
+    let started = host_sample();
+    let mut samples = Vec::new();
+    let mut losses = Vec::new();
+    for _ in 0..NORMAL_SAMPLES {
+        samples.push(step_ms(session));
+        losses.push(session.read_loss());
+    }
+    let comparison = TensorComparison::new(
+        "loss_trajectory".into(),
+        &[expected_loss; NORMAL_SAMPLES],
+        &losses,
+    );
+    json!({"host_start": started, "host_finish": host_sample(), "samples_ms": samples,
+        "median_ms": median(&samples), "losses": losses, "loss_comparison": comparison})
+}
+
+// Canonical, length-delimited names and f32 bits; no float formatting or norm floor.
+fn state_sha256(state: &Snapshot) -> Result<String, Box<dyn Error>> {
+    let mut child = Command::new("sha256sum")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .or_else(|_| {
+            Command::new("shasum")
+                .args(["-a", "256"])
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+        })?;
+    {
+        let mut stream = BufWriter::new(child.stdin.take().unwrap());
+        stream.write_all(b"meganeura.snapshot.f32le.v1\0")?;
+        stream.write_all(&state.adam_step.to_le_bytes())?;
+        stream.write_all(&(state.adam_bytes as u64).to_le_bytes())?;
+        let mut tensors: Vec<_> = state.tensors.iter().collect();
+        tensors.sort_by(|a, b| a.0.cmp(&b.0));
+        stream.write_all(&(tensors.len() as u64).to_le_bytes())?;
+        for (name, values) in tensors {
+            stream.write_all(&(name.len() as u64).to_le_bytes())?;
+            stream.write_all(name.as_bytes())?;
+            stream.write_all(&(values.len() as u64).to_le_bytes())?;
+            for value in values {
+                stream.write_all(&value.to_bits().to_le_bytes())?;
+            }
+        }
+        stream.flush()?;
+    }
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        return Err("snapshot sha256sum failed".into());
+    }
+    Ok(String::from_utf8(output.stdout)?
+        .split_whitespace()
+        .next()
+        .ok_or("missing snapshot hash")?
+        .into())
+}
+
+fn run_case(
+    case: &Case,
+    gpu: &Arc<blade_graphics::Context>,
+    indexing_audit: bool,
+) -> Result<Value, Box<dyn Error>> {
+    let (mut session, build) = make_session(case, gpu, CoopPolicy::Disabled);
+    let keys = session.dispatch_pipeline_keys();
+    let mut record = json!({"name": case.name, "description": case.description, "work": case.work,
+        "status": "running", "build": build, "host_start": host_sample(),
+        "initial_memory": memory(&session), "pipeline_keys": keys,
+        "dispatch_contracts": session.plan().dispatches});
+    // A zero deadline reports exact eligibility without compiling, allocating or selecting.
+    record["search_census"] = serde_json::to_value(session.tune_with(TuneOptions {
+        scope: meganeura::TuneScope::Dense,
+        max_time: Duration::ZERO,
+        ..Default::default()
+    })?)?;
+    advance(&mut session, WARMUP);
+    let reference = snapshot(&mut session, case);
+    if indexing_audit {
+        record["reference_state_sha256"] = json!(state_sha256(&reference)?);
+    }
+    let expected_loss = session.read_loss();
+    let prefix = compare(
+        "reference",
+        case.work.adam_step_after(WARMUP),
+        &reference,
+        &reference,
+    );
+    let mut valid = prefix.passed
+        && prefix
+            .tensors
+            .iter()
+            .any(|t| t.name.starts_with("gradient.") && t.reference_sum_sq > 0.0);
+    record["reference_comparison"] = serde_json::to_value(prefix)?;
+    if !valid {
+        record["status"] = json!("reference_failed");
+        return Ok(record);
+    }
+    record["normal_before"] = normal_samples(&mut session, expected_loss);
+    let state = snapshot(&mut session, case);
+    let before = compare("normal_before", 0, &reference, &state);
+    valid &= before.passed;
+    record["normal_before_comparison"] = serde_json::to_value(before)?;
+    drop(state);
+
+    advance(&mut session, SETTLING);
+    let mut preparations = 0;
+    let mut comparisons = Vec::new();
+    let profile_start = host_sample();
+    let profile = capture_session_profile(
+        &mut session,
+        |session| {
+            // The first ring-advance callback sees the retained profiled result,
+            // before an ordinary execution can overwrite it. Readbacks use their
+            // own encoders and are outside the retained step's wall timer.
+            if preparations % 3 == 1 {
+                let state = snapshot(session, case);
+                let comparison = compare("profiled", 0, &reference, &state);
+                valid &= comparison.passed;
+                comparisons.push(comparison);
+            }
+            preparations += 1;
+        },
+        CaptureOptions {
+            samples: PROFILE_SAMPLES,
+            unprofiled_median_ms: record["normal_before"]["median_ms"].as_f64(),
+            include_pipeline_statistics: true,
+        },
+    );
+    record["profile_host_start"] = profile_start;
+    record["profile_host_finish"] = host_sample();
+    record["profile_comparisons"] = serde_json::to_value(comparisons)?;
+    record["profile_prepare_calls"] = json!(preparations);
+    let profile = match profile {
+        Ok(profile) => profile,
+        Err(error) => {
+            record["status"] = json!("profile_error");
+            record["error"] = json!(error.to_string());
+            return Ok(record);
+        }
+    };
+    assert_eq!(preparations, PROFILE_SAMPLES * 3);
+    assert_eq!(
+        record["profile_comparisons"].as_array().unwrap().len(),
+        PROFILE_SAMPLES
+    );
+    record["profile"] = serde_json::to_value(profile)?;
+    record["normal_after"] = normal_samples(&mut session, expected_loss);
+    let after = snapshot(&mut session, case);
+    if indexing_audit {
+        record["final_state_sha256"] = json!(state_sha256(&after)?);
+        valid &= record["reference_state_sha256"] == record["final_state_sha256"];
+    }
+    let comparison = compare("normal_after", 0, &reference, &after);
+    valid &= comparison.passed
+        && record["normal_before"]["loss_comparison"]["passed"] == true
+        && record["normal_after"]["loss_comparison"]["passed"] == true;
+    record["normal_after_comparison"] = serde_json::to_value(comparison)?;
+    assert_eq!(keys, session.dispatch_pipeline_keys());
+    record["final_memory"] = memory(&session);
+    let same_memory = record["initial_memory"]
+        .as_object()
+        .unwrap()
+        .iter()
+        .filter(|(key, _)| key.as_str() != "process_api_sample")
+        .all(|(key, value)| value == &record["final_memory"][key]);
+    let no_update_state = ["adam_bytes", "accumulator_bytes"]
+        .iter()
+        .all(|key| record["final_memory"][key] == 0)
+        && record["final_memory"]["auxiliary_bytes"] == 4;
+    valid &= same_memory && no_update_state;
+    record["same_memory"] = json!(same_memory);
+    record["host_finish"] = host_sample();
+    record["status"] = json!(if valid {
+        "complete"
+    } else {
+        "numerical_failure"
+    });
+    Ok(record)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+    let mut args = std::env::args_os().skip(1);
+    let path = args.next().ok_or(
+        "usage: profile_training <new-output.json> <seed 1..3> [--conv-indexing|--conv-divisor]",
+    )?;
+    let seed: usize = args
+        .next()
+        .ok_or("missing seed")?
+        .to_str()
+        .ok_or("non-UTF8 seed")?
+        .parse()?;
+    let protocol = match args.next() {
+        None => "training-profile-2026-09-06",
+        Some(arg) if arg == "--conv-indexing" => "conv-indexing-2026-09-06",
+        Some(arg) if arg == "--conv-divisor" => "conv-divisor-2026-09-06",
+        Some(_) => return Err("unknown profiling mode".into()),
+    };
+    let indexing_audit = protocol != "training-profile-2026-09-06";
+    if !(1..=3).contains(&seed) || args.next().is_some() {
+        return Err(
+            "expected one output, seed 1..3, optional --conv-indexing or --conv-divisor".into(),
+        );
+    }
+    if !command("git", &["status", "--porcelain", "--untracked-files=no"])?.is_empty() {
+        return Err("commit tracked source before profiling".into());
+    }
+    let mut output = OpenOptions::new().write(true).create_new(true).open(path)?;
+    let started = unix_ms();
+    let before = command("nvidia-smi", &[]).ok();
+    let monitor = gpu_monitor::Monitor::start();
+    let gpu = Arc::new(meganeura::init_gpu_context_with(GpuOptions {
+        timing: true,
+        ..Default::default()
+    })?);
+    let info = gpu.device_information();
+    let caps = &gpu.capabilities().cooperative_matrix;
+    let mut cases = profile_cases();
+    cases.rotate_left(seed - 1);
+    let mut document = json!({"schema_version": 1, "protocol": protocol, "status": "running",
+        "metadata": {"revision": command("git", &["rev-parse", "HEAD"])?, "tracked_source_clean": true,
+            "cargo_lock_sha256": sha256(&Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock"))?,
+            "executable_sha256": sha256(&std::env::current_exe()?)?, "rustc": command("rustc", &["--version"])?,
+            "seed": seed, "process_id": std::process::id(), "started_unix_ms": started,
+            "case_order": cases.iter().map(|c| c.name).collect::<Vec<_>>(),
+            "device": {"name": info.device_name, "driver": info.driver_info, "f32_tile": caps.f32_tile, "f16_tile": caps.f16_tile},
+            "cooperative_policy": "Disabled", "compile_options": compile_options(),
+            "runtime_options": format!("{:?}", runtime_options(CoopPolicy::Disabled)), "optimize": meganeura::optimize::OptimizeConfig::default(),
+            "warmup": WARMUP, "settling": SETTLING, "normal_samples": NORMAL_SAMPLES, "profile_samples": PROFILE_SAMPLES,
+            "contract": "strict scalar f32; fixed-input F+L+B, no optimizer/clip/accumulation; normal step+wait before and after one-pass-per-dispatch capture; all profiled full states checked before ring advance; telemetry active",
+            "gpu_timing": true, "nvidia_smi_before": before, "rustflags": std::env::var("RUSTFLAGS").ok()}, "cases": []});
+    write_record(&mut output, &document)?;
+    let mut valid = true;
+    for case in cases {
+        eprintln!("profiling {}", case.name);
+        let record = run_case(&case, &gpu, indexing_audit).unwrap_or_else(
+            |error| json!({"name": case.name, "status": "error", "error": error.to_string()}),
+        );
+        valid &= record["status"] == "complete";
+        document["cases"].as_array_mut().unwrap().push(record);
+        write_record(&mut output, &document)?;
+    }
+    document["telemetry"] = monitor.finish();
+    document["finished_unix_ms"] = json!(unix_ms());
+    document["status"] = json!(if valid {
+        "complete"
+    } else {
+        "validation_failed"
+    });
+    write_record(&mut output, &document)?;
+    if !valid {
+        return Err("profile or validation failed; completed records retained".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_digest_covers_bits_names_lengths_and_optimizer_state() {
+        let mut state = Snapshot {
+            tensors: vec![("a".into(), vec![0.0, 1.0]), ("b".into(), vec![1e-12])],
+            adam_step: 0,
+            adam_bytes: 0,
+        };
+        let baseline = state_sha256(&state).unwrap();
+        assert_eq!(baseline.len(), 64);
+        state.tensors.reverse();
+        assert_eq!(state_sha256(&state).unwrap(), baseline);
+        state.tensors.reverse();
+        state.tensors[0].1[0] = -0.0;
+        assert_ne!(state_sha256(&state).unwrap(), baseline);
+        state.tensors[0].1[0] = 0.0;
+        state.tensors[0].0 = "c".into();
+        assert_ne!(state_sha256(&state).unwrap(), baseline);
+        state.tensors[0].0 = "a".into();
+        let value = state.tensors[1].1.pop().unwrap();
+        state.tensors[0].1.push(value);
+        assert_ne!(state_sha256(&state).unwrap(), baseline);
+        let value = state.tensors[0].1.pop().unwrap();
+        state.tensors[1].1.push(value);
+        state.adam_step = 1;
+        assert_ne!(state_sha256(&state).unwrap(), baseline);
+        state.adam_step = 0;
+        state.adam_bytes = 4;
+        assert_ne!(state_sha256(&state).unwrap(), baseline);
+    }
+
+    #[test]
+    fn fixed_profile_boundaries_and_balanced_case_order() {
+        let cases = profile_cases();
+        assert_eq!(
+            cases.iter().map(|c| c.name).collect::<Vec<_>>(),
+            ["smollm2-flb", "whisper-flb", "resnet50-flb"]
+        );
+        assert!(cases.iter().all(|c| c.work == Work::ForwardLossBackward));
+        for index in 0..3 {
+            let mut positions: Vec<_> = (1..=3).map(|seed| (index + 3 - (seed - 1)) % 3).collect();
+            positions.sort_unstable();
+            assert_eq!(positions, [0, 1, 2]);
+        }
+    }
+
+    #[test]
+    #[ignore = "GPU numerical prefix and timestamp/readback-ring qualification, not retained performance"]
+    fn profiling_reads_retained_results_without_advancing_the_session_ring() {
+        let gpu = Arc::new(
+            meganeura::init_gpu_context_with(GpuOptions {
+                timing: true,
+                ..Default::default()
+            })
+            .unwrap(),
+        );
+        for case in profile_cases() {
+            let (mut session, _) = make_session(&case, &gpu, CoopPolicy::Disabled);
+            advance(&mut session, 3);
+            let reference = snapshot(&mut session, &case);
+            let mut preparations = 0;
+            let mut checked = 0;
+            let profile = capture_session_profile(
+                &mut session,
+                |session| {
+                    if preparations % 3 == 1 {
+                        let state = snapshot(session, &case);
+                        assert!(compare("profiled", 0, &reference, &state).passed);
+                        checked += 1;
+                    }
+                    preparations += 1;
+                },
+                CaptureOptions {
+                    samples: 2,
+                    include_pipeline_statistics: false,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            assert_eq!(checked, 2);
+            assert_eq!(preparations, 6);
+            assert_eq!(profile.plan.dispatch_count, session.plan().dispatches.len());
+            assert_eq!(profile.plan.adam_state_bytes, 0);
+            assert_eq!(profile.plan.optimizer_aux_bytes, 4);
+            assert!(
+                profile
+                    .dispatches
+                    .iter()
+                    .all(|d| d.timing_samples_ms.len() == 2)
+            );
+        }
+    }
+}

--- a/examples/support/crossover_measurement.rs
+++ b/examples/support/crossover_measurement.rs
@@ -1,0 +1,206 @@
+//! Descriptive crossover gates. These are not confidence intervals.
+
+use super::measurement::PairedTiming;
+use serde::{Deserialize, Serialize};
+
+pub const PREFIX: usize = 3;
+pub const WARMUP: usize = 30;
+pub const SETTLING: usize = 5;
+pub const CONTROL_PAIRS: usize = 40;
+pub const BLOCK_PAIRS: usize = 20;
+pub const BLOCKS: usize = 4;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Pair {
+    pub step: usize,
+    pub first_session: usize,
+    pub left_ms: f64,
+    pub right_ms: f64,
+    pub left_loss: Option<f32>,
+    pub right_loss: Option<f32>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Block {
+    pub winner_session: usize,
+    pub pairs: Vec<Pair>,
+}
+
+pub fn winner_order(first: usize) -> [usize; BLOCKS] {
+    assert!(first < 2);
+    [first, 1 - first, 1 - first, first]
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Confirmation {
+    pub control: PairedTiming,
+    pub control_stable: bool,
+    pub left_winner: PairedTiming,
+    pub right_winner: PairedTiming,
+    pub pooled: PairedTiming,
+    pub decision: String,
+}
+
+impl Confirmation {
+    pub fn new(
+        control: &[Pair],
+        blocks: &[Block],
+        changed: usize,
+        valid: bool,
+    ) -> Result<Self, &'static str> {
+        if control.len() != CONTROL_PAIRS || blocks.len() != BLOCKS {
+            return Err("incomplete control or crossover blocks");
+        }
+        let first = blocks[0].winner_session;
+        if first > 1
+            || blocks.iter().map(|b| b.winner_session).collect::<Vec<_>>() != winner_order(first)
+        {
+            return Err("roles must follow the declared counterbalanced order");
+        }
+        let control = PairedTiming::new(
+            &control.iter().map(|p| p.left_ms).collect::<Vec<_>>(),
+            &control.iter().map(|p| p.right_ms).collect::<Vec<_>>(),
+        )?;
+        let limit = 0.05 * control.baseline_median_ms;
+        let control_stable = (control.baseline_median_ms - control.tuned_median_ms).abs() <= limit
+            && control.paired_gain_median_ms.abs() <= limit
+            && control.paired_noise_margin_ms <= limit;
+        let mut baseline = [Vec::new(), Vec::new()];
+        let mut tuned = [Vec::new(), Vec::new()];
+        let (mut all_baseline, mut all_tuned) = (Vec::new(), Vec::new());
+        for block in blocks {
+            if block.pairs.len() != BLOCK_PAIRS {
+                return Err("incomplete crossover pair block");
+            }
+            for pair in &block.pairs {
+                let (a, b) = if block.winner_session == 0 {
+                    (pair.right_ms, pair.left_ms)
+                } else {
+                    (pair.left_ms, pair.right_ms)
+                };
+                baseline[block.winner_session].push(a);
+                tuned[block.winner_session].push(b);
+                all_baseline.push(a);
+                all_tuned.push(b);
+            }
+        }
+        let left_winner = PairedTiming::new(&baseline[0], &tuned[0])?;
+        let right_winner = PairedTiming::new(&baseline[1], &tuned[1])?;
+        let pooled = PairedTiming::new(&all_baseline, &all_tuned)?;
+        let guards = [&left_winner, &right_winner, &pooled];
+        let decision = if !valid {
+            "numerical_failure"
+        } else if changed == 0 {
+            "unchanged_selection"
+        } else if !control_stable {
+            "unstable_control"
+        } else if guards.iter().all(|g| g.improvement_exceeds_guard) {
+            "confirmed_gain"
+        } else if guards.iter().all(|g| g.regression_exceeds_guard) {
+            "confirmed_regression"
+        } else {
+            "inconclusive"
+        };
+        Ok(Self {
+            control,
+            control_stable,
+            left_winner,
+            right_winner,
+            pooled,
+            decision: decision.into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pair(left_ms: f64, right_ms: f64) -> Pair {
+        Pair {
+            step: 0,
+            first_session: 0,
+            left_ms,
+            right_ms,
+            left_loss: None,
+            right_loss: None,
+        }
+    }
+
+    #[test]
+    fn crossover_requires_both_roles_stable_controls_changes_and_numerics() {
+        let control = vec![pair(10.0, 10.0); CONTROL_PAIRS];
+        let mut blocks: Vec<_> = winner_order(0)
+            .into_iter()
+            .map(|winner_session| Block {
+                winner_session,
+                pairs: vec![
+                    if winner_session == 0 {
+                        pair(8.0, 10.0)
+                    } else {
+                        pair(10.0, 8.0)
+                    };
+                    BLOCK_PAIRS
+                ],
+            })
+            .collect();
+        assert_eq!(
+            Confirmation::new(&control, &blocks, 1, true)
+                .unwrap()
+                .decision,
+            "confirmed_gain"
+        );
+        assert_eq!(
+            Confirmation::new(&control, &blocks, 0, true)
+                .unwrap()
+                .decision,
+            "unchanged_selection"
+        );
+        assert_eq!(
+            Confirmation::new(&control, &blocks, 1, false)
+                .unwrap()
+                .decision,
+            "numerical_failure"
+        );
+        let biased = vec![pair(10.0, 8.0); CONTROL_PAIRS];
+        assert_eq!(
+            Confirmation::new(&biased, &blocks, 1, true)
+                .unwrap()
+                .decision,
+            "unstable_control"
+        );
+        let noisy: Vec<_> = (0..CONTROL_PAIRS)
+            .map(|i| pair(10.0, if i % 2 == 0 { 9.0 } else { 11.0 }))
+            .collect();
+        assert_eq!(
+            Confirmation::new(&noisy, &blocks, 1, true)
+                .unwrap()
+                .decision,
+            "unstable_control"
+        );
+        let mut regression = blocks.clone();
+        for block in &mut regression {
+            for pair in &mut block.pairs {
+                std::mem::swap(&mut pair.left_ms, &mut pair.right_ms);
+            }
+        }
+        assert_eq!(
+            Confirmation::new(&control, &regression, 1, true)
+                .unwrap()
+                .decision,
+            "confirmed_regression"
+        );
+        for block in &mut blocks {
+            block.pairs = vec![pair(8.0, 10.0); BLOCK_PAIRS];
+        }
+        assert_eq!(
+            Confirmation::new(&control, &blocks, 1, true)
+                .unwrap()
+                .decision,
+            "inconclusive"
+        );
+        assert!(Confirmation::new(&control[..39], &blocks, 1, true).is_err());
+        blocks[0].winner_session = 5;
+        assert!(Confirmation::new(&control, &blocks, 1, true).is_err());
+    }
+}

--- a/examples/support/experiment_io.rs
+++ b/examples/support/experiment_io.rs
@@ -1,0 +1,55 @@
+use serde_json::{Value, json};
+use std::{
+    error::Error,
+    fs::File,
+    io::{Seek, SeekFrom, Write},
+    path::Path,
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+pub fn command(program: &str, args: &[&str]) -> Result<String, Box<dyn Error>> {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()?;
+    if !output.status.success() {
+        return Err(format!("{program}: {}", String::from_utf8_lossy(&output.stderr)).into());
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+pub fn sha256(path: &Path) -> Result<String, Box<dyn Error>> {
+    let path = path.to_str().ok_or("non-UTF8 path")?;
+    let output =
+        command("sha256sum", &[path]).or_else(|_| command("shasum", &["-a", "256", path]))?;
+    Ok(output
+        .split_whitespace()
+        .next()
+        .ok_or("missing hash")?
+        .into())
+}
+
+pub fn write_record(file: &mut File, record: &Value) -> Result<(), Box<dyn Error>> {
+    file.seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
+    serde_json::to_writer_pretty(&mut *file, record)?;
+    file.flush()?;
+    Ok(())
+}
+
+pub fn unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+pub fn host_sample() -> Value {
+    json!({
+        "unix_ms": unix_ms(),
+        "loadavg": std::fs::read_to_string("/proc/loadavg").ok(),
+        "cpu_ticks": std::fs::read_to_string("/proc/stat").ok().and_then(|s| s.lines().next().map(str::to_owned)),
+        "cpu0_frequency_khz": std::fs::read_to_string("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq").ok(),
+    })
+}

--- a/examples/support/gpu_monitor.rs
+++ b/examples/support/gpu_monitor.rs
@@ -1,0 +1,84 @@
+//! Optional continuous telemetry. Its overhead is part of this experiment.
+use super::experiment_io::unix_ms;
+use serde_json::{Value, json};
+use std::{
+    io::{BufRead, BufReader},
+    process::{Child, Command, Stdio},
+    sync::{Arc, Mutex},
+    thread::JoinHandle,
+};
+
+const MAX_SAMPLES: usize = 40_000;
+const FIELDS: &str = "timestamp,uuid,utilization.gpu,memory.used,clocks.gr,clocks.mem,power.draw,temperature.gpu,pstate";
+
+pub struct Monitor {
+    child: Option<Child>,
+    reader: Option<JoinHandle<()>>,
+    samples: Arc<Mutex<Vec<Value>>>,
+    error: Option<String>,
+}
+
+impl Monitor {
+    pub fn start() -> Self {
+        let mut monitor = Self {
+            child: None,
+            reader: None,
+            samples: Arc::default(),
+            error: None,
+        };
+        match Command::new("nvidia-smi")
+            .args([
+                format!("--query-gpu={FIELDS}"),
+                "--format=csv,noheader,nounits".into(),
+                "--loop-ms=250".into(),
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(mut child) => {
+                let output = child.stdout.take().unwrap();
+                let samples = monitor.samples.clone();
+                monitor.reader = Some(std::thread::spawn(move || {
+                    for line in BufReader::new(output).lines() {
+                        let Ok(line) = line else {
+                            break;
+                        };
+                        let mut samples = samples.lock().unwrap();
+                        if samples.len() < MAX_SAMPLES {
+                            samples.push(json!({"received_unix_ms": unix_ms(), "csv": line}));
+                        }
+                    }
+                }));
+                monitor.child = Some(child);
+            }
+            Err(error) => monitor.error = Some(error.to_string()),
+        }
+        monitor
+    }
+
+    pub fn finish(mut self) -> Value {
+        self.stop();
+        let samples = self.samples.lock().unwrap();
+        json!({"fields": FIELDS, "requested_interval_ms": 250, "sample_cap": MAX_SAMPLES, "cap_reached": samples.len() == MAX_SAMPLES, "error": self.error, "samples": *samples})
+    }
+
+    fn stop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            if let Ok(Some(status)) = child.try_wait() {
+                self.error = Some(format!("telemetry exited before stop: {status}"));
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+impl Drop for Monitor {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/examples/support/holdout_workloads.rs
+++ b/examples/support/holdout_workloads.rs
@@ -1,0 +1,429 @@
+//! Deterministic workloads and full-state comparisons shared by tuning experiments.
+
+use super::measurement::TensorComparison;
+use meganeura::{
+    CoopPolicy, Graph, Mode, Session, SessionConfig, SessionOptions,
+    compile::CompileOptions,
+    graph::{NodeId, Op},
+};
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Instant,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub enum Work {
+    Inference,
+    ForwardLossBackward,
+    Sgd,
+    Adam,
+}
+
+impl Work {
+    pub fn adam_step_after(self, steps: usize) -> u32 {
+        if self == Self::Adam { steps as u32 } else { 0 }
+    }
+}
+
+enum Input {
+    F32(&'static str, Vec<f32>),
+    U32(&'static str, Vec<u32>),
+}
+
+pub struct Case {
+    pub name: &'static str,
+    pub description: Value,
+    pub work: Work,
+    graph: Graph,
+    inputs: Vec<Input>,
+    output_elements: usize,
+}
+
+fn data(count: usize, seed: u32, scale: f32) -> Vec<f32> {
+    let mut state = seed;
+    (0..count)
+        .map(|_| {
+            state = state.wrapping_mul(747796405).wrapping_add(2891336453);
+            let word = ((state >> ((state >> 28) + 4)) ^ state).wrapping_mul(277803737);
+            (((((word >> 22) ^ word) >> 8) as f32 / 16_777_216.0) - 0.5) * scale
+        })
+        .collect()
+}
+
+fn labels(rows: usize, classes: usize) -> Vec<f32> {
+    let mut values = vec![0.0; rows * classes];
+    for row in 0..rows {
+        values[row * classes + (row + 1) % classes] = 1.0;
+    }
+    values
+}
+
+pub fn cases() -> Vec<Case> {
+    let mut cases = Vec::new();
+    for work in [Work::Inference, Work::Adam] {
+        let mut graph = Graph::new();
+        let x = graph.input("input", &[127, 384]);
+        let w1 = graph.parameter("first.weight", &[384, 640]);
+        let b1 = graph.parameter("first.bias", &[640]);
+        let h = graph.matmul(x, w1);
+        let h = graph.bias_add(h, b1);
+        let h = graph.gelu(h);
+        let w2 = graph.parameter("second.weight", &[640, 256]);
+        let b2 = graph.parameter("second.bias", &[256]);
+        let y = graph.matmul(h, w2);
+        let y = graph.bias_add(y, b2);
+        let mut inputs = vec![Input::F32("input", data(127 * 384, 1, 2.0))];
+        let output = if work == Work::Adam {
+            let labels = graph.input("labels", &[127, 256]);
+            inputs.push(Input::F32("labels", self::labels(127, 256)));
+            graph.cross_entropy_loss(y, labels)
+        } else {
+            y
+        };
+        graph.set_outputs(vec![output]);
+        cases.push(Case {
+            name: if work == Work::Inference { "mlp-inference" } else { "mlp-adam" },
+            description: json!({"rows": 127, "widths": [384, 640, 256], "activation": "GELU", "bias": true}),
+            work,
+            graph,
+            inputs,
+            output_elements: 127 * 256,
+        });
+    }
+    for work in [Work::Inference, Work::Adam] {
+        use meganeura::models::smollm2::{self, SmolLM2Config};
+        let config = SmolLM2Config::medium_test();
+        let seq = 127;
+        let graph = if work == Work::Adam {
+            smollm2::build_training_graph(&config, seq)
+        } else {
+            let mut graph = Graph::new();
+            let y = smollm2::build_graph(&mut graph, &config, seq);
+            graph.set_outputs(vec![y]);
+            graph
+        };
+        let mut inputs = vec![Input::U32(
+            "token_ids",
+            (0..seq).map(|i| (i % config.vocab_size) as u32).collect(),
+        )];
+        if work == Work::Adam {
+            inputs.push(Input::F32("labels", labels(seq, config.vocab_size)));
+        }
+        cases.push(Case {
+            name: if work == Work::Inference { "smollm2-inference" } else { "smollm2-adam" },
+            description: json!({"builder": "SmolLM2Config::medium_test", "sequence": seq, "layers": config.num_hidden_layers, "hidden": config.hidden_size, "ffn": config.intermediate_size, "heads": config.num_attention_heads, "kv_heads": config.num_key_value_heads, "vocabulary": config.vocab_size, "kv_cache": false}),
+            work,
+            graph,
+            inputs,
+            output_elements: seq * config.vocab_size,
+        });
+    }
+    let config = meganeura::models::whisper::WhisperConfig::whisper_tiny();
+    cases.push(Case {
+        name: "whisper-sgd",
+        description: json!({"builder": "WhisperConfig::whisper_tiny encoder", "batch": 1, "mel_frames": 100, "hidden": config.d_model, "layers": config.n_layers, "loss": "mean squared encoder output"}),
+        work: Work::Sgd,
+        graph: meganeura::models::whisper::build_training_graph(&config, 1, 100),
+        inputs: vec![Input::F32("mel", data(config.n_mels * 100, 1, 2.0))],
+        output_elements: 1,
+    });
+    cases.push(Case {
+        name: "resnet50-flb",
+        description: json!({"builder": "build_resnet50_training", "batch": 1, "image": [3, 224, 224], "classes": 1000, "batch_norm": "folded, not running-statistic training", "loss": "cross entropy"}),
+        work: Work::ForwardLossBackward,
+        graph: meganeura::models::resnet::build_resnet50_training(1),
+        inputs: vec![
+            Input::F32("image", data(3 * 224 * 224, 1, 2.0)),
+            Input::F32("labels", labels(1, 1000)),
+        ],
+        output_elements: 1,
+    });
+    cases
+}
+
+#[allow(dead_code)] // Shared module also builds in the original holdout runner.
+pub fn crossover_cases() -> Vec<Case> {
+    let mut graph = Graph::new();
+    let mut x = graph.input("input", &[128, 512]);
+    for layer in 0..8 {
+        let w = graph.parameter(&format!("layer{layer}"), &[512, 512]);
+        x = graph.matmul(x, w);
+    }
+    graph.set_outputs(vec![x]);
+    let mut result = vec![Case {
+        name: "dense-inference",
+        description: json!({"rows": 128, "width": 512, "layers": 8, "activation": null}),
+        work: Work::Inference,
+        graph,
+        inputs: vec![Input::F32("input", data(128 * 512, 1, 2.0))],
+        output_elements: 128 * 512,
+    }];
+    result.extend(
+        cases()
+            .into_iter()
+            .filter(|c| matches!(c.name, "mlp-adam" | "resnet50-flb")),
+    );
+    result
+}
+
+#[allow(dead_code)] // Only the convolution crossover uses this diagnostic roster.
+pub fn conv_derivative_cases() -> Vec<Case> {
+    let mut result: Vec<_> = cases()
+        .into_iter()
+        .filter(|c| c.name == "resnet50-flb")
+        .collect();
+    for work in [Work::Adam, Work::Sgd] {
+        let mut graph = Graph::new();
+        let x = graph.input("input", &[2 * 5 * 17 * 19]);
+        let w1 = graph.parameter("first.weight", &[17 * 5 * 3 * 2]);
+        let h = graph.conv2d_hw(x, w1, 2, 5, 17, 19, 17, 3, 2, 1, 2, 0);
+        let w2 = graph.parameter("second.weight", &[33 * 17 * 2 * 3]);
+        let y = graph.conv2d_hw(h, w2, 2, 17, 19, 18, 33, 2, 3, 2, 0, 1);
+        let squared = graph.mul(y, y);
+        let loss = graph.mean_all(squared);
+        graph.set_outputs(vec![loss]);
+        result.push(Case {
+            name: if work == Work::Adam {
+                "conv-edges-adam"
+            } else {
+                "conv-edges-sgd"
+            },
+            description: json!({"batch": 2, "input": [5, 17, 19], "channels": [17, 33],
+                "kernels": [[3, 2], [2, 3]], "strides": [1, 2], "padding": [[2, 0], [0, 1]],
+                "activation": null, "loss": "mean squared output"}),
+            work,
+            graph,
+            inputs: vec![Input::F32("input", data(2 * 5 * 17 * 19, 1, 2.0))],
+            output_elements: 1,
+        });
+    }
+    result
+}
+
+fn initialize(case: &Case, session: &mut Session) {
+    let mut ones = HashSet::<NodeId>::new();
+    let mut zeros = HashSet::<NodeId>::new();
+    let mut fan_in = HashMap::<NodeId, usize>::new();
+    for node in case.graph.nodes() {
+        match node.op {
+            Op::RmsNorm { .. } => {
+                ones.insert(node.inputs[1]);
+            }
+            Op::LayerNorm { .. } => {
+                ones.insert(node.inputs[1]);
+                zeros.insert(node.inputs[2]);
+            }
+            Op::BiasAdd | Op::AddPerChannel { .. } => {
+                zeros.insert(node.inputs[1]);
+            }
+            Op::Conv2d {
+                in_channels,
+                kernel_h,
+                kernel_w,
+                ..
+            } => {
+                fan_in.insert(node.inputs[1], (in_channels * kernel_h * kernel_w) as usize);
+            }
+            _ => {}
+        }
+    }
+    for node in case.graph.nodes() {
+        let Op::Parameter { ref name } = node.op else {
+            continue;
+        };
+        assert!(
+            session.has_parameter(name),
+            "original parameter {name} missing"
+        );
+        let values = if ones.contains(&node.id) {
+            vec![1.0; node.ty.num_elements()]
+        } else if zeros.contains(&node.id) {
+            vec![0.0; node.ty.num_elements()]
+        } else {
+            let fan = fan_in.get(&node.id).copied().unwrap_or(node.ty.shape[0]);
+            data(
+                node.ty.num_elements(),
+                node.id + 2,
+                (12.0 / fan as f32).sqrt(),
+            )
+        };
+        session.set_parameter(name, &values);
+    }
+    for input in &case.inputs {
+        match input {
+            Input::F32(name, values) => session.set_input(name, values),
+            Input::U32(name, values) => session.set_input_u32(name, values),
+        }
+    }
+    match case.work {
+        Work::Adam => session.set_adam(1e-4, 0.9, 0.999, 1e-8),
+        Work::Sgd => session.set_learning_rate(1e-3),
+        _ => {}
+    }
+    if matches!(case.work, Work::Adam | Work::Sgd) {
+        session.set_grad_clip_norm(1.0);
+    }
+}
+
+pub fn compile_options() -> CompileOptions {
+    CompileOptions {
+        flash_forward_coop: false,
+        flash_backward_coop: false,
+        ..Default::default()
+    }
+}
+
+pub fn runtime_options(policy: CoopPolicy) -> SessionOptions {
+    SessionOptions {
+        coop: policy,
+        ..Default::default()
+    }
+}
+
+pub fn make_session(
+    case: &Case,
+    gpu: &Arc<blade_graphics::Context>,
+    policy: CoopPolicy,
+) -> (Session, Value) {
+    let start = Instant::now();
+    let (mut session, _) = meganeura::build(
+        &case.graph,
+        SessionConfig {
+            mode: if case.work == Work::Inference {
+                Mode::Inference
+            } else {
+                Mode::Training
+            },
+            gpu: Some(Arc::clone(gpu)),
+            runtime: runtime_options(policy),
+            options: compile_options(),
+            ..Default::default()
+        },
+    );
+    let build_ms = start.elapsed().as_secs_f64() * 1e3;
+    let start = Instant::now();
+    initialize(case, &mut session);
+    let initialization_ms = start.elapsed().as_secs_f64() * 1e3;
+    (
+        session,
+        json!({"build_ms": build_ms, "initialization_ms": initialization_ms}),
+    )
+}
+
+pub struct Snapshot {
+    pub tensors: Vec<(String, Vec<f32>)>,
+    pub adam_step: u32,
+    pub adam_bytes: usize,
+}
+
+pub fn snapshot(session: &mut Session, case: &Case) -> Snapshot {
+    session.wait();
+    let names = session.param_names();
+    let mut tensors: Vec<_> = names
+        .iter()
+        .zip(session.read_params(&names))
+        .map(|(name, values)| (format!("parameter.{name}"), values))
+        .collect();
+    let gradient_names: Vec<_> = names
+        .iter()
+        .copied()
+        .filter(|name| session.has_param_grad(name))
+        .collect();
+    for &name in &gradient_names {
+        let mut values = vec![0.0; session.param_size(name).unwrap()];
+        session.read_param_grad(name, &mut values);
+        tensors.push((format!("gradient.{name}"), values));
+    }
+    let adam_bytes = session.memory_summary().adam_state_bytes;
+    if adam_bytes != 0 {
+        for (name, (m, v)) in gradient_names
+            .iter()
+            .zip(session.read_adam_states(&gradient_names))
+        {
+            tensors.push((format!("adam_m.{name}"), m));
+            tensors.push((format!("adam_v.{name}"), v));
+        }
+    }
+    if case.work == Work::Inference {
+        tensors.push(("output".into(), session.read_output(case.output_elements)));
+    } else {
+        let loss = session.plan().loss_buffer.unwrap();
+        let mut partials = vec![0.0; session.plan().buffers[loss.0 as usize] / 4];
+        session.read_buffer(loss, &mut partials);
+        tensors.push(("loss_partials".into(), partials));
+        tensors.push(("loss".into(), vec![session.read_loss()]));
+    }
+    Snapshot {
+        tensors,
+        adam_step: session.adam_step_count(),
+        adam_bytes,
+    }
+}
+
+#[derive(Serialize)]
+pub struct Comparison {
+    stage: &'static str,
+    expected_adam_step: u32,
+    baseline_adam_step: u32,
+    tuned_adam_step: u32,
+    same_moment_allocation: bool,
+    pub exact: bool,
+    pub passed: bool,
+    pub tensors: Vec<TensorComparison>,
+}
+
+pub fn compare(
+    stage: &'static str,
+    expected_adam_step: u32,
+    a: &Snapshot,
+    b: &Snapshot,
+) -> Comparison {
+    assert_eq!(a.tensors.len(), b.tensors.len());
+    let tensors: Vec<_> = a
+        .tensors
+        .iter()
+        .zip(&b.tensors)
+        .map(|((name, a), (other, b))| {
+            assert_eq!(name, other);
+            TensorComparison::new(name.clone(), a, b)
+        })
+        .collect();
+    let state_matches = a.adam_step == expected_adam_step
+        && b.adam_step == expected_adam_step
+        && a.adam_bytes == b.adam_bytes;
+    Comparison {
+        stage,
+        expected_adam_step,
+        baseline_adam_step: a.adam_step,
+        tuned_adam_step: b.adam_step,
+        same_moment_allocation: a.adam_bytes == b.adam_bytes,
+        exact: state_matches && tensors.iter().all(|t| t.exact),
+        passed: state_matches && tensors.iter().all(|t| t.passed),
+        tensors,
+    }
+}
+
+pub fn memory(session: &Session) -> Value {
+    let m = session.memory_summary();
+    json!({
+        "plan_capacity_bytes": m.total_buffer_bytes,
+        "graph_allocation_bytes": m.allocated_buffer_bytes,
+        "adam_bytes": m.adam_state_bytes,
+        "accumulator_bytes": m.grad_accumulator_bytes,
+        "auxiliary_bytes": m.optimizer_aux_bytes,
+        "resident_buffer_requests": m.total_allocated_bytes(),
+        "device_local_bytes": m.device_local_bytes,
+        "process_api_sample": session.device_memory_stats().map(|s| json!({"usage_bytes": s.usage_bytes, "budget_bytes": s.budget_bytes})),
+    })
+}
+
+#[allow(dead_code)] // The readback experiment continues these workloads without timing steps.
+pub fn step_ms(session: &mut Session) -> f64 {
+    let start = Instant::now();
+    session.step();
+    session.wait();
+    start.elapsed().as_secs_f64() * 1e3
+}

--- a/examples/support/preparation_measurement.rs
+++ b/examples/support/preparation_measurement.rs
@@ -1,0 +1,51 @@
+//! Allocation/cleanup accounting added after the retained readback cohort.
+use super::readback;
+use meganeura::TuneReport;
+use std::collections::BTreeMap;
+
+pub fn costs(report: &TuneReport) -> Result<BTreeMap<String, f64>, &'static str> {
+    let mut times = readback::costs(report)?;
+    for outcome in &report.outcomes {
+        let phases = outcome.phase_times.ok_or("missing phases")?;
+        let prep = phases
+            .preparation_breakdown
+            .ok_or("missing preparation breakdown")?;
+        for (key, duration) in [
+            ("prep_checks", prep.checks),
+            ("prep_pipelines", prep.pipelines),
+            ("prep_buffers", prep.buffers),
+            ("prep_staging", prep.staging),
+            ("prep_encoder", prep.encoder),
+            ("prep_bindings", prep.bindings),
+            ("cleanup", phases.cleanup),
+        ] {
+            *times.entry(key.into()).or_default() +=
+                duration.ok_or("unreached phase")?.as_secs_f64() * 1e3;
+        }
+    }
+    let nested: f64 = [
+        "prep_checks",
+        "prep_pipelines",
+        "prep_buffers",
+        "prep_staging",
+        "prep_encoder",
+        "prep_bindings",
+    ]
+    .iter()
+    .map(|key| times[*key])
+    .sum();
+    let remainder = times["preparation"] - nested;
+    if remainder < 0.0 {
+        return Err("nested times exceed preparation");
+    }
+    times.insert("preparation_other".into(), remainder);
+    // Fresh has no retained resource to release. Reuse records the final release
+    // separately, within total search, not within a comparison's cleanup.
+    *times.get_mut("cleanup").unwrap() +=
+        report.final_cleanup.unwrap_or_default().as_secs_f64() * 1e3;
+    times.insert(
+        "staging_and_cleanup".into(),
+        times["prep_staging"] + times["cleanup"],
+    );
+    Ok(times)
+}

--- a/examples/support/readback_measurement.rs
+++ b/examples/support/readback_measurement.rs
@@ -1,0 +1,93 @@
+//! Fixed readback experiment accounting, shared by the runner and CPU replay.
+use meganeura::{TuneDecision, TuneReport};
+use std::collections::BTreeMap;
+
+pub const PROCESSES: usize = 6;
+pub const PREFIX: usize = 3;
+pub const MIDDLE: usize = 33;
+pub const FINAL: usize = 178;
+
+pub fn search_order(seed: usize, case: usize) -> [usize; 2] {
+    let first = (seed + case) % 2;
+    [first, 1 - first]
+}
+
+pub fn costs(report: &TuneReport) -> Result<BTreeMap<String, f64>, &'static str> {
+    if report.outcomes.is_empty() || report.time_budget_exhausted || report.class_limit_reached {
+        return Err("incomplete search");
+    }
+    let mut times = BTreeMap::<String, f64>::new();
+    times.insert("elapsed".into(), report.elapsed.as_secs_f64() * 1e3);
+    for outcome in &report.outcomes {
+        if !outcome.qualified
+            || outcome.failure.is_some()
+            || !matches!(
+                outcome.decision,
+                TuneDecision::FasterCandidate | TuneDecision::KeepBaseline
+            )
+        {
+            return Err("unqualified or incomplete comparison");
+        }
+        let phases = outcome.phase_times.ok_or("missing phases")?;
+        let detail = phases
+            .qualification_breakdown
+            .ok_or("missing qualification breakdown")?;
+        for (name, duration) in [
+            ("preparation", phases.preparation),
+            ("qualification", phases.qualification),
+            ("warmup", phases.warmup),
+            ("sampling", phases.sampling),
+            ("compile", Some(outcome.compile_time)),
+            ("input_preparation", detail.input_preparation),
+            ("upload_host_copy", detail.upload_host_copy),
+            ("upload_transfer", detail.upload_transfer),
+            ("dispatch", detail.dispatch),
+            ("readback_transfer", detail.readback_transfer),
+            ("readback_host_copy", detail.readback_host_copy),
+            ("validation", detail.validation),
+        ] {
+            *times.entry(name.into()).or_default() +=
+                duration.ok_or("unreached phase")?.as_secs_f64() * 1e3;
+        }
+    }
+    let nested: f64 = [
+        "input_preparation",
+        "upload_host_copy",
+        "upload_transfer",
+        "dispatch",
+        "readback_transfer",
+        "readback_host_copy",
+        "validation",
+    ]
+    .iter()
+    .map(|key| times[*key])
+    .sum();
+    let remainder = times["qualification"] - nested;
+    if remainder < 0.0 {
+        return Err("nested times exceed qualification");
+    }
+    times.insert("qualification_other".into(), remainder);
+    Ok(times)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_order_is_balanced_and_missing_phases_are_not_zero_cost() {
+        for case in 0..3 {
+            assert_eq!(
+                (1..=PROCESSES)
+                    .filter(|seed| search_order(*seed, case)[0] == 0)
+                    .count(),
+                3
+            );
+            for seed in 1..=PROCESSES {
+                let order = search_order(seed, case);
+                assert_ne!(order[0], order[1]);
+            }
+        }
+        assert!(costs(&TuneReport::default()).is_err());
+    }
+}

--- a/examples/support/tuning_diagnostic.rs
+++ b/examples/support/tuning_diagnostic.rs
@@ -1,0 +1,209 @@
+//! Matched private-resource diagnostics; no whole-step speed claim.
+#[path = "experiment_io.rs"]
+mod experiment_io;
+#[path = "gpu_monitor.rs"]
+mod gpu_monitor;
+#[path = "tuning_measurement.rs"]
+#[allow(dead_code)] // Whole-step timing arithmetic is only used by the cohort replay.
+mod measurement;
+#[path = "preparation_measurement.rs"]
+mod preparation;
+#[path = "readback_measurement.rs"]
+mod readback;
+#[path = "holdout_workloads.rs"]
+mod workloads;
+
+use experiment_io::{command, host_sample, sha256, unix_ms, write_record};
+use measurement::TensorComparison;
+use meganeura::{CoopPolicy, Session, TuneOptions};
+use readback::{FINAL, MIDDLE, PREFIX, PROCESSES, search_order};
+use serde_json::{Value, json};
+use std::{error::Error, fs::OpenOptions, path::Path, sync::Arc};
+use workloads::*;
+
+fn snapshots(sessions: &mut [Session; 2], case: &Case) -> [Snapshot; 2] {
+    let [left, right] = sessions;
+    [snapshot(left, case), snapshot(right, case)]
+}
+
+fn run_case(
+    case: &Case,
+    gpu: &Arc<blade_graphics::Context>,
+    seed: usize,
+    case_index: usize,
+    labels: [&str; 2],
+    options: &[TuneOptions; 2],
+) -> Result<Value, Box<dyn Error>> {
+    let (shared, shared_build) = make_session(case, gpu, CoopPolicy::Disabled);
+    let (download, download_build) = make_session(case, gpu, CoopPolicy::Disabled);
+    let mut sessions = [shared, download];
+    let keys = sessions[0].dispatch_pipeline_keys();
+    assert_eq!(keys, sessions[1].dispatch_pipeline_keys());
+    let mut record = json!({"name": case.name, "work": case.work, "description": case.description,
+        "status": "running", "build": [shared_build, download_build], "host_start": host_sample(),
+        "initial_pipeline_keys": keys, "search_order": search_order(seed, case_index),
+        "searches": [null, null], "loss_trajectory": []});
+    for _ in 0..PREFIX {
+        for session in &mut sessions {
+            session.step();
+            session.wait();
+        }
+    }
+    let before = snapshots(&mut sessions, case);
+    let prefix = compare(
+        "prefix",
+        case.work.adam_step_after(PREFIX),
+        &before[0],
+        &before[1],
+    );
+    let mut valid = prefix.passed;
+    record["prefix_comparison"] = serde_json::to_value(prefix)?;
+    if !valid {
+        record["status"] = json!("prefix_failed");
+        return Ok(record);
+    }
+    for index in search_order(seed, case_index) {
+        let session = &mut sessions[index];
+        let memory_before = memory(session);
+        let host = host_sample();
+        let started = unix_ms();
+        let report = session.tune_with(options[index].clone())?;
+        let finished = unix_ms();
+        let after = snapshot(session, case);
+        let comparison = compare(
+            "search",
+            case.work.adam_step_after(PREFIX),
+            &before[index],
+            &after,
+        );
+        valid &= comparison.passed && comparison.exact;
+        let costs = preparation::costs(&report);
+        valid &= costs.is_ok();
+        let search_costs = match costs {
+            Ok(value) => serde_json::to_value(value)?,
+            Err(error) => json!({"error": error}),
+        };
+        record["searches"][index] = json!({"arm": labels[index], "staging": report.options.staging,
+            "staging_reuse": report.options.staging_reuse, "host_start": host,
+            "started_unix_ms": started, "finished_unix_ms": finished, "report": report,
+            "state_comparison": comparison, "cost_ms": search_costs,
+            "selected_pipeline_keys": session.dispatch_pipeline_keys(),
+            "memory_before": memory_before, "memory_after": memory(session)});
+    }
+    drop(before);
+    for age in PREFIX + 1..=FINAL {
+        let first = (age + seed) % 2;
+        for index in [first, 1 - first] {
+            sessions[index].step();
+            sessions[index].wait();
+        }
+        if case.work != Work::Inference {
+            let a = sessions[0].read_loss();
+            let b = sessions[1].read_loss();
+            valid &= TensorComparison::new("loss".into(), &[a], &[b]).passed;
+            record["loss_trajectory"]
+                .as_array_mut()
+                .unwrap()
+                .push(json!({"step": age, (labels[0]): a, (labels[1]): b}));
+        }
+        if age == MIDDLE || age == FINAL {
+            let state = snapshots(&mut sessions, case);
+            let comparison = compare(
+                if age == MIDDLE { "middle" } else { "final" },
+                case.work.adam_step_after(age),
+                &state[0],
+                &state[1],
+            );
+            valid &= comparison.passed;
+            record[if age == MIDDLE {
+                "middle_comparison"
+            } else {
+                "final_comparison"
+            }] = serde_json::to_value(comparison)?;
+        }
+    }
+    record["final_memory"] = json!([memory(&sessions[0]), memory(&sessions[1])]);
+    record["final_age"] = json!(FINAL);
+    record["host_finish"] = host_sample();
+    record["status"] = json!(if valid {
+        "complete"
+    } else {
+        "validation_failed"
+    });
+    eprintln!(
+        "{}: {} {} ms, {} {} ms; {}",
+        case.name,
+        labels[0],
+        record["searches"][0]["cost_ms"]["elapsed"],
+        labels[1],
+        record["searches"][1]["cost_ms"]["elapsed"],
+        record["status"]
+    );
+    Ok(record)
+}
+
+pub fn run(
+    protocol: &str,
+    labels: [&str; 2],
+    options: [TuneOptions; 2],
+) -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+    let mut args = std::env::args_os().skip(1);
+    let path = args
+        .next()
+        .ok_or("usage: <example> <new-output.json> <seed 1..6>")?;
+    let seed: usize = args
+        .next()
+        .ok_or("missing seed")?
+        .to_str()
+        .ok_or("non-UTF8 seed")?
+        .parse()?;
+    if !(1..=PROCESSES).contains(&seed) || args.next().is_some() {
+        return Err("expected one output and seed 1..6".into());
+    }
+    if !command("git", &["status", "--porcelain", "--untracked-files=no"])?.is_empty() {
+        return Err("commit tracked source before measuring".into());
+    }
+    let mut output = OpenOptions::new().write(true).create_new(true).open(path)?;
+    let before = command("nvidia-smi", &[]).ok();
+    let monitor = gpu_monitor::Monitor::start();
+    let gpu = Arc::new(meganeura::init_gpu_context()?);
+    let info = gpu.device_information();
+    let caps = &gpu.capabilities().cooperative_matrix;
+    let mut document = json!({"schema_version": 1, "protocol": protocol, "status": "running",
+        "metadata": {"revision": command("git", &["rev-parse", "HEAD"])?, "tracked_source_clean": true,
+            "cargo_lock_sha256": sha256(&Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock"))?,
+            "executable_sha256": sha256(&std::env::current_exe()?)?, "rustc": command("rustc", &["--version"])?,
+            "seed": seed, "process_id": std::process::id(), "started_unix_ms": unix_ms(),
+            "device": {"name": info.device_name, "driver": info.driver_info, "f32_tile": caps.f32_tile, "f16_tile": caps.f16_tile},
+            "cooperative_policy": "Disabled", "compile_options": compile_options(),
+            "runtime_options": format!("{:?}", runtime_options(CoopPolicy::Disabled)), "optimize": meganeura::optimize::OptimizeConfig::default(),
+            "prefix": PREFIX, "middle": MIDDLE, "final": FINAL,
+            "arms": labels, "search_options": options,
+            "contract": "strict f32; private staging policy only; full ordinary/tiny qualification unchanged; no whole-step speed claim",
+            "nvidia_smi_before": before, "rustflags": std::env::var("RUSTFLAGS").ok(),
+            "optimizer": {"adam_lr": 1e-4, "beta1": 0.9, "beta2": 0.999, "epsilon": 1e-8, "clip_norm": 1.0, "clip_every": 1, "accumulation": false, "decay": 0.0}}, "cases": []});
+    write_record(&mut output, &document)?;
+    let mut valid = true;
+    for (index, case) in crossover_cases().into_iter().enumerate() {
+        eprintln!("running {}", case.name);
+        let record = run_case(&case, &gpu, seed, index, labels, &options).unwrap_or_else(
+            |e| json!({"name": case.name, "status": "error", "error": e.to_string()}),
+        );
+        valid &= record["status"] == "complete";
+        document["cases"].as_array_mut().unwrap().push(record);
+        write_record(&mut output, &document)?;
+    }
+    document["telemetry"] = monitor.finish();
+    document["finished_unix_ms"] = json!(unix_ms());
+    document["status"] = json!(if valid {
+        "complete"
+    } else {
+        "validation_failed"
+    });
+    write_record(&mut output, &document)?;
+    if !valid {
+        return Err("validation failed; completed records retained".into());
+    }
+    Ok(())
+}

--- a/examples/support/tuning_measurement.rs
+++ b/examples/support/tuning_measurement.rs
@@ -1,0 +1,144 @@
+//! CPU-only evidence arithmetic shared by the holdout runner and replay tests.
+
+use serde::{Deserialize, Serialize};
+
+pub fn median(values: &[f64]) -> f64 {
+    assert!(!values.is_empty());
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let mid = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        sorted[mid - 1] * 0.5 + sorted[mid] * 0.5
+    } else {
+        sorted[mid]
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PairedTiming {
+    pub baseline_median_ms: f64,
+    pub tuned_median_ms: f64,
+    pub speedup: f64,
+    pub paired_gain_median_ms: f64,
+    pub paired_noise_margin_ms: f64,
+    pub improvement_exceeds_guard: bool,
+    pub regression_exceeds_guard: bool,
+}
+
+impl PairedTiming {
+    pub fn new(baseline: &[f64], tuned: &[f64]) -> Result<Self, &'static str> {
+        if baseline.len() != tuned.len()
+            || baseline.is_empty()
+            || !baseline
+                .iter()
+                .chain(tuned)
+                .all(|v| v.is_finite() && *v > 0.0)
+        {
+            return Err("timings must be complete, finite, positive pairs");
+        }
+        let a = median(baseline);
+        let b = median(tuned);
+        let differences: Vec<_> = baseline.iter().zip(tuned).map(|(a, b)| a - b).collect();
+        let gain = median(&differences);
+        let noise = 2.0
+            * median(
+                &differences
+                    .iter()
+                    .map(|d| (d - gain).abs())
+                    .collect::<Vec<_>>(),
+            );
+        Ok(Self {
+            baseline_median_ms: a,
+            tuned_median_ms: b,
+            speedup: a / b,
+            paired_gain_median_ms: gain,
+            paired_noise_margin_ms: noise,
+            improvement_exceeds_guard: a - b > 0.05 * a + noise && gain > 0.05 * a + noise,
+            regression_exceeds_guard: b - a > 0.05 * a + noise && -gain > 0.05 * a + noise,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TensorComparison {
+    pub name: String,
+    pub elements: usize,
+    pub nonfinite_pairs: usize,
+    pub exact: bool,
+    pub reference_sum_sq: f64,
+    pub candidate_sum_sq: f64,
+    pub error_sum_sq: f64,
+    pub relative_l2: f64,
+    pub max_abs_error: f64,
+    pub elementwise_failures: usize,
+    pub passed: bool,
+}
+
+impl TensorComparison {
+    pub fn new(name: String, reference: &[f32], candidate: &[f32]) -> Self {
+        assert_eq!(reference.len(), candidate.len(), "tensor layout changed");
+        let mut result = Self {
+            name,
+            elements: reference.len(),
+            nonfinite_pairs: 0,
+            exact: true,
+            reference_sum_sq: 0.0,
+            candidate_sum_sq: 0.0,
+            error_sum_sq: 0.0,
+            relative_l2: 0.0,
+            max_abs_error: 0.0,
+            elementwise_failures: 0,
+            passed: false,
+        };
+        for (&a, &b) in reference.iter().zip(candidate) {
+            result.exact &= a.to_bits() == b.to_bits();
+            if !a.is_finite() || !b.is_finite() {
+                result.nonfinite_pairs += 1;
+                continue;
+            }
+            let (a, b) = (f64::from(a), f64::from(b));
+            let error = (a - b).abs();
+            result.reference_sum_sq += a * a;
+            result.candidate_sum_sq += b * b;
+            result.error_sum_sq += error * error;
+            result.max_abs_error = result.max_abs_error.max(error);
+            result.elementwise_failures += usize::from(error > 1e-6 + 2e-4 * a.abs());
+        }
+        result.relative_l2 = (result.error_sum_sq / result.reference_sum_sq.max(1e-30)).sqrt();
+        result.passed = result.nonfinite_pairs == 0
+            && result.relative_l2 <= 2e-4
+            && result.elementwise_failures == 0;
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paired_timing_handles_wins_regressions_noise_and_bad_samples() {
+        let win = PairedTiming::new(&[10.0; 4], &[8.0; 4]).unwrap();
+        assert!(win.improvement_exceeds_guard && !win.regression_exceeds_guard);
+        assert_eq!(win.speedup, 1.25);
+        let loss = PairedTiming::new(&[10.0; 4], &[12.0; 4]).unwrap();
+        assert!(!loss.improvement_exceeds_guard && loss.regression_exceeds_guard);
+        let noisy = PairedTiming::new(&[10.0; 4], &[6.0, 10.0, 6.0, 10.0]).unwrap();
+        assert!(!noisy.improvement_exceeds_guard);
+        assert!(PairedTiming::new(&[], &[]).is_err());
+        assert!(PairedTiming::new(&[1.0], &[1.0, 2.0]).is_err());
+        for value in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(PairedTiming::new(&[1.0], &[value]).is_err());
+        }
+    }
+
+    #[test]
+    fn tensor_comparison_rejects_sign_errors_tiny_signal_loss_and_nonfinite_values() {
+        for (a, b) in [(1.0, -1.0), (1e-12, 0.0), (f32::NAN, f32::NAN)] {
+            assert!(!TensorComparison::new("test".into(), &[a], &[b]).passed);
+        }
+        let same = TensorComparison::new("test".into(), &[1.0, -2.0], &[1.0, -2.0]);
+        assert!(same.passed && same.exact);
+        assert_eq!(same.reference_sum_sq, 5.0);
+    }
+}

--- a/examples/tune_crossover.rs
+++ b/examples/tune_crossover.rs
@@ -1,0 +1,454 @@
+//! Fixed A/A and role-reversed whole-step confirmation. See the retained protocol.
+#[path = "support/crossover_measurement.rs"]
+mod crossover;
+#[path = "support/experiment_io.rs"]
+mod experiment_io;
+#[path = "support/gpu_monitor.rs"]
+mod gpu_monitor;
+#[path = "support/tuning_measurement.rs"]
+mod measurement;
+#[path = "support/holdout_workloads.rs"]
+mod workloads;
+
+use crossover::{BLOCK_PAIRS, Block, CONTROL_PAIRS, Confirmation, PREFIX, Pair, SETTLING, WARMUP};
+use experiment_io::{command, host_sample, sha256, unix_ms, write_record};
+use measurement::TensorComparison;
+use meganeura::{CoopPolicy, Session, TuneOptions, TuneScope};
+use serde_json::{Value, json};
+use std::{
+    error::Error,
+    fs::OpenOptions,
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use workloads::*;
+
+fn snapshots(sessions: &mut [Session; 2], case: &Case) -> [Snapshot; 2] {
+    let [left, right] = sessions;
+    [snapshot(left, case), snapshot(right, case)]
+}
+
+fn advance(sessions: &mut [Session; 2], steps: usize, age: &mut usize) {
+    for _ in 0..steps {
+        for session in sessions.iter_mut() {
+            session.step();
+            session.wait();
+        }
+        *age += 1;
+    }
+}
+
+fn sample_pairs(
+    sessions: &mut [Session; 2],
+    work: Work,
+    count: usize,
+    seed: usize,
+    age: &mut usize,
+) -> Vec<Pair> {
+    (0..count)
+        .map(|index| {
+            let first_session = (index + seed) % 2;
+            let mut ms = [0.0; 2];
+            ms[first_session] = step_ms(&mut sessions[first_session]);
+            ms[1 - first_session] = step_ms(&mut sessions[1 - first_session]);
+            *age += 1;
+            Pair {
+                step: *age,
+                first_session,
+                left_ms: ms[0],
+                right_ms: ms[1],
+                left_loss: (work != Work::Inference).then(|| sessions[0].read_loss()),
+                right_loss: (work != Work::Inference).then(|| sessions[1].read_loss()),
+            }
+        })
+        .collect()
+}
+
+fn valid_losses(pairs: &[Pair], work: Work) -> bool {
+    pairs.iter().all(|p| match (p.left_loss, p.right_loss) {
+        (None, None) => work == Work::Inference,
+        (Some(a), Some(b)) => {
+            work != Work::Inference && TensorComparison::new("loss".into(), &[a], &[b]).passed
+        }
+        _ => false,
+    })
+}
+
+fn has_training_signal(comparison: &Comparison, work: Work) -> bool {
+    work == Work::Inference
+        || ["loss", "gradient."].iter().all(|prefix| {
+            comparison.tensors.iter().any(|t| {
+                t.name.starts_with(prefix) && t.reference_sum_sq > 0.0 && t.candidate_sum_sq > 0.0
+            })
+        })
+}
+
+fn run_case(
+    case: &Case,
+    gpu: &Arc<blade_graphics::Context>,
+    policy: CoopPolicy,
+    seed: usize,
+    scope: TuneScope,
+) -> Result<Value, Box<dyn Error>> {
+    let (left, left_build) = make_session(case, gpu, policy);
+    let (right, right_build) = make_session(case, gpu, policy);
+    let mut sessions = [left, right];
+    let baseline_keys = sessions[0].dispatch_pipeline_keys();
+    assert_eq!(baseline_keys, sessions[1].dispatch_pipeline_keys());
+    let mut record = json!({"name": case.name, "description": case.description, "work": case.work,
+        "seed": seed, "status": "running", "build": [left_build, right_build],
+        "baseline_pipeline_keys": baseline_keys, "initial_memory": [memory(&sessions[0]), memory(&sessions[1])],
+        "host_start": host_sample(), "blocks": []});
+    if scope == TuneScope::ConvDerivatives {
+        record["baseline_dispatches"] = serde_json::to_value(&sessions[0].plan().dispatches)?;
+        record["plan_buffers"] = json!(sessions[0].plan().buffers);
+        if sessions[0]
+            .plan()
+            .dispatches
+            .iter()
+            .any(|d| d.workgroups.contains(&0))
+        {
+            record["status"] = json!("zero_workgroups");
+            return Ok(record);
+        }
+    }
+    let initial_parameters = sessions[0].read_params(&sessions[0].param_names());
+    let mut age = 0;
+    advance(&mut sessions, PREFIX, &mut age);
+    let prefix = snapshots(&mut sessions, case);
+    let prefix_comparison = compare(
+        "prefix",
+        case.work.adam_step_after(age),
+        &prefix[0],
+        &prefix[1],
+    );
+    let signal = has_training_signal(&prefix_comparison, case.work);
+    let mut valid = prefix_comparison.passed && signal;
+    record["prefix_training_signal"] = json!(signal);
+    record["prefix_comparison"] = serde_json::to_value(prefix_comparison)?;
+    drop(prefix);
+    if !valid {
+        record["status"] = json!("prefix_failed");
+        return Ok(record);
+    }
+    advance(&mut sessions, WARMUP, &mut age);
+    let warm = snapshots(&mut sessions, case);
+    let warm_comparison = compare("warmup", case.work.adam_step_after(age), &warm[0], &warm[1]);
+    valid &= warm_comparison.passed;
+    record["warmup_comparison"] = serde_json::to_value(warm_comparison)?;
+    drop(warm);
+    if !valid {
+        record["status"] = json!("warmup_failed");
+        return Ok(record);
+    }
+    {
+        let [left, right] = &mut sessions;
+        assert_eq!(left.swap_tuning_with(right)?, 0);
+    }
+    let aa_host_start = host_sample();
+    advance(&mut sessions, SETTLING, &mut age);
+    let aa_started_ms = unix_ms();
+    let control = sample_pairs(&mut sessions, case.work, CONTROL_PAIRS, seed, &mut age);
+    let aa_finished_ms = unix_ms();
+    let mut previous = snapshots(&mut sessions, case);
+    let aa_comparison = compare(
+        "control",
+        case.work.adam_step_after(age),
+        &previous[0],
+        &previous[1],
+    );
+    valid &= aa_comparison.passed && valid_losses(&control, case.work);
+    record["control"] = json!({"host_start": aa_host_start, "started_unix_ms": aa_started_ms,
+        "finished_unix_ms": aa_finished_ms, "pairs": control, "comparison": aa_comparison});
+    let first_winner = seed % 2;
+    let search = sessions[first_winner].tune_with(TuneOptions {
+        scope,
+        max_time: Duration::from_secs(10),
+        ..Default::default()
+    })?;
+    let after_search = snapshot(&mut sessions[first_winner], case);
+    let isolation = compare(
+        "search",
+        case.work.adam_step_after(age),
+        &previous[first_winner],
+        &after_search,
+    );
+    let isolated = isolation.exact && isolation.passed;
+    record["search"] = serde_json::to_value(search)?;
+    record["search_state_comparison"] = serde_json::to_value(isolation)?;
+    drop(after_search);
+    if !isolated {
+        record["status"] = json!("search_changed_state");
+        return Ok(record);
+    }
+    let winner_keys = sessions[first_winner].dispatch_pipeline_keys();
+    if scope == TuneScope::ConvDerivatives {
+        record["selected_dispatches"] =
+            serde_json::to_value(&sessions[first_winner].plan().dispatches)?;
+    }
+    let changed = baseline_keys
+        .iter()
+        .zip(&winner_keys)
+        .filter(|(a, b)| a != b)
+        .count();
+    record["winner_pipeline_keys"] = json!(winner_keys);
+    record["dispatches_changed"] = json!(changed);
+    let mut current_winner = first_winner;
+    let mut blocks = Vec::new();
+    for (index, winner_session) in crossover::winner_order(first_winner)
+        .into_iter()
+        .enumerate()
+    {
+        let mut swap_record = Value::Null;
+        if winner_session != current_winner {
+            let start = Instant::now();
+            let [left, right] = &mut sessions;
+            assert_eq!(left.swap_tuning_with(right)?, changed);
+            let swap_ms = start.elapsed().as_secs_f64() * 1e3;
+            let after = snapshots(&mut sessions, case);
+            let a = compare(
+                "swap_left",
+                case.work.adam_step_after(age),
+                &previous[0],
+                &after[0],
+            );
+            let b = compare(
+                "swap_right",
+                case.work.adam_step_after(age),
+                &previous[1],
+                &after[1],
+            );
+            let isolated = a.exact && a.passed && b.exact && b.passed;
+            swap_record = json!({"elapsed_ms": swap_ms, "left": a, "right": b});
+            if !isolated {
+                record["status"] = json!("swap_changed_state");
+                record["failed_swap"] = swap_record;
+                return Ok(record);
+            }
+            current_winner = winner_session;
+        }
+        assert_eq!(
+            sessions[winner_session].dispatch_pipeline_keys(),
+            winner_keys
+        );
+        assert_eq!(
+            sessions[1 - winner_session].dispatch_pipeline_keys(),
+            baseline_keys
+        );
+        let host_start = host_sample();
+        advance(&mut sessions, SETTLING, &mut age);
+        let started_ms = unix_ms();
+        let pairs = sample_pairs(
+            &mut sessions,
+            case.work,
+            BLOCK_PAIRS,
+            seed + index,
+            &mut age,
+        );
+        let finished_ms = unix_ms();
+        valid &= valid_losses(&pairs, case.work);
+        let block = Block {
+            winner_session,
+            pairs,
+        };
+        previous = snapshots(&mut sessions, case);
+        let comparison = compare(
+            "crossover",
+            case.work.adam_step_after(age),
+            &previous[0],
+            &previous[1],
+        );
+        valid &= comparison.passed;
+        record["blocks"].as_array_mut().unwrap().push(
+            json!({"index": index, "host_start": host_start,
+            "started_unix_ms": started_ms, "finished_unix_ms": finished_ms, "swap": swap_record,
+            "samples": block, "comparison": comparison}),
+        );
+        blocks.push(block);
+    }
+    if matches!(case.work, Work::Adam | Work::Sgd) {
+        let updates: [bool; 2] = std::array::from_fn(|index| {
+            sessions[index].read_params(&sessions[index].param_names()) != initial_parameters
+        });
+        valid &= updates.into_iter().all(|changed| changed);
+        record["parameters_updated"] = json!(updates);
+    }
+    let confirmation = Confirmation::new(&control, &blocks, changed, valid)?;
+    eprintln!(
+        "{}: {} changed; {:.3}x / {:.3}x by winner side; {}",
+        case.name,
+        changed,
+        confirmation.left_winner.speedup,
+        confirmation.right_winner.speedup,
+        confirmation.decision
+    );
+    record["confirmation"] = serde_json::to_value(confirmation)?;
+    record["status"] = json!(if valid {
+        "complete"
+    } else {
+        "numerical_failure"
+    });
+    record["final_age"] = json!(age);
+    record["final_memory"] = json!([memory(&sessions[0]), memory(&sessions[1])]);
+    record["host_finish"] = host_sample();
+    Ok(record)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+    let mut args = std::env::args_os().skip(1);
+    let path = args
+        .next()
+        .ok_or("usage: tune_crossover <new-output.json> <seed 1..6> [--conv-derivatives]")?;
+    let seed: usize = args
+        .next()
+        .ok_or("missing seed")?
+        .to_str()
+        .ok_or("non-UTF8 seed")?
+        .parse()?;
+    let scope = match args.next() {
+        None => TuneScope::Dense,
+        Some(arg) if arg == "--conv-derivatives" => TuneScope::ConvDerivatives,
+        _ => return Err("unknown search scope".into()),
+    };
+    if !(1..=6).contains(&seed) || args.next().is_some() {
+        return Err("expected one output, seed 1..6, optional --conv-derivatives".into());
+    }
+    if !command("git", &["status", "--porcelain", "--untracked-files=no"])?.is_empty() {
+        return Err("commit tracked source before measuring".into());
+    }
+    let mut output = OpenOptions::new().write(true).create_new(true).open(path)?;
+    let before = command("nvidia-smi", &[]).ok();
+    let monitor = gpu_monitor::Monitor::start();
+    let gpu = Arc::new(meganeura::init_gpu_context()?);
+    let info = gpu.device_information();
+    let caps = &gpu.capabilities().cooperative_matrix;
+    let policy = if caps.f32_tile > 0 {
+        CoopPolicy::Auto
+    } else {
+        CoopPolicy::Disabled
+    };
+    let protocol = if scope == TuneScope::ConvDerivatives {
+        "conv-tiles-corrected-2026-09-06"
+    } else {
+        "crossover-2026-09-06"
+    };
+    let mut document = json!({"schema_version": 1, "protocol": protocol, "status": "running",
+        "metadata": {"revision": command("git", &["rev-parse", "HEAD"])?, "tracked_source_clean": true,
+            "cargo_lock_sha256": sha256(&Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock"))?,
+            "executable_sha256": sha256(&std::env::current_exe()?)?, "rustc": command("rustc", &["--version"])?,
+            "seed": seed, "scope": scope, "process_id": std::process::id(), "started_unix_ms": unix_ms(),
+            "device": {"name": info.device_name, "driver": info.driver_info, "f32_tile": caps.f32_tile, "f16_tile": caps.f16_tile},
+            "cooperative_policy": format!("{policy:?}"), "compile_options": compile_options(),
+            "runtime_options": format!("{:?}", runtime_options(policy)), "optimize": meganeura::optimize::OptimizeConfig::default(),
+            "prefix": PREFIX, "warmup": WARMUP, "settling": SETTLING, "control_pairs": CONTROL_PAIRS, "block_pairs": BLOCK_PAIRS,
+            "contract": "strict f32; matched evolving states; step+wait including optimizer/clip; telemetry active; swapping/search/readbacks/settling excluded",
+            "nvidia_smi_before": before, "rustflags": std::env::var("RUSTFLAGS").ok(),
+            "optimizer": {"adam_lr": 1e-4, "sgd_lr": 1e-3, "beta1": 0.9, "beta2": 0.999, "epsilon": 1e-8, "clip_norm": 1.0, "clip_every": 1, "accumulation": false, "decay": 0.0}}, "cases": []});
+    write_record(&mut output, &document)?;
+    let mut valid = true;
+    let cases = if scope == TuneScope::ConvDerivatives {
+        conv_derivative_cases()
+    } else {
+        crossover_cases()
+    };
+    for (index, case) in cases.into_iter().enumerate() {
+        eprintln!("running {}", case.name);
+        let record = run_case(&case, &gpu, policy, seed + index, scope).unwrap_or_else(
+            |e| json!({"name": case.name, "status": "error", "error": e.to_string()}),
+        );
+        valid &= record["status"] == "complete";
+        document["cases"].as_array_mut().unwrap().push(record);
+        write_record(&mut output, &document)?;
+    }
+    document["telemetry"] = monitor.finish();
+    document["finished_unix_ms"] = json!(unix_ms());
+    document["status"] = json!(if valid {
+        "complete"
+    } else {
+        "validation_failed"
+    });
+    write_record(&mut output, &document)?;
+    if !valid {
+        return Err("validation failed; completed records retained".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matching_zero_states_are_not_training_qualification() {
+        for (loss, gradient) in [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)] {
+            let state = Snapshot {
+                tensors: vec![
+                    ("loss".into(), vec![loss]),
+                    ("gradient.w".into(), vec![gradient]),
+                ],
+                adam_step: 0,
+                adam_bytes: 0,
+            };
+            let comparison = compare("prefix", 0, &state, &state);
+            assert!(comparison.passed && comparison.exact);
+            assert_eq!(
+                has_training_signal(&comparison, Work::Sgd),
+                loss != 0.0 && gradient != 0.0
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_roster_and_balanced_roles() {
+        assert_eq!(
+            crossover_cases().iter().map(|c| c.name).collect::<Vec<_>>(),
+            ["dense-inference", "mlp-adam", "resnet50-flb"]
+        );
+        assert_eq!(
+            conv_derivative_cases()
+                .iter()
+                .map(|c| c.name)
+                .collect::<Vec<_>>(),
+            ["resnet50-flb", "conv-edges-adam", "conv-edges-sgd"]
+        );
+        for case in 0..3 {
+            assert_eq!((1..=6).filter(|seed| (seed + case) % 2 == 0).count(), 3);
+        }
+    }
+
+    #[test]
+    #[ignore = "GPU numerical preflight; no search or performance confirmation"]
+    fn crossover_prefix_and_noop_swap_are_numerically_sound() {
+        let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+        for case in crossover_cases().into_iter().chain(conv_derivative_cases()) {
+            let mut sessions = [
+                make_session(&case, &gpu, CoopPolicy::Disabled).0,
+                make_session(&case, &gpu, CoopPolicy::Disabled).0,
+            ];
+            let mut age = 0;
+            advance(&mut sessions, PREFIX, &mut age);
+            let before = snapshots(&mut sessions, &case);
+            let comparison = compare(
+                "prefix",
+                case.work.adam_step_after(age),
+                &before[0],
+                &before[1],
+            );
+            assert!(comparison.passed && has_training_signal(&comparison, case.work));
+            let [left, right] = &mut sessions;
+            assert_eq!(left.swap_tuning_with(right).unwrap(), 0);
+            let after = snapshots(&mut sessions, &case);
+            for index in 0..2 {
+                let result = compare(
+                    "swap",
+                    case.work.adam_step_after(age),
+                    &before[index],
+                    &after[index],
+                );
+                assert!(result.exact && result.passed);
+            }
+        }
+    }
+}

--- a/examples/tune_holdouts.rs
+++ b/examples/tune_holdouts.rs
@@ -1,0 +1,355 @@
+//! Whole-step inference/training holdouts for the existing isolated tuner.
+
+#[path = "support/tuning_measurement.rs"]
+mod measurement;
+
+#[path = "support/holdout_workloads.rs"]
+mod workloads;
+use measurement::{PairedTiming, TensorComparison};
+use meganeura::{CoopPolicy, TuneOptions};
+use serde_json::{Value, json};
+use std::{
+    error::Error,
+    fs::{File, OpenOptions},
+    io::{Seek, SeekFrom, Write},
+    path::Path,
+    process::Command,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use workloads::*;
+
+const PREFIX_STEPS: usize = 3;
+const WARMUPS: usize = 30;
+const SETTLING_STEPS: usize = 5;
+const SAMPLE_PAIRS: usize = 40;
+
+fn run_case(
+    case: &Case,
+    gpu: &Arc<blade_graphics::Context>,
+    policy: CoopPolicy,
+) -> Result<Value, Box<dyn Error>> {
+    let (mut baseline, baseline_build) = make_session(case, gpu, policy);
+    let (mut tuned, tuned_build) = make_session(case, gpu, policy);
+    let initial_keys = baseline.dispatch_pipeline_keys();
+    assert_eq!(initial_keys, tuned.dispatch_pipeline_keys());
+    let mut record = json!({
+        "name": case.name, "description": case.description, "work": case.work,
+        "status": "checking_prefix", "baseline_build": baseline_build, "tuned_build": tuned_build,
+        "baseline_pipeline_keys": initial_keys, "dispatches": baseline.plan().dispatches.len(),
+        "baseline_memory": memory(&baseline), "tuned_memory_before_search": memory(&tuned),
+    });
+    for _ in 0..PREFIX_STEPS {
+        step_ms(&mut baseline);
+        step_ms(&mut tuned);
+    }
+    let a = snapshot(&mut baseline, case);
+    let b = snapshot(&mut tuned, case);
+    let initial = compare("prefix", case.work.adam_step_after(PREFIX_STEPS), &a, &b);
+    let valid = initial.passed;
+    record["prefix_comparison"] = serde_json::to_value(initial)?;
+    if !valid {
+        record["status"] = json!("prefix_parity_failed");
+        return Ok(record);
+    }
+    drop(a);
+    let report = match tuned.tune_with(TuneOptions {
+        scope: meganeura::TuneScope::Dense,
+        max_time: Duration::from_secs(10),
+        ..Default::default()
+    }) {
+        Ok(report) => report,
+        Err(error) => {
+            record["status"] = json!("search_error");
+            record["error"] = json!(error.to_string());
+            return Ok(record);
+        }
+    };
+    let after = snapshot(&mut tuned, case);
+    let isolation = compare(
+        "before_after_search",
+        case.work.adam_step_after(PREFIX_STEPS),
+        &b,
+        &after,
+    );
+    let isolated = isolation.exact && isolation.passed;
+    record["search_state_comparison"] = serde_json::to_value(isolation)?;
+    record["search"] = serde_json::to_value(report)?;
+    record["tuned_memory_after_search"] = memory(&tuned);
+    drop(b);
+    drop(after);
+    if !isolated {
+        record["status"] = json!("search_changed_state");
+        return Ok(record);
+    }
+    for _ in 0..WARMUPS {
+        step_ms(&mut baseline);
+        step_ms(&mut tuned);
+    }
+    let warm = compare(
+        "warmup",
+        case.work.adam_step_after(PREFIX_STEPS + WARMUPS),
+        &snapshot(&mut baseline, case),
+        &snapshot(&mut tuned, case),
+    );
+    let valid = warm.passed;
+    record["warmup_comparison"] = serde_json::to_value(warm)?;
+    if !valid {
+        record["status"] = json!("warmup_parity_failed");
+        return Ok(record);
+    }
+
+    for _ in 0..SETTLING_STEPS {
+        step_ms(&mut baseline);
+        step_ms(&mut tuned);
+    }
+
+    let mut baseline_ms = Vec::new();
+    let mut tuned_ms = Vec::new();
+    let mut loss_trajectory = Vec::new();
+    let mut loss_trajectory_passed = true;
+    for pair in 0..SAMPLE_PAIRS {
+        let (a, b) = if pair % 2 == 0 {
+            (step_ms(&mut baseline), step_ms(&mut tuned))
+        } else {
+            let b = step_ms(&mut tuned);
+            (step_ms(&mut baseline), b)
+        };
+        baseline_ms.push(a);
+        tuned_ms.push(b);
+        if case.work != Work::Inference {
+            let a = baseline.read_loss();
+            let b = tuned.read_loss();
+            loss_trajectory_passed &= TensorComparison::new("loss".into(), &[a], &[b]).passed;
+            loss_trajectory.push(json!({"step": PREFIX_STEPS + WARMUPS + SETTLING_STEPS + pair + 1, "baseline": a, "tuned": b}));
+        }
+    }
+    let final_comparison = compare(
+        "final",
+        case.work
+            .adam_step_after(PREFIX_STEPS + WARMUPS + SETTLING_STEPS + SAMPLE_PAIRS),
+        &snapshot(&mut baseline, case),
+        &snapshot(&mut tuned, case),
+    );
+    let valid = final_comparison.passed && loss_trajectory_passed;
+    record["final_comparison"] = serde_json::to_value(final_comparison)?;
+    let timing = PairedTiming::new(&baseline_ms, &tuned_ms)?;
+    let final_keys = tuned.dispatch_pipeline_keys();
+    let changed = initial_keys
+        .iter()
+        .zip(&final_keys)
+        .filter(|(a, b)| a != b)
+        .count();
+    eprintln!(
+        "{}: {} dispatches changed; {:.4} -> {:.4} ms ({:.3}x), parity={valid}",
+        case.name, changed, timing.baseline_median_ms, timing.tuned_median_ms, timing.speedup
+    );
+    record["timing"] = serde_json::to_value(timing)?;
+    record["baseline_ms"] = json!(baseline_ms);
+    record["tuned_ms"] = json!(tuned_ms);
+    record["loss_trajectory"] = json!(loss_trajectory);
+    record["loss_trajectory_passed"] = json!(loss_trajectory_passed);
+    record["dispatches_changed"] = json!(changed);
+    record["tuned_pipeline_keys"] = json!(final_keys);
+    record["status"] = json!(if valid {
+        "complete"
+    } else if !loss_trajectory_passed {
+        "loss_trajectory_failed"
+    } else {
+        "final_parity_failed"
+    });
+    Ok(record)
+}
+
+fn command(program: &str, args: &[&str]) -> Result<String, Box<dyn Error>> {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()?;
+    if !output.status.success() {
+        return Err(format!("{program}: {}", String::from_utf8_lossy(&output.stderr)).into());
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+fn sha256(path: &Path) -> Result<String, Box<dyn Error>> {
+    let path = path.to_str().ok_or("non-UTF8 path")?;
+    let output =
+        command("sha256sum", &[path]).or_else(|_| command("shasum", &["-a", "256", path]))?;
+    Ok(output
+        .split_whitespace()
+        .next()
+        .ok_or("missing hash")?
+        .to_owned())
+}
+
+fn write_record(file: &mut File, record: &Value) -> Result<(), Box<dyn Error>> {
+    file.seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
+    serde_json::to_writer_pretty(&mut *file, record)?;
+    file.flush()?;
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+    let path = std::env::args_os()
+        .nth(1)
+        .ok_or("usage: tune_holdouts <new-output.json> | --list")?;
+    if path == "--list" {
+        for case in cases() {
+            println!("{} {:?}: {}", case.name, case.work, case.description);
+        }
+        return Ok(());
+    }
+    if !command("git", &["status", "--porcelain", "--untracked-files=no"])?.is_empty() {
+        return Err("commit tracked source changes before measuring".into());
+    }
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+    let nvidia_before = command("nvidia-smi", &[]).ok();
+    let gpu = Arc::new(meganeura::init_gpu_context()?);
+    let device = gpu.device_information();
+    let caps = &gpu.capabilities().cooperative_matrix;
+    let policy = if caps.f32_tile > 0 {
+        CoopPolicy::Auto
+    } else {
+        CoopPolicy::Disabled
+    };
+    let mut document = json!({
+        "schema_version": 1,
+        "status": "running",
+        "metadata": {
+            "revision": command("git", &["rev-parse", "HEAD"] )?,
+            "tracked_source_clean": true,
+            "cargo_lock_sha256": sha256(&Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock"))?,
+            "executable_sha256": sha256(&std::env::current_exe()?)?,
+            "rustc": command("rustc", &["--version"] )?,
+            "os": std::env::consts::OS, "arch": std::env::consts::ARCH,
+            "process_id": std::process::id(),
+            "started_unix_seconds": SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
+            "device": {"name": device.device_name, "driver_name": device.driver_name, "driver_info": device.driver_info, "software_emulated": device.is_software_emulated, "f32_tile": caps.f32_tile, "f16_tile": caps.f16_tile},
+            "cooperative_policy": format!("{policy:?}"),
+            "flash_forward_coop": false, "flash_backward_coop": false,
+            "compile_options": compile_options(),
+            "optimize_config": meganeura::optimize::OptimizeConfig::default(),
+            "runtime_options": format!("{:?}", runtime_options(policy)),
+            "skip_full_optimize": false, "build_cache": false,
+            "prefix_steps": PREFIX_STEPS, "warmups_per_session": WARMUPS, "settling_steps": SETTLING_STEPS, "sample_pairs": SAMPLE_PAIRS,
+            "contract": "strict f32; synthetic weights/inputs; matched evolving trajectories; normal step+wait including stated optimizer/clip; construction/uploads/search/readbacks excluded",
+            "optimizer": {"adam_lr": 1e-4, "sgd_lr": 1e-3, "beta1": 0.9, "beta2": 0.999, "epsilon": 1e-8, "clip_norm": 1.0, "clip_every": 1, "accumulation": false, "weight_decay": 0.0},
+            "nvidia_smi_before": nvidia_before,
+            "rust_log": std::env::var("RUST_LOG").ok(),
+            "memory_contract": "retained buffer requests plus stage samples of API process usage with both sessions resident; not peak VRAM",
+        },
+        "cases": [],
+    });
+    write_record(&mut output, &document)?;
+    let mut all_valid = true;
+    for case in cases() {
+        eprintln!("running {}", case.name);
+        let record = run_case(&case, &gpu, policy).unwrap_or_else(
+            |error| json!({"name": case.name, "status": "error", "error": error.to_string()}),
+        );
+        all_valid &= record["status"] == "complete";
+        document["cases"].as_array_mut().unwrap().push(record);
+        write_record(&mut output, &document)?;
+    }
+    document["status"] = json!(if all_valid {
+        "complete"
+    } else {
+        "validation_failed"
+    });
+    document["finished_unix_seconds"] =
+        json!(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs());
+    document["nvidia_smi_after"] = json!(command("nvidia-smi", &[]).ok());
+    write_record(&mut output, &document)?;
+    if !all_valid {
+        return Err("holdout validation failed; all completed case records retained".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn holdout_case_roster_is_fixed() {
+        let cases = cases();
+        assert_eq!(
+            cases.iter().map(|c| c.name).collect::<Vec<_>>(),
+            [
+                "mlp-inference",
+                "mlp-adam",
+                "smollm2-inference",
+                "smollm2-adam",
+                "whisper-sgd",
+                "resnet50-flb"
+            ]
+        );
+        assert_eq!(cases.iter().filter(|c| c.work == Work::Adam).count(), 2);
+        assert_eq!(
+            cases.iter().filter(|c| c.work == Work::Inference).count(),
+            2
+        );
+    }
+
+    #[test]
+    fn equal_but_wrong_optimizer_counters_fail() {
+        let snapshot = Snapshot {
+            tensors: vec![("parameter".into(), vec![1.0])],
+            adam_step: 3,
+            adam_bytes: 8,
+        };
+        assert!(compare("test", 3, &snapshot, &snapshot).passed);
+        let wrong = compare("test", 4, &snapshot, &snapshot);
+        assert!(!wrong.passed && !wrong.exact);
+    }
+
+    #[test]
+    #[ignore = "constructs GPU sessions; numerical preflight, not a performance run"]
+    fn holdout_prefixes_are_finite_and_match_before_search() {
+        let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+        for case in cases() {
+            eprintln!("preflight {}", case.name);
+            let (mut a, _) = make_session(&case, &gpu, CoopPolicy::Disabled);
+            let (mut b, _) = make_session(&case, &gpu, CoopPolicy::Disabled);
+            for _ in 0..PREFIX_STEPS {
+                a.step();
+                a.wait();
+                b.step();
+                b.wait();
+            }
+            let comparison = compare(
+                "prefix",
+                case.work.adam_step_after(PREFIX_STEPS),
+                &snapshot(&mut a, &case),
+                &snapshot(&mut b, &case),
+            );
+            for tensor in &comparison.tensors {
+                assert!(tensor.passed, "{} {}: {:?}", case.name, tensor.name, tensor);
+            }
+            assert!(comparison.passed, "{}", case.name);
+            if case.work != Work::Inference {
+                assert!(a.read_loss().is_finite() && a.read_loss() > 0.0);
+                assert!(
+                    comparison
+                        .tensors
+                        .iter()
+                        .any(|t| t.name.starts_with("gradient.") && t.reference_sum_sq > 0.0)
+                );
+            }
+            assert_eq!(
+                a.adam_step_count(),
+                if case.work == Work::Adam {
+                    PREFIX_STEPS as u32
+                } else {
+                    0
+                }
+            );
+        }
+    }
+}

--- a/examples/tune_readback.rs
+++ b/examples/tune_readback.rs
@@ -1,0 +1,18 @@
+//! Shared versus read-optimized private staging; original fresh-buffer policy.
+#[path = "support/tuning_diagnostic.rs"]
+mod diagnostic;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use meganeura::{TuneOptions, TuneStaging, TuneStagingReuse};
+    diagnostic::run(
+        "readback-2026-09-06",
+        ["shared", "download"],
+        [TuneStaging::Shared, TuneStaging::Download].map(|staging| TuneOptions {
+            scope: meganeura::TuneScope::Dense,
+            staging,
+            staging_reuse: TuneStagingReuse::Fresh,
+            max_time: std::time::Duration::from_secs(10),
+            ..Default::default()
+        }),
+    )
+}

--- a/examples/tune_session.rs
+++ b/examples/tune_session.rs
@@ -1,0 +1,308 @@
+//! Isolated kernel search followed by independent whole-step confirmation.
+//!
+//! Run on an idle GPU, from a clean tracked checkout:
+//! `cargo run --release --example tune_session -- results.json`
+//! The output path must not exist. This is a synthetic f32 experiment, not a
+//! model benchmark or a comparison with another engine. Native-f32 coverage
+//! is reported explicitly; f16-input hardware is not silently substituted.
+
+use meganeura::{
+    CoopPolicy, Graph, MatmulTile, Mode, Session, SessionConfig, SessionOptions, TuneOptions, build,
+};
+use serde_json::{Value, json};
+use std::{
+    error::Error,
+    fs::OpenOptions,
+    path::Path,
+    process::Command,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+const WARMUPS: usize = 30;
+const SAMPLE_PAIRS: usize = 40;
+
+fn command(program: &str, args: &[&str]) -> Result<String, Box<dyn Error>> {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "{program} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+fn sha256(path: &Path) -> Result<String, Box<dyn Error>> {
+    let path = path.to_str().ok_or("non-UTF8 path")?;
+    let output =
+        command("sha256sum", &[path]).or_else(|_| command("shasum", &["-a", "256", path]))?;
+    Ok(output
+        .split_whitespace()
+        .next()
+        .ok_or("missing hash")?
+        .to_owned())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+    let path = std::env::args_os()
+        .nth(1)
+        .ok_or("usage: tune_session <new-output.json>")?;
+    if path == "--device" {
+        let gpu = meganeura::init_gpu_context()?;
+        let device = gpu.device_information();
+        let caps = &gpu.capabilities().cooperative_matrix;
+        println!(
+            "{}; {} {}; f32_tile={}; f16_tile={}",
+            device.device_name,
+            device.driver_name,
+            device.driver_info,
+            caps.f32_tile,
+            caps.f16_tile
+        );
+        return Ok(());
+    }
+    let source_status = command("git", &["status", "--porcelain", "--untracked-files=no"])?;
+    if !source_status.is_empty() {
+        return Err(
+            "commit tracked source changes before measuring; results need an exact revision".into(),
+        );
+    }
+    // Reserve the path before doing GPU work. Never overwrite frozen results.
+    let output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+    let gpu = Arc::new(meganeura::init_gpu_context()?);
+    let device = gpu.device_information();
+    let caps = &gpu.capabilities().cooperative_matrix;
+    let policy = if caps.f32_tile > 0 {
+        CoopPolicy::Auto
+    } else {
+        CoopPolicy::Disabled
+    };
+    eprintln!(
+        "{}: f32_tile={}, f16_tile={}, policy={policy:?}",
+        device.device_name, caps.f32_tile, caps.f16_tile
+    );
+    let metadata = json!({
+        "revision": command("git", &["rev-parse", "HEAD"] )?,
+        "tracked_source_clean": true,
+        "cargo_lock_sha256": sha256(&Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock"))?,
+        "executable_sha256": sha256(&std::env::current_exe()?)?,
+        "rustc": command("rustc", &["--version"] )?,
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "available_parallelism": std::thread::available_parallelism()?.get(),
+        "started_unix_seconds": SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
+        "device": {
+            "name": device.device_name,
+            "driver_name": device.driver_name,
+            "driver_info": device.driver_info,
+            "software_emulated": device.is_software_emulated,
+            "f32_tile": caps.f32_tile,
+            "f16_tile": caps.f16_tile,
+        },
+        "cooperative_policy": format!("{policy:?}"),
+        "contract": "strict f32 operands/storage; deterministic nonzero dense chains; inference; normal step+wait wall time; uploads, compilation and search excluded from steady-state samples",
+        "warmups_per_session": WARMUPS,
+        "whole_step_sample_pairs": SAMPLE_PAIRS,
+        "order": "alternating baseline/tuned then tuned/baseline; raw arrays remain paired",
+    });
+    let mut cases = Vec::new();
+    for (rows, input_width, width, layers) in [
+        (33, 17, 65, 4),
+        (32, 256, 256, 8),
+        (128, 512, 512, 8),
+        (64, 1024, 1024, 4),
+    ] {
+        cases.push(run_case(&gpu, policy, rows, input_width, width, layers)?);
+    }
+    serde_json::to_writer_pretty(
+        output,
+        &json!({"schema_version": 1, "metadata": metadata, "cases": cases}),
+    )?;
+    eprintln!("wrote {}", Path::new(&path).display());
+    Ok(())
+}
+
+fn data(count: usize, seed: u32, scale: f32) -> Vec<f32> {
+    let mut state = seed;
+    (0..count)
+        .map(|_| {
+            state = state.wrapping_mul(747796405).wrapping_add(2891336453);
+            let word = ((state >> ((state >> 28) + 4)) ^ state).wrapping_mul(277803737);
+            (((((word >> 22) ^ word) >> 8) as f32 / 16_777_216.0) - 0.5) * scale
+        })
+        .collect()
+}
+
+fn step_ms(session: &mut Session) -> f64 {
+    let start = Instant::now();
+    session.step();
+    session.wait();
+    start.elapsed().as_secs_f64() * 1e3
+}
+
+fn median(values: &[f64]) -> f64 {
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let mid = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        (sorted[mid - 1] + sorted[mid]) * 0.5
+    } else {
+        sorted[mid]
+    }
+}
+
+fn parity(reference: &[f32], output: &[f32]) -> Result<Value, Box<dyn Error>> {
+    let mut square_error = 0.0;
+    let mut square_reference = 0.0;
+    let mut max_abs = 0.0_f64;
+    if reference.len() != output.len() {
+        return Err("output length changed".into());
+    }
+    for (&a, &b) in reference.iter().zip(output) {
+        if !a.is_finite() || !b.is_finite() {
+            return Err("nonfinite graph output".into());
+        }
+        let difference = (a as f64 - b as f64).abs();
+        square_error += difference * difference;
+        square_reference += (a as f64).powi(2);
+        max_abs = max_abs.max(difference);
+    }
+    let relative_l2 = (square_error / square_reference.max(1e-30)).sqrt();
+    if relative_l2 > 2e-4 {
+        return Err(format!("whole-graph parity failed: relative L2 {relative_l2}").into());
+    }
+    Ok(
+        json!({"relative_l2": relative_l2, "max_abs": max_abs, "elements": output.len(), "passed": true}),
+    )
+}
+
+fn run_case(
+    gpu: &Arc<blade_graphics::Context>,
+    policy: CoopPolicy,
+    rows: usize,
+    input_width: usize,
+    width: usize,
+    layers: usize,
+) -> Result<Value, Box<dyn Error>> {
+    let mut graph = Graph::new();
+    let mut y = graph.input("input", &[rows, input_width]);
+    for layer in 0..layers {
+        let k = if layer == 0 { input_width } else { width };
+        let weight = graph.parameter(&format!("weight_{layer}"), &[k, width]);
+        y = graph.matmul(y, weight);
+    }
+    graph.set_outputs(vec![y]);
+    let make_session = || {
+        let (mut session, _) = build(
+            &graph,
+            SessionConfig {
+                mode: Mode::Inference,
+                gpu: Some(Arc::clone(gpu)),
+                runtime: SessionOptions {
+                    coop: policy,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        session.set_input("input", &data(rows * input_width, 1, 1.0));
+        for layer in 0..layers {
+            let k = if layer == 0 { input_width } else { width };
+            session.set_parameter(
+                &format!("weight_{layer}"),
+                &data(k * width, layer as u32 + 2, (12.0 / k as f32).sqrt()),
+            );
+        }
+        session
+    };
+    let mut baseline = make_session();
+    let mut tuned = make_session();
+    let initial_keys = baseline.dispatch_pipeline_keys();
+    assert_eq!(initial_keys, tuned.dispatch_pipeline_keys());
+    step_ms(&mut baseline);
+    step_ms(&mut tuned);
+    let reference = baseline.read_output(rows * width);
+    let before = tuned.read_output(rows * width);
+    let initial_parity = parity(&reference, &before)?;
+    let report = tuned.tune_with(TuneOptions {
+        scope: meganeura::TuneScope::Dense,
+        max_time: Duration::from_secs(10),
+        ..Default::default()
+    })?;
+    let unchanged = tuned
+        .read_output(rows * width)
+        .iter()
+        .zip(&before)
+        .all(|(a, b)| a.to_bits() == b.to_bits());
+    if !unchanged {
+        return Err("tuning changed live output".into());
+    }
+    let native_f32_qualified = report.outcomes.iter().any(|o| {
+        o.qualified
+            && (matches!(o.initial, MatmulTile::CooperativeF32 { .. })
+                || matches!(o.candidate, MatmulTile::CooperativeF32 { .. }))
+    });
+    for _ in 0..WARMUPS {
+        step_ms(&mut baseline);
+        step_ms(&mut tuned);
+    }
+    let mut baseline_ms = vec![0.0; SAMPLE_PAIRS];
+    let mut tuned_ms = vec![0.0; SAMPLE_PAIRS];
+    for pair in 0..SAMPLE_PAIRS {
+        if pair % 2 == 0 {
+            baseline_ms[pair] = step_ms(&mut baseline);
+            tuned_ms[pair] = step_ms(&mut tuned);
+        } else {
+            tuned_ms[pair] = step_ms(&mut tuned);
+            baseline_ms[pair] = step_ms(&mut baseline);
+        }
+    }
+    let final_parity = parity(&reference, &tuned.read_output(rows * width))?;
+    let baseline_median = median(&baseline_ms);
+    let tuned_median = median(&tuned_ms);
+    let differences: Vec<_> = baseline_ms
+        .iter()
+        .zip(&tuned_ms)
+        .map(|(a, b)| a - b)
+        .collect();
+    let difference_median = median(&differences);
+    let noise_margin = 2.0
+        * median(
+            &differences
+                .iter()
+                .map(|d| (d - difference_median).abs())
+                .collect::<Vec<_>>(),
+        );
+    let final_keys = tuned.dispatch_pipeline_keys();
+    let changed = initial_keys
+        .iter()
+        .zip(&final_keys)
+        .filter(|(a, b)| a != b)
+        .count();
+    eprintln!(
+        "{rows}x{input_width}->{width}, {layers} layers: {changed} dispatches changed; {baseline_median:.4} -> {tuned_median:.4} ms ({:.3}x); search {:.3}s",
+        baseline_median / tuned_median,
+        report.elapsed.as_secs_f64()
+    );
+    Ok(json!({
+        "rows": rows, "input_width": input_width, "width": width, "layers": layers,
+        "baseline_pipeline_keys": initial_keys, "tuned_pipeline_keys": final_keys,
+        "dispatches_changed": changed, "native_f32_qualified": native_f32_qualified,
+        "initial_parity": initial_parity, "final_parity": final_parity,
+        "live_output_unchanged_by_search": unchanged, "search": report,
+        "baseline_ms": baseline_ms, "tuned_ms": tuned_ms,
+        "baseline_median_ms": baseline_median, "tuned_median_ms": tuned_median,
+        "speedup": baseline_median / tuned_median,
+        "paired_difference_median_ms": difference_median, "paired_noise_margin_ms": noise_margin,
+        "whole_step_improvement_exceeds_guard": baseline_median - tuned_median > baseline_median * 0.05 + noise_margin && difference_median > baseline_median * 0.05 + noise_margin,
+    }))
+}

--- a/examples/tune_staging_reuse.rs
+++ b/examples/tune_staging_reuse.rs
@@ -1,0 +1,18 @@
+//! Fresh versus exact-size, call-local reuse of Download staging.
+#[path = "support/tuning_diagnostic.rs"]
+mod diagnostic;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use meganeura::{TuneOptions, TuneStaging, TuneStagingReuse};
+    diagnostic::run(
+        "staging-reuse-2026-09-06",
+        ["fresh", "reuse"],
+        [TuneStagingReuse::Fresh, TuneStagingReuse::SameSize].map(|staging_reuse| TuneOptions {
+            scope: meganeura::TuneScope::Dense,
+            staging: TuneStaging::Download,
+            staging_reuse,
+            max_time: std::time::Duration::from_secs(10),
+            ..Default::default()
+        }),
+    )
+}

--- a/paper/p3hpc/REVISION.md
+++ b/paper/p3hpc/REVISION.md
@@ -138,8 +138,10 @@ hide a missing dependency.
   provenance. Do not claim independent evaluation unless it actually occurred.
 - [ ] Resolve permanent artifact hosting/DOI, rights and upload requirements
   through the venue's instructions. Nothing was uploaded in this audit.
-- [ ] Rehearse with [28 questions and exercises](../../docs/study/p3hpc-questions.md),
+- [ ] Rehearse with [48 questions and exercises](../../docs/study/p3hpc-questions.md),
   then adapt slides to the confirmed talk length.
 
-GPU benchmarks remain deferred. Current development improvements cannot be
-described as measured paper improvements without a new controlled experiment.
+The bounded tuning-foundation engineering phase is closed with split-K promotion
+deferred after numerical rejection. No further development benchmark is required
+for this checklist. Separately retained development results must not be described
+as improvements to the frozen paper measurements.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -9,7 +9,7 @@ use std::{io, path::Path};
 
 /// Increment whenever the serialized execution plan or build pipeline changes
 /// in a way that can make an older plan unsafe to reuse.
-const CACHE_FORMAT_VERSION: u32 = 4;
+const CACHE_FORMAT_VERSION: u32 = 5;
 
 /// Cached execution plan with a graph fingerprint for invalidation.
 #[derive(Serialize, Deserialize)]
@@ -207,6 +207,7 @@ mod tests {
         let loaded = loaded.unwrap();
         assert_eq!(loaded.buffers.len(), plan.buffers.len());
         assert_eq!(loaded.dispatches.len(), plan.dispatches.len());
+        assert_eq!(loaded.param_types, plan.param_types);
 
         // Load with different graph — should invalidate
         let mut g2 = Graph::new();
@@ -228,6 +229,26 @@ mod tests {
         let path = std::env::temp_dir().join("meganeura_nonexistent_cache.ron");
         let result = load_plan(&g, &path).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn cache_without_logical_parameter_types_is_invalidated() {
+        let mut graph = Graph::new();
+        let p = graph.parameter("p", &[2, 3]);
+        graph.set_outputs(vec![p]);
+        let mut plan = compile::compile(&graph);
+        plan.param_types.clear();
+        let legacy = CachedPlan {
+            format_version: 4,
+            graph_hash: hash_graph(&graph),
+            build_hash: 0,
+            plan,
+        };
+        let path =
+            std::env::temp_dir().join(format!("meganeura-cache-v4-{}.ron", std::process::id()));
+        std::fs::write(&path, ron::ser::to_string(&legacy).unwrap()).unwrap();
+        assert!(load_plan(&graph, &path).unwrap().is_none());
+        std::fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -13,7 +13,7 @@ use naga::Module;
 ///
 /// Derived from `blade_graphics::CooperativeMatrix` capabilities at runtime.
 /// Determines which shader variant is generated for coop matmul.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CoopConfig {
     /// Cooperative matrix tile dimension (8 for Apple Silicon, 16 for RDNA3/Volta+).
     pub tile_size: u32,
@@ -423,6 +423,8 @@ pub enum ShaderGroup {
     WinogradWeightTransform,
     Conv2dGradWeightGemm,
     Conv2dGradWeightGemmSmall,
+    Conv2dGradWeightGemmSplit,
+    Conv2dGradWeightGemmSplitSmall,
     CacheWrite,
     CachedAttention,
     RoPEDynamic,
@@ -545,14 +547,12 @@ pub fn generate_module(group: ShaderGroup) -> ShaderModule {
         ShaderGroup::WinogradWeightTransform => {
             parse_wgsl(include_str!("shaders/winograd_weight_transform.wgsl"))
         }
-        ShaderGroup::Conv2dGradWeightGemm => conv_gemm_tiled(
-            include_str!("shaders/conv2d_grad_weight_gemm.wgsl"),
-            MatMulTile::Large,
-        ),
-        ShaderGroup::Conv2dGradWeightGemmSmall => conv_gemm_tiled(
-            include_str!("shaders/conv2d_grad_weight_gemm.wgsl"),
-            MatMulTile::Small,
-        ),
+        ShaderGroup::Conv2dGradWeightGemm => conv_grad_weight_tiled(MatMulTile::Large, false),
+        ShaderGroup::Conv2dGradWeightGemmSmall => conv_grad_weight_tiled(MatMulTile::Small, false),
+        ShaderGroup::Conv2dGradWeightGemmSplit => conv_grad_weight_tiled(MatMulTile::Large, true),
+        ShaderGroup::Conv2dGradWeightGemmSplitSmall => {
+            conv_grad_weight_tiled(MatMulTile::Small, true)
+        }
         ShaderGroup::CacheWrite => parse_wgsl(include_str!("shaders/cache_write.wgsl")),
         ShaderGroup::CachedAttention => parse_wgsl(include_str!("shaders/cached_attention.wgsl")),
         ShaderGroup::RoPEDynamic => parse_wgsl(include_str!("shaders/rope_dynamic.wgsl")),
@@ -865,6 +865,7 @@ fn conv_gemm_tiled(src: &str, tile: MatMulTile) -> ShaderModule {
     let src = preprocess(
         src,
         &[
+            ("$DIVISOR", crate::divisor::SHADER),
             ("$BM_U", &format!("{bm}u")),
             ("$TM_U", &format!("{tm}u")),
             ("$STAGE_EPT_U", &format!("{}u", bm * 16 / 256)),
@@ -875,6 +876,36 @@ fn conv_gemm_tiled(src: &str, tile: MatMulTile) -> ShaderModule {
         ],
     );
     parse_wgsl(&src)
+}
+
+fn conv_grad_weight_tiled(tile: MatMulTile, split_k: bool) -> ShaderModule {
+    let (counts, range, start, end, offset) = if split_k {
+        (
+            ", @builtin(num_workgroups) counts: vec3<u32>",
+            "let tiles = (k_total + 15u) / 16u;\n\
+             let per_split = tiles / counts.z;\n\
+             let extra = tiles - per_split * counts.z;\n\
+             let first = wgid.z * per_split + min(wgid.z, extra);\n\
+             let last = first + per_split + u32(wgid.z < extra);\n\
+             let k_end = min(last * 16u, k_total);",
+            "first * 16u",
+            "k_end",
+            "wgid.z * m_total * n_total + ",
+        )
+    } else {
+        ("", "", "0u", "k_total", "")
+    };
+    let source = preprocess(
+        include_str!("shaders/conv2d_grad_weight_gemm.wgsl"),
+        &[
+            ("$COUNTS", counts),
+            ("$K_RANGE", range),
+            ("$K_START", start),
+            ("$K_END", end),
+            ("$OUTPUT_OFFSET", offset),
+        ],
+    );
+    conv_gemm_tiled(&source, tile)
 }
 
 /// Shared unroll generator for every register-tiled GEMM skeleton
@@ -4340,6 +4371,7 @@ pub fn generate_conv2d_coop_module(
     src.push('\n');
     src.push_str(enable_f16);
     src.push_str("enable wgpu_cooperative_matrix;\n\n");
+    src.push_str(crate::divisor::SHADER);
 
     // Params struct — identical layout to Conv2dParams for binding compatibility.
     // kernel_h/kernel_w/stride fields are still present but ignored in favor of constants.
@@ -4357,10 +4389,10 @@ pub fn generate_conv2d_coop_module(
          \x20   out_h: u32,\n\
          \x20   out_w: u32,\n\
          \x20   padding_w: u32,\n\
-         \x20   inv_kernel_w: f32,\n\
-         \x20   inv_kernel_hw: f32,\n\
-         \x20   inv_col_w: f32,\n\
-         \x20   inv_go_spatial: f32,\n\
+         \x20   kernel_w_multiplier: u32,\n\
+         \x20   kernel_hw_multiplier: u32,\n\
+         \x20   column_width_multiplier: u32,\n\
+         \x20   output_spatial_multiplier: u32,\n\
          }\n\n",
     );
 
@@ -4415,15 +4447,9 @@ pub fn generate_conv2d_coop_module(
         let _ = writeln!(src, "    let k_total = params.out_channels * KERNEL_HW;");
         src.push_str("    let go_spatial = params.out_h * params.out_w;\n\n");
 
-        // Padding computation for backward
-        let _ = writeln!(
-            src,
-            "    let pad_h = i32(KERNEL_H) - 1 - i32(params.padding_h);"
-        );
-        let _ = writeln!(
-            src,
-            "    let pad_w = i32(KERNEL_W) - 1 - i32(params.padding_w);"
-        );
+        // Invert forward cross-correlation without flipping the weight indices.
+        src.push_str("    let pad_h = i32(params.padding_h);\n");
+        src.push_str("    let pad_w = i32(params.padding_w);\n");
     } else {
         // Forward: M = Co, N = oH*oW, K = Ci*kH*kW
         let _ = writeln!(src, "    let tile_row = wgid.x * {output_tile}u;");
@@ -4764,7 +4790,7 @@ fn emit_grad_input_im2col_stage(
     // Pre-decompose spatial position (invariant across e iterations)
     let _ = writeln!(
         src,
-        "        let {ih_var} = u32(f32({cc_var}) * params.inv_col_w);"
+        "        let {ih_var} = divide_exact({cc_var}, params.in_w, params.column_width_multiplier);"
     );
     let _ = writeln!(
         src,
@@ -5056,7 +5082,7 @@ fn emit_forward_im2col_stage(
     // Decompose hw_idx -> (oh, ow) -> (ih, iw)
     let _ = writeln!(
         src,
-        "                let oh = u32(f32({cc_var}) * params.inv_col_w);"
+        "                let oh = divide_exact({cc_var}, params.out_w, params.column_width_multiplier);"
     );
     let _ = writeln!(
         src,
@@ -5093,6 +5119,19 @@ fn emit_forward_im2col_stage(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ordinary_weight_gradients_have_no_split_partition_logic() {
+        for tile in [MatMulTile::Small, MatMulTile::Large] {
+            let ordinary = conv_grad_weight_tiled(tile, false);
+            assert!(!ordinary.source.contains("num_workgroups"));
+            assert!(!ordinary.source.contains("k_end"));
+            assert!(ordinary.source.contains("var t = 0u;"));
+            let split = conv_grad_weight_tiled(tile, true);
+            assert!(split.source.contains("num_workgroups"));
+            assert!(split.source.contains("var t = first * 16u;"));
+        }
+    }
 
     /// Verify every shader group generates a valid Naga module.
     #[test]
@@ -5173,6 +5212,22 @@ mod tests {
                 naga::valid::Capabilities::empty(),
             ),
             (ShaderGroup::SumRows, naga::valid::Capabilities::empty()),
+            (
+                ShaderGroup::Conv2dGradWeightGemm,
+                naga::valid::Capabilities::empty(),
+            ),
+            (
+                ShaderGroup::Conv2dGradWeightGemmSmall,
+                naga::valid::Capabilities::empty(),
+            ),
+            (
+                ShaderGroup::Conv2dGradWeightGemmSplit,
+                naga::valid::Capabilities::empty(),
+            ),
+            (
+                ShaderGroup::Conv2dGradWeightGemmSplitSmall,
+                naga::valid::Capabilities::empty(),
+            ),
             (ShaderGroup::RmsNormGrad, naga::valid::Capabilities::empty()),
             (
                 ShaderGroup::RmsNormGradWRowPar,
@@ -5511,6 +5566,10 @@ mod tests {
             (ShaderGroup::SwiGLUGrad, empty),
             (ShaderGroup::SwiGLUConcat, empty),
             (ShaderGroup::SumRows, empty),
+            (ShaderGroup::Conv2dGradWeightGemm, empty),
+            (ShaderGroup::Conv2dGradWeightGemmSmall, empty),
+            (ShaderGroup::Conv2dGradWeightGemmSplit, empty),
+            (ShaderGroup::Conv2dGradWeightGemmSplitSmall, empty),
             (ShaderGroup::RmsNormGrad, empty),
             (ShaderGroup::RmsNormGradWRowPar, empty),
             (ShaderGroup::ScatterAdd, empty),
@@ -5715,7 +5774,10 @@ mod tests {
                 | ShaderEntry::Conv2dGradInputGemmCoopGen(..) => {
                     vec!["grad_out", "weight", "dst", "params"]
                 }
-                ShaderEntry::Conv2dGradWeightGemm | ShaderEntry::Conv2dGradWeightGemmSmall => {
+                ShaderEntry::Conv2dGradWeightGemm
+                | ShaderEntry::Conv2dGradWeightGemmSmall
+                | ShaderEntry::Conv2dGradWeightGemmSplit
+                | ShaderEntry::Conv2dGradWeightGemmSplitSmall => {
                     vec!["grad_out", "src", "dst", "params"]
                 }
                 ShaderEntry::RoPEDynamic => vec!["src", "dst", "pos_offset_buf", "params"],
@@ -5820,6 +5882,10 @@ mod tests {
             ShaderEntry::Conv2dGemmSmall,
             ShaderEntry::Conv2dGradInputGemm,
             ShaderEntry::Conv2dGradInputGemmSmall,
+            ShaderEntry::Conv2dGradWeightGemm,
+            ShaderEntry::Conv2dGradWeightGemmSmall,
+            ShaderEntry::Conv2dGradWeightGemmSplit,
+            ShaderEntry::Conv2dGradWeightGemmSplitSmall,
             ShaderEntry::WinogradInputTransform,
             ShaderEntry::WinogradOutputTransform,
             ShaderEntry::WinogradBatchedMatMul,
@@ -5888,6 +5954,11 @@ mod tests {
             },
             CoopConfig {
                 tile_size: 16,
+                use_f16_input: false,
+                compensated: false,
+            },
+            CoopConfig {
+                tile_size: 16,
                 use_f16_input: true,
                 compensated: false,
             },
@@ -5901,6 +5972,8 @@ mod tests {
             (3, 3, 1, Conv2dCoopDirection::GradInput),
             (3, 3, 2, Conv2dCoopDirection::Forward),
             (3, 3, 2, Conv2dCoopDirection::GradInput),
+            (2, 4, 1, Conv2dCoopDirection::GradInput),
+            (3, 2, 2, Conv2dCoopDirection::GradInput),
             (5, 5, 1, Conv2dCoopDirection::GradInput),
             (7, 7, 2, Conv2dCoopDirection::Forward),
         ];

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -3,6 +3,8 @@ use crate::schedule::{PointwiseDAG, Pw, ReductionEpilogue, ReductionKernel};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+mod split_k;
+
 /// Weight storage format for matmul B operands.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum WeightFormat {
@@ -230,6 +232,9 @@ pub enum ShaderEntry {
     Conv2dGradInputGemmCoopGen(u32, u32, u32),
     Conv2dGradWeightGemm,
     Conv2dGradWeightGemmSmall,
+    /// Split reduction tiles into `[split, Co, Ci*Kh*Kw]` partials for SumRows.
+    Conv2dGradWeightGemmSplit,
+    Conv2dGradWeightGemmSplitSmall,
     CacheWrite,
     CachedAttention,
     RoPEDynamic,
@@ -299,6 +304,8 @@ impl ShaderEntry {
             | ShaderEntry::Conv2dGradInputGemmCoopGen(..)
             | ShaderEntry::Conv2dGradWeightGemm
             | ShaderEntry::Conv2dGradWeightGemmSmall
+            | ShaderEntry::Conv2dGradWeightGemmSplit
+            | ShaderEntry::Conv2dGradWeightGemmSplitSmall
             | ShaderEntry::Upsample2x
             | ShaderEntry::Upsample2xGrad
             | ShaderEntry::MaxPool2d
@@ -454,6 +461,10 @@ impl ShaderEntry {
             ShaderEntry::Conv2dGradInputGemmCoopGen(..) => ShaderGroup::Conv2dGradInputGemmCoop,
             ShaderEntry::Conv2dGradWeightGemm => ShaderGroup::Conv2dGradWeightGemm,
             ShaderEntry::Conv2dGradWeightGemmSmall => ShaderGroup::Conv2dGradWeightGemmSmall,
+            ShaderEntry::Conv2dGradWeightGemmSplit => ShaderGroup::Conv2dGradWeightGemmSplit,
+            ShaderEntry::Conv2dGradWeightGemmSplitSmall => {
+                ShaderGroup::Conv2dGradWeightGemmSplitSmall
+            }
             ShaderEntry::CacheWrite => ShaderGroup::CacheWrite,
             ShaderEntry::CachedAttention => ShaderGroup::CachedAttention,
             ShaderEntry::RoPEDynamic => ShaderGroup::RoPEDynamic,
@@ -553,7 +564,10 @@ impl ShaderEntry {
             ShaderEntry::Conv2dGradInputGemm
             | ShaderEntry::Conv2dGradInputGemmSmall
             | ShaderEntry::Conv2dGradInputGemmCoopGen(..) => "main",
-            ShaderEntry::Conv2dGradWeightGemm | ShaderEntry::Conv2dGradWeightGemmSmall => "main",
+            ShaderEntry::Conv2dGradWeightGemm
+            | ShaderEntry::Conv2dGradWeightGemmSmall
+            | ShaderEntry::Conv2dGradWeightGemmSplit
+            | ShaderEntry::Conv2dGradWeightGemmSplitSmall => "main",
             ShaderEntry::CacheWrite => "main",
             ShaderEntry::CachedAttention => "main",
             ShaderEntry::RoPEDynamic => "main",
@@ -826,7 +840,7 @@ fn group_norm_stats_kernel() -> crate::schedule::ReductionKernel {
 }
 
 /// A single GPU dispatch in the execution plan.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Dispatch {
     pub shader: ShaderEntry,
     pub workgroups: [u32; 3],
@@ -929,6 +943,9 @@ pub struct ExecutionPlan {
     pub buffers: Vec<usize>,
     /// Which buffers hold parameters (need initialization).
     pub param_buffers: Vec<(String, BufferRef)>,
+    /// Logical parameter types, unaffected by runtime allocation padding.
+    #[serde(default)]
+    pub param_types: HashMap<BufferRef, crate::graph::TensorType>,
     /// Which buffers hold inputs (filled each step).
     pub input_buffers: Vec<(String, BufferRef)>,
     /// Constant buffers with their initial data (uploaded once at session creation).
@@ -2355,6 +2372,7 @@ impl<'a> Compiler<'a> {
             plan: ExecutionPlan {
                 buffers: vec![],
                 param_buffers: vec![],
+                param_types: HashMap::new(),
                 input_buffers: Vec::new(),
                 constant_buffers: Vec::new(),
                 dispatches: Vec::new(),
@@ -2594,6 +2612,7 @@ impl<'a> Compiler<'a> {
             match node.op {
                 Op::Parameter { ref name } => {
                     self.plan.param_buffers.push((name.clone(), buf));
+                    self.plan.param_types.insert(buf, node.ty.clone());
                     let wf = WeightFormat::from_dtype(node.ty.dtype);
                     if wf.uses_reduced_storage() {
                         let shape = &node.ty.shape;

--- a/src/compile/split_k.rs
+++ b/src/compile/split_k.rs
@@ -1,0 +1,301 @@
+use super::{BufferRef, Dispatch, ExecutionPlan, ShaderEntry};
+use crate::tune::{MatmulTile, TuneClass, TuneError};
+
+impl ExecutionPlan {
+    /// Experimentally lower selected scalar convolution weight gradients to
+    /// partials followed by the existing SumRows reduction, before allocating a session.
+    ///
+    /// Selections are `(dispatch_index, splits)` in this plan's current order.
+    /// Preflight every selection before changing anything. The byte cap bounds
+    /// the sum of new logical partial capacities, conservatively before aliasing;
+    /// the session's ordinary memory preflight still checks actual allocation.
+    /// The returned value is this charged sum, not peak memory or tuning scratch.
+    ///
+    /// This changes reduction order. Callers must qualify numerical behavior and
+    /// measure the full sequence; this method neither selects nor qualifies a winner.
+    /// The live tile tuner excludes these two-pass entries and cannot swap them.
+    pub fn split_conv_weight_gradients(
+        &mut self,
+        selections: &[(usize, u32)],
+        max_partial_bytes: usize,
+    ) -> Result<usize, TuneError> {
+        let mut selections = selections.to_vec();
+        selections.sort_unstable();
+        if selections.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+            return Err(TuneError("duplicate split-K dispatch selection"));
+        }
+        let mut replacements = Vec::new();
+        let mut total_bytes = 0usize;
+        for (index, splits) in selections {
+            let dispatch = self
+                .dispatches
+                .get(index)
+                .ok_or(TuneError("split-K dispatch index out of range"))?;
+            let mut class = TuneClass::from_dispatch(dispatch, None)
+                .filter(|class| class.shader == ShaderEntry::Conv2dGradWeightGemm)
+                .ok_or(TuneError(
+                    "split-K requires an unmodified legal scalar weight gradient",
+                ))?;
+            let bindings: Vec<_> = dispatch
+                .input_buffers
+                .iter()
+                .chain(std::iter::once(&dispatch.output_buffer))
+                .collect();
+            for (i, buffer) in bindings.iter().enumerate() {
+                if bindings[..i].contains(buffer) {
+                    return Err(TuneError("split-K requires distinct logical bindings"));
+                }
+                class.binding_bytes.push(
+                    *self
+                        .buffers
+                        .get(buffer.0 as usize)
+                        .ok_or(TuneError("split-K binding index out of range"))?,
+                );
+            }
+            let tile = MatmulTile::selected(dispatch, None).expect("checked scalar class");
+            if !tile.fits(&class) {
+                return Err(TuneError("split-K binding capacity is too small"));
+            }
+            if !(2..=65_535).contains(&splits) || splits > class.k.div_ceil(16) {
+                return Err(TuneError(
+                    "split-K needs 2..65535 nonempty reduction partitions",
+                ));
+            }
+            let columns = class
+                .m
+                .checked_mul(class.n)
+                .ok_or(TuneError("split-K output index overflow"))?;
+            if columns.div_ceil(32) > 65_535 {
+                return Err(TuneError(
+                    "split-K final reduction exceeds portable dispatch limits",
+                ));
+            }
+            let bytes = columns
+                .checked_mul(splits)
+                .and_then(|elements| usize::try_from(elements).ok())
+                .and_then(|elements| elements.checked_mul(4))
+                .ok_or(TuneError("split-K partial index overflow"))?;
+            total_bytes = total_bytes
+                .checked_add(bytes)
+                .filter(|&total| total <= max_partial_bytes)
+                .ok_or(TuneError("split-K partial byte budget exceeded"))?;
+            let buffer_index = self
+                .buffers
+                .len()
+                .checked_add(replacements.len())
+                .and_then(|index| u32::try_from(index).ok())
+                .ok_or(TuneError("split-K buffer index overflow"))?;
+            let partial = BufferRef(buffer_index);
+            let mut producer = dispatch.clone();
+            producer.shader = if tile == MatmulTile::Tile32 {
+                ShaderEntry::Conv2dGradWeightGemmSplitSmall
+            } else {
+                ShaderEntry::Conv2dGradWeightGemmSplit
+            };
+            producer.workgroups[2] = splits;
+            producer.output_buffer = partial;
+            producer.label = format!("{} split-K partials ({splits})", dispatch.label);
+            let reduction = Dispatch {
+                shader: ShaderEntry::SumRows,
+                workgroups: [columns.div_ceil(32), 1, 1],
+                input_buffers: vec![partial],
+                output_buffer: dispatch.output_buffer,
+                params: vec![splits, columns, 0, 0],
+                requires_full_precision: dispatch.requires_full_precision,
+                fusion_barrier: dispatch.fusion_barrier,
+                label: format!("{} split-K reduction", dispatch.label),
+                origin: dispatch.origin.clone(),
+                ..Default::default()
+            };
+            replacements.push((index, bytes, producer, reduction));
+        }
+        self.buffers.extend(replacements.iter().map(|r| r.1));
+        for (index, _, producer, reduction) in replacements.into_iter().rev() {
+            self.dispatches
+                .splice(index..index + 1, [producer, reduction]);
+        }
+        Ok(total_bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Graph;
+
+    fn plan() -> (ExecutionPlan, usize) {
+        let mut graph = Graph::new();
+        let x = graph.input("x", &[3 * 3 * 5 * 7]);
+        let w = graph.parameter("w", &[5 * 3 * 2 * 3]);
+        let y = graph.conv2d(x, w, 3, 3, 5, 7, 5, 2, 3, 1, 0);
+        let loss = graph.sum_all(y);
+        graph.set_outputs(vec![loss]);
+        let plan = super::super::compile(&crate::autodiff::differentiate(&graph));
+        let index = plan
+            .dispatches
+            .iter()
+            .position(|d| {
+                matches!(
+                    d.shader,
+                    ShaderEntry::Conv2dGradWeightGemm | ShaderEntry::Conv2dGradWeightGemmSmall
+                )
+            })
+            .unwrap();
+        (plan, index)
+    }
+
+    #[test]
+    fn split_sequence_preserves_logical_output_and_provenance() {
+        let (mut plan, index) = plan();
+        let original = plan.clone();
+        let output = original.dispatches[index].output_buffer;
+        let bytes = original.buffers[output.0 as usize] * 3;
+        assert_eq!(
+            plan.split_conv_weight_gradients(&[(index, 3)], bytes),
+            Ok(bytes)
+        );
+        assert_eq!(plan.buffers.len(), original.buffers.len() + 1);
+        assert_eq!(plan.buffers.last(), Some(&bytes));
+        assert_eq!(plan.dispatches.len(), original.dispatches.len() + 1);
+        let a = &plan.dispatches[index];
+        let b = &plan.dispatches[index + 1];
+        assert_eq!(a.workgroups[2], 3);
+        assert_eq!(a.input_buffers, original.dispatches[index].input_buffers);
+        assert_eq!(a.params, original.dispatches[index].params);
+        assert!(TuneClass::from_dispatch(a, None).is_none());
+        assert_eq!(b.shader, ShaderEntry::SumRows);
+        assert_eq!(b.input_buffers, [a.output_buffer]);
+        assert_eq!(b.output_buffer, output);
+        for dispatch in [a, b] {
+            assert_eq!(dispatch.origin, original.dispatches[index].origin);
+            assert_eq!(
+                dispatch.requires_full_precision,
+                original.dispatches[index].requires_full_precision
+            );
+        }
+        assert_eq!(plan.node_buffers, original.node_buffers);
+        assert_eq!(plan.param_grad_pairs, original.param_grad_pairs);
+        assert_eq!(plan.output_buffers, original.output_buffers);
+        assert_eq!(plan.loss_buffer, original.loss_buffer);
+        let restored: ExecutionPlan =
+            serde_json::from_value(serde_json::to_value(&plan).unwrap()).unwrap();
+        assert_eq!(restored.dispatches, plan.dispatches);
+    }
+
+    fn rejected(mut plan: ExecutionPlan, selections: &[(usize, u32)], cap: usize) {
+        let before = serde_json::to_value(&plan).unwrap();
+        assert!(plan.split_conv_weight_gradients(selections, cap).is_err());
+        assert_eq!(serde_json::to_value(&plan).unwrap(), before);
+    }
+
+    #[test]
+    fn all_selections_are_checked_before_any_plan_change() {
+        let (mut plan, index) = plan();
+        let mut second = plan.dispatches[index].clone();
+        let size = plan.buffers[second.output_buffer.0 as usize];
+        second.output_buffer = BufferRef(plan.buffers.len() as u32);
+        plan.buffers.push(size);
+        let other = plan.dispatches.len();
+        plan.dispatches.push(second);
+        for selections in [
+            vec![(index, 3), (index, 2)],
+            vec![(index, 3), (other, 1)],
+            vec![(index, 3), (usize::MAX, 3)],
+        ] {
+            rejected(plan.clone(), &selections, usize::MAX);
+        }
+        rejected(plan.clone(), &[(index, 3), (other, 3)], 6 * size - 1);
+        let mut reverse = plan.clone();
+        assert_eq!(
+            plan.split_conv_weight_gradients(&[(index, 3), (other, 3)], 6 * size),
+            Ok(6 * size)
+        );
+        reverse
+            .split_conv_weight_gradients(&[(other, 3), (index, 3)], 6 * size)
+            .unwrap();
+        assert_eq!(
+            serde_json::to_value(plan).unwrap(),
+            serde_json::to_value(reverse).unwrap()
+        );
+    }
+
+    #[test]
+    fn split_legality_rejects_bad_geometry_capacities_and_modifiers() {
+        let (plan, index) = plan();
+        for splits in [0, 1, 5, 65_536, u32::MAX] {
+            rejected(plan.clone(), &[(index, splits)], usize::MAX);
+        }
+        rejected(plan.clone(), &[(index, 2)], 0);
+        for change in [
+            |d: &mut Dispatch| d.use_coop = true,
+            |d: &mut Dispatch| d.workgroups[2] = 2,
+            |d: &mut Dispatch| d.params[6] = 0,
+            |d: &mut Dispatch| d.input_buffers[0] = d.output_buffer,
+            |d: &mut Dispatch| d.output_buffer = BufferRef(u32::MAX),
+        ] {
+            let mut changed = plan.clone();
+            change(&mut changed.dispatches[index]);
+            rejected(changed, &[(index, 2)], usize::MAX);
+        }
+        let mut small = plan.clone();
+        small.buffers[plan.dispatches[index].output_buffer.0 as usize] -= 4;
+        rejected(small, &[(index, 2)], usize::MAX);
+        let mut unchanged = plan.clone();
+        assert_eq!(unchanged.split_conv_weight_gradients(&[], 0), Ok(0));
+        assert_eq!(
+            serde_json::to_value(unchanged).unwrap(),
+            serde_json::to_value(plan).unwrap()
+        );
+    }
+
+    #[test]
+    fn balanced_tile_partitions_cover_uneven_k_without_overflow() {
+        for k in [17u32, 31, 32, 33, 41, 60, 65_537, 12_544, u32::MAX - 15] {
+            let tiles = k.div_ceil(16);
+            for splits in [2, 3, 7, 16, 65_535].into_iter().filter(|&s| s <= tiles) {
+                let mut previous = 0u32;
+                for split in 0..splits {
+                    let per_split = tiles / splits;
+                    let extra = tiles % splits;
+                    let first = split.checked_mul(per_split).unwrap() + split.min(extra);
+                    let last = first + per_split + u32::from(split < extra);
+                    let start = first.checked_mul(16).unwrap();
+                    let end = last.checked_mul(16).unwrap().min(k);
+                    assert_eq!(start, previous);
+                    assert!(end > start);
+                    previous = end;
+                }
+                assert_eq!(previous, k);
+            }
+        }
+    }
+
+    #[test]
+    fn partial_indices_and_final_reduction_geometry_are_bounded() {
+        for (channels, width, splits, error) in [
+            (
+                2048,
+                32,
+                2,
+                "split-K final reduction exceeds portable dispatch limits",
+            ),
+            (1024, 1_048_560, 65_535, "split-K partial index overflow"),
+        ] {
+            let (mut plan, index) = plan();
+            let d = &mut plan.dispatches[index];
+            d.shader = ShaderEntry::Conv2dGradWeightGemmSmall;
+            d.params = vec![1, channels, 1, width, channels, 1, 1, 1, 0, 1, width, 0];
+            d.workgroups = [channels.div_ceil(32), channels.div_ceil(32), 1];
+            for &buffer in &d.input_buffers {
+                plan.buffers[buffer.0 as usize] = channels as usize * width as usize * 4;
+            }
+            plan.buffers[d.output_buffer.0 as usize] = channels as usize * channels as usize * 4;
+            let before = serde_json::to_value(&plan).unwrap();
+            assert_eq!(
+                plan.split_conv_weight_gradients(&[(index, splits)], usize::MAX),
+                Err(TuneError(error))
+            );
+            assert_eq!(serde_json::to_value(&plan).unwrap(), before);
+        }
+    }
+}

--- a/src/divisor.rs
+++ b/src/divisor.rs
@@ -1,0 +1,170 @@
+pub(crate) const SHADER: &str = include_str!("shaders/divisor.wgsl");
+
+pub(crate) fn multiplier(divisor: u32) -> u32 {
+    assert_ne!(divisor, 0, "index divisor must be positive");
+    // Division by one bypasses multiplication in the shader.
+    ((1u64 << 32) / u64::from(divisor)) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::multiplier;
+
+    fn cases() -> Vec<[u32; 4]> {
+        let mut divisors: Vec<_> = (1..=256).collect();
+        let mut numerators: Vec<_> = (0..=256).collect();
+        for bit in 1..32 {
+            let value = 1u32 << bit;
+            for offset in -2i64..=2 {
+                if let Ok(value) = u32::try_from(i64::from(value) + offset) {
+                    numerators.push(value);
+                    if value != 0 {
+                        divisors.push(value);
+                    }
+                }
+            }
+        }
+        numerators.extend([u32::MAX - 1, u32::MAX]);
+        divisors.extend([u32::MAX - 1, u32::MAX]);
+        let mut cases = Vec::new();
+        for divisor in divisors {
+            for &value in &numerators {
+                cases.push([value, divisor, multiplier(divisor), 0]);
+            }
+            for quotient in [1, 2, 3, 41, 47, 55, 65535, u32::MAX / divisor] {
+                let boundary = u64::from(divisor) * u64::from(quotient);
+                for value in [boundary.saturating_sub(1), boundary, boundary + 1] {
+                    if let Ok(value) = u32::try_from(value) {
+                        cases.push([value, divisor, multiplier(divisor), 0]);
+                    }
+                }
+            }
+        }
+        let mut state = 0x243f6a88u32;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            state
+        };
+        for i in 0..100_000 {
+            let value = next();
+            let raw = next();
+            let divisor = if i % 2 == 0 { raw } else { raw & 0xffff }.max(1);
+            cases.push([value, divisor, multiplier(divisor), 0]);
+        }
+        cases
+    }
+
+    #[test]
+    fn reciprocal_estimate_is_at_most_one_low_without_overflow() {
+        for [value, divisor, reciprocal, _] in cases() {
+            if divisor == 1 {
+                assert_eq!(reciprocal, 0);
+                continue;
+            }
+            let estimate = (u64::from(value) * u64::from(reciprocal)) >> 32;
+            let expected = value / divisor;
+            assert!(estimate <= u64::from(expected));
+            assert!(u64::from(expected) - estimate <= 1);
+            let product = u32::try_from(estimate * u64::from(divisor)).unwrap();
+            let remainder = value.checked_sub(product).unwrap();
+            assert_eq!(estimate as u32 + u32::from(remainder >= divisor), expected);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "index divisor must be positive")]
+    fn zero_divisor_is_rejected() {
+        multiplier(0);
+    }
+
+    #[test]
+    fn gpu_exact_division_and_multiply_high() {
+        use bg::ShaderData;
+        use blade_graphics as bg;
+
+        #[derive(blade_macros::ShaderData)]
+        struct Data {
+            src: bg::BufferPiece,
+            dst: bg::BufferPiece,
+        }
+
+        let source = format!(
+            "{}\n\
+             var<storage> src: array<vec4<u32>>;\n\
+             var<storage, read_write> dst: array<vec2<u32>>;\n\
+             @compute @workgroup_size(64)\n\
+             fn main(@builtin(global_invocation_id) id: vec3<u32>) {{\n\
+                 if id.x < arrayLength(&src) {{\n\
+                     let input = src[id.x];\n\
+                     dst[id.x] = vec2<u32>(divide_exact(input.x, input.y, input.z),\n\
+                         multiply_high(input.x, input.y));\n\
+                 }}\n\
+             }}",
+            super::SHADER
+        );
+        let gpu = crate::init_gpu_context().unwrap();
+        let shader = gpu.create_shader(bg::ShaderDesc {
+            source: &source,
+            naga_module: None,
+        });
+        let mut pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
+            name: "exact_division_test",
+            data_layouts: &[&Data::layout()],
+            compute: shader.at("main"),
+        });
+        let inputs = cases();
+        let src = gpu.create_buffer(bg::BufferDesc {
+            name: "exact_division_inputs",
+            size: (inputs.len() * 16) as u64,
+            memory: bg::Memory::Shared,
+        });
+        let dst = gpu.create_buffer(bg::BufferDesc {
+            name: "exact_division_outputs",
+            size: (inputs.len() * 8) as u64,
+            memory: bg::Memory::Shared,
+        });
+        unsafe {
+            std::slice::from_raw_parts_mut(src.data().cast::<[u32; 4]>(), inputs.len())
+                .copy_from_slice(&inputs);
+            std::slice::from_raw_parts_mut(dst.data().cast::<[u32; 2]>(), inputs.len())
+                .fill([u32::MAX; 2]);
+        }
+        let mut encoder = gpu.create_command_encoder(bg::CommandEncoderDesc {
+            name: "exact_division_test",
+            buffer_count: 1,
+            manual_barriers: false,
+        });
+        encoder.start();
+        {
+            let mut pass = encoder.compute("exact_division_test");
+            let mut command = pass.with(&pipeline);
+            command.bind(
+                0,
+                &Data {
+                    src: src.at(0),
+                    dst: dst.at(0),
+                },
+            );
+            command.dispatch([(inputs.len() as u32).div_ceil(64), 1, 1]);
+        }
+        let sync = gpu.submit(&mut encoder);
+        assert!(gpu.wait_for(&sync, !0).unwrap());
+        let outputs = unsafe {
+            std::slice::from_raw_parts(dst.data().cast::<[u32; 2]>(), inputs.len()).to_vec()
+        };
+        gpu.destroy_command_encoder(&mut encoder);
+        gpu.destroy_compute_pipeline(&mut pipeline);
+        gpu.destroy_buffer(src);
+        gpu.destroy_buffer(dst);
+        for ([value, divisor, _, _], [quotient, high]) in inputs.into_iter().zip(outputs) {
+            assert_eq!(quotient, value / divisor, "{value} / {divisor}");
+            assert_eq!(
+                u64::from(high),
+                (u64::from(value) * u64::from(divisor)) >> 32,
+                "high product: {value} * {divisor}"
+            );
+        }
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2003,6 +2003,8 @@ impl Graph {
     }
 
     /// Conv2d with separate height/width padding (for Conv1d emulation etc.).
+    /// Input and kernel must have the flat shapes documented by [`Self::conv2d`].
+    #[track_caller]
     #[allow(clippy::too_many_arguments)]
     pub fn conv2d_hw(
         &mut self,
@@ -2019,6 +2021,19 @@ impl Graph {
         padding_h: u32,
         padding_w: u32,
     ) -> NodeId {
+        let input_size = batch as usize * in_channels as usize * in_h as usize * in_w as usize;
+        let kernel_size =
+            out_channels as usize * in_channels as usize * kernel_h as usize * kernel_w as usize;
+        assert_eq!(
+            self.node(input).ty.shape,
+            [input_size],
+            "Conv2d expects a flat NCHW input matching batch/channels/spatial extents; reshape first"
+        );
+        assert_eq!(
+            self.node(kernel).ty.shape,
+            [kernel_size],
+            "Conv2d expects a flat kernel matching channels/kernel extents; reshape first"
+        );
         let out_h = (in_h + 2 * padding_h - kernel_h) / stride + 1;
         let out_w = (in_w + 2 * padding_w - kernel_w) / stride + 1;
         let out_size = batch as usize * out_channels as usize * out_h as usize * out_w as usize;
@@ -2504,6 +2519,25 @@ impl fmt::Display for Graph {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn conv2d_rejects_nonflat_or_mismatched_operands_before_compilation() {
+        for (input_shape, weight_shape, batch) in [
+            (vec![2, 3, 5, 7], vec![5 * 3 * 2 * 3], 2),
+            (vec![2 * 3 * 5 * 7], vec![5, 3, 2, 3], 2),
+            (vec![2 * 3 * 5 * 7 - 1], vec![5 * 3 * 2 * 3], 2),
+            (vec![2 * 3 * 5 * 7], vec![5 * 3 * 2 * 3], 1),
+        ] {
+            assert!(
+                std::panic::catch_unwind(|| {
+                    let mut graph = super::Graph::new();
+                    let x = graph.input("x", &input_shape);
+                    let w = graph.parameter("w", &weight_shape);
+                    graph.conv2d_hw(x, w, batch, 3, 5, 7, 5, 2, 3, 1, 0, 1);
+                })
+                .is_err()
+            );
+        }
+    }
     use super::*;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod codegen;
 pub mod compile;
 pub mod config;
 pub mod data;
+mod divisor;
 pub mod eager;
 pub mod graph;
 pub mod load;
@@ -66,4 +67,8 @@ pub use train::{
     TrainConfig, TrainHistory, Trainer, build, build_inference_session, build_session,
     build_session_unoptimized, compile_training_graph,
 };
-pub use tune::{MatmulTile, TuneClass, TuneDecision, TuneError, TuneOptions, TuneReport};
+pub use tune::{
+    MatmulTile, TuneClass, TuneConv2d, TuneDecision, TuneError, TuneOptions, TunePhaseTimes,
+    TunePreparationTimes, TuneQualificationTimes, TuneReport, TuneScope, TuneScratchStats,
+    TuneScratchUsage, TuneStaging, TuneStagingReuse,
+};

--- a/src/memplan.rs
+++ b/src/memplan.rs
@@ -475,6 +475,7 @@ mod tests {
         ExecutionPlan {
             buffers,
             param_buffers: Vec::new(),
+            param_types: Default::default(),
             input_buffers: Vec::new(),
             constant_buffers: Vec::new(),
             dispatches,

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -215,6 +215,11 @@ pub struct ProfilePlan {
     pub barrier_group_count: usize,
     pub logical_buffer_bytes: usize,
     pub allocated_buffer_bytes: usize,
+    /// Resident graph/optimizer buffer requests, not driver allocation or peak.
+    pub resident_buffer_bytes: usize,
+    pub adam_state_bytes: usize,
+    pub grad_accumulator_bytes: usize,
+    pub optimizer_aux_bytes: usize,
     pub device_local_bytes: usize,
     pub physical_allocation_count: usize,
 }
@@ -597,6 +602,10 @@ pub fn capture_session_profile(
             barrier_group_count: session.num_groups(),
             logical_buffer_bytes: memory.total_buffer_bytes,
             allocated_buffer_bytes: memory.allocated_buffer_bytes,
+            resident_buffer_bytes: memory.total_allocated_bytes(),
+            adam_state_bytes: memory.adam_state_bytes,
+            grad_accumulator_bytes: memory.grad_accumulator_bytes,
+            optimizer_aux_bytes: memory.optimizer_aux_bytes,
             device_local_bytes: memory.device_local_bytes,
             physical_allocation_count: memory.num_allocations,
         },

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2,6 +2,7 @@ use crate::compile::{BufferRef, Dispatch, ExecutionPlan, ShaderEntry};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
+mod checkpoint;
 mod tuning;
 pub use crate::tune::TuneOutcome;
 
@@ -72,18 +73,34 @@ struct ScatterAddParams {
 /// Summary of GPU memory allocation for a session.
 #[derive(Clone, Debug)]
 pub struct MemorySummary {
+    /// Sum of plan buffer capacities before aliasing, including runtime padding.
     pub total_buffer_bytes: usize,
+    /// Resident Adam/LaProp moments; zero until configuration, write or restore.
     pub adam_state_bytes: usize,
+    pub grad_accumulator_bytes: usize,
+    /// Clip scalar and optional grouped-gradient diagnostic storage.
+    pub optimizer_aux_bytes: usize,
     pub num_buffers: usize,
     pub largest_buffer_bytes: usize,
     /// Bytes actually allocated on the GPU after lifetime-based buffer
-    /// aliasing (≤ `total_buffer_bytes`, which counts logical buffers).
+    /// aliasing, excluding optimizer state and staging.
     pub allocated_buffer_bytes: usize,
     /// Number of physical allocations backing the logical buffers.
     pub num_allocations: usize,
     /// Bytes placed in device-local (non-host-visible) memory —
     /// step-local intermediates on discrete GPUs.
     pub device_local_bytes: usize,
+}
+
+impl MemorySummary {
+    /// Resident tensor/optimizer allocation requests, excluding driver objects
+    /// and staging. Not a peak or device-budget measurement.
+    pub fn total_allocated_bytes(&self) -> usize {
+        self.allocated_buffer_bytes
+            + self.adam_state_bytes
+            + self.grad_accumulator_bytes
+            + self.optimizer_aux_bytes
+    }
 }
 
 /// Per-process GPU memory usage as reported by the graphics API.
@@ -110,13 +127,15 @@ impl std::fmt::Display for MemorySummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{} buffers in {} allocations, {:.1} MB allocated ({:.1} MB device-local, {:.1} MB logical, {:.1} MB adam state), largest {:.1} MB",
+            "{} graph buffers in {} allocations, {:.1} MB resident ({:.1} MB graph, {:.1} MB device-local, {:.1} MB logical, {:.1} MB adam, {:.1} MB accumulators), largest {:.1} MB",
             self.num_buffers,
             self.num_allocations,
+            self.total_allocated_bytes() as f64 / 1e6,
             self.allocated_buffer_bytes as f64 / 1e6,
             self.device_local_bytes as f64 / 1e6,
             self.total_buffer_bytes as f64 / 1e6,
             self.adam_state_bytes as f64 / 1e6,
+            self.grad_accumulator_bytes as f64 / 1e6,
             self.largest_buffer_bytes as f64 / 1e6,
         )
     }
@@ -606,11 +625,40 @@ struct Conv2dParams {
     out_h: u32,
     out_w: u32,
     padding_w: u32,
-    // Reciprocals for strength-reduced integer division in im2col
-    inv_kernel_w: f32,
-    inv_kernel_hw: f32,
-    inv_col_w: f32,      // 1/out_w (forward, grad_weight) or 1/in_w (grad_input)
-    inv_go_spatial: f32, // 1/(out_h*out_w) for grad_weight, unused otherwise
+    kernel_w_multiplier: u32,
+    kernel_hw_multiplier: u32,
+    column_width_multiplier: u32,
+    output_spatial_multiplier: u32,
+}
+
+impl From<&Dispatch> for Conv2dParams {
+    fn from(dispatch: &Dispatch) -> Self {
+        let p = &dispatch.params;
+        let column_width = match dispatch.shader {
+            ShaderEntry::Conv2dGradInputGemm
+            | ShaderEntry::Conv2dGradInputGemmSmall
+            | ShaderEntry::Conv2dGradInputGemmCoopGen(..) => p[3],
+            _ => p[10],
+        };
+        Self {
+            batch: p[0],
+            in_channels: p[1],
+            in_h: p[2],
+            in_w: p[3],
+            out_channels: p[4],
+            kernel_h: p[5],
+            kernel_w: p[6],
+            stride: p[7],
+            padding_h: p[8],
+            out_h: p[9],
+            out_w: p[10],
+            padding_w: p[11],
+            kernel_w_multiplier: crate::divisor::multiplier(p[6]),
+            kernel_hw_multiplier: crate::divisor::multiplier(p[5] * p[6]),
+            column_width_multiplier: crate::divisor::multiplier(column_width),
+            output_spatial_multiplier: crate::divisor::multiplier(p[9] * p[10]),
+        }
+    }
 }
 
 // conv2d_dw: var src, weight, dst, params (depthwise, no in/out channels split)
@@ -1858,9 +1906,10 @@ pub fn shader_data_layout(entry: &ShaderEntry) -> blade_graphics::ShaderDataLayo
         ShaderEntry::Conv2dGradInputGemm
         | ShaderEntry::Conv2dGradInputGemmSmall
         | ShaderEntry::Conv2dGradInputGemmCoopGen(..) => Conv2dGradInputData::layout(),
-        ShaderEntry::Conv2dGradWeightGemm | ShaderEntry::Conv2dGradWeightGemmSmall => {
-            Conv2dGradWeightData::layout()
-        }
+        ShaderEntry::Conv2dGradWeightGemm
+        | ShaderEntry::Conv2dGradWeightGemmSmall
+        | ShaderEntry::Conv2dGradWeightGemmSplit
+        | ShaderEntry::Conv2dGradWeightGemmSplitSmall => Conv2dGradWeightData::layout(),
         ShaderEntry::RoPEDynamic => RoPEDynamicData::layout(),
         ShaderEntry::CacheWrite => CacheWriteData::layout(),
         ShaderEntry::CachedAttention => CachedAttentionData::layout(),
@@ -1956,7 +2005,7 @@ fn compute_groups(dispatches: &[Dispatch]) -> Vec<std::ops::Range<usize>> {
 /// kernels and output padding), the RmsNorm→matmul prologue fusion that
 /// depends on it, and small-tile demotion. Mutates the plan in place.
 /// This establishes deterministic initial choices. The optional scratch tuner
-/// independently checks legality within its narrower scalar-tile domain.
+/// independently checks legality within its narrower f32-matmul domain.
 pub(crate) fn select_variants(
     plan: &mut ExecutionPlan,
     coop_config: Option<&crate::codegen::CoopConfig>,
@@ -2404,6 +2453,9 @@ pub struct Session {
     /// device-local placement.
     alias: crate::memplan::AliasPlan,
     pipelines: Pipelines,
+    /// Session policy/capabilities after the cooperative smoke test. Tuning
+    /// must not re-enable a rejected or explicitly disabled implementation.
+    coop_config: Option<crate::codegen::CoopConfig>,
     plan: ExecutionPlan,
     /// Pre-computed barrier groups: each range of dispatch indices shares one
     /// compute pass. Pass boundaries in blade emit ALL_COMMANDS barriers.
@@ -2433,7 +2485,7 @@ pub struct Session {
     /// overridden by another `set_learning_rate` / `set_adam` call or
     /// cleared via `clear_optimizer()`.
     pending_lr: Option<f32>,
-    /// Per-parameter Adam state buffers: (m_buf, v_buf).
+    /// Per-parameter Adam/LaProp state, empty until configured or restored.
     adam_state: Vec<(blade_graphics::Buffer, blade_graphics::Buffer)>,
     /// Optional exact temporal sum of grouped gradient L2 norms for one
     /// parameter. Adam already visits every scalar gradient, so collecting
@@ -2922,27 +2974,13 @@ impl Session {
             alias.physical_bytes() as f64 / 1e6,
             alias.device_local_bytes() as f64 / 1e6,
         );
-        let adam_state_bytes = plan
-            .param_grad_pairs
-            .iter()
-            .try_fold(0usize, |total, &(param, _)| {
-                let parameter_bytes = plan.buffers[param.0 as usize];
-                total.checked_add(
-                    parameter_bytes
-                        .checked_mul(2)
-                        .expect("Adam state size overflow"),
-                )
-            })
-            .expect("Adam state total size overflow");
         let planned_allocation_bytes = alias
-            .physical_bytes()
-            .checked_add(adam_state_bytes)
+            .sizes
+            .iter()
+            .try_fold(0usize, |sum, &size| sum.checked_add(size.max(4)))
+            .and_then(|bytes| bytes.checked_add(usize::from(!plan.param_grad_pairs.is_empty()) * 4))
             .expect("session allocation size overflow");
-        ensure_device_memory_budget(
-            &gpu,
-            planned_allocation_bytes,
-            "session buffers and Adam state",
-        );
+        ensure_device_memory_budget(&gpu, planned_allocation_bytes, "session buffers");
         let physical_buffers: Vec<blade_graphics::Buffer> = alias
             .sizes
             .iter()
@@ -3010,30 +3048,6 @@ impl Session {
 
         let optimizer_device = !opts.no_device_local && !opts.debug;
         let mut optimizer_device_bufs: Vec<(blade_graphics::Buffer, u64)> = Vec::new();
-        let adam_state = plan
-            .param_grad_pairs
-            .iter()
-            .enumerate()
-            .map(|(i, &(param_buf, _))| {
-                let size = (plan.buffers[param_buf.0 as usize] as u64).max(4);
-                let m_buf = create_optimizer_buffer(
-                    &gpu,
-                    &format!("adam_m_{i}"),
-                    size,
-                    optimizer_device,
-                    &mut optimizer_device_bufs,
-                );
-                let v_buf = create_optimizer_buffer(
-                    &gpu,
-                    &format!("adam_v_{i}"),
-                    size,
-                    optimizer_device,
-                    &mut optimizer_device_bufs,
-                );
-                (m_buf, v_buf)
-            })
-            .collect();
-
         // Grad-clip accumulator: a single f32. GPU-only after the
         // barriered clip path landed; host-visible only in debug.
         let grad_clip_acc = if !plan.param_grad_pairs.is_empty() {
@@ -3092,6 +3106,7 @@ impl Session {
             physical_buffers,
             alias,
             pipelines,
+            coop_config,
             plan,
             groups,
             encoder,
@@ -3111,7 +3126,7 @@ impl Session {
             grad_accum_bufs: Vec::new(),
             grad_accum_scale: None,
             lr_multipliers: Vec::new(),
-            adam_state,
+            adam_state: Vec::new(),
             adam_grouped_grad_norm: None,
             adam_step: 0,
             pending_adam: None,
@@ -3571,6 +3586,55 @@ mod variant_tests {
 }
 
 #[cfg(test)]
+mod split_k_tests {
+    use super::{BufferRef, Dispatch, ShaderEntry, compute_groups, reorder_by_level};
+
+    #[test]
+    fn split_sequences_get_barriers_and_reuse_nonoverlapping_partials() {
+        let mut plan = crate::compile::compile(&crate::Graph::new());
+        let bytes = 33 * 33 * 4;
+        plan.buffers = vec![bytes; 4];
+        plan.input_buffers = vec![
+            ("upstream".into(), BufferRef(0)),
+            ("input".into(), BufferRef(1)),
+        ];
+        plan.output_buffers = vec![BufferRef(2), BufferRef(3)];
+        let first = Dispatch {
+            shader: ShaderEntry::Conv2dGradWeightGemmSmall,
+            workgroups: [2, 2, 1],
+            input_buffers: vec![BufferRef(0), BufferRef(1)],
+            output_buffer: BufferRef(2),
+            params: vec![1, 33, 1, 33, 33, 1, 1, 1, 0, 1, 33, 0],
+            requires_full_precision: true,
+            ..Default::default()
+        };
+        let mut second = first.clone();
+        second.input_buffers[1] = BufferRef(2);
+        second.output_buffer = BufferRef(3);
+        plan.dispatches = vec![first, second];
+        assert_eq!(
+            plan.split_conv_weight_gradients(&[(0, 2), (1, 2)], bytes * 4),
+            Ok(bytes * 4)
+        );
+        reorder_by_level(&mut plan.dispatches);
+        let groups = compute_groups(&plan.dispatches);
+        assert_eq!(groups, [0..1, 1..2, 2..3, 3..4]);
+        let alias = crate::memplan::plan_buffer_aliasing(&plan, &groups, None);
+        assert_eq!(alias.map[4], alias.map[5]);
+        assert_eq!(alias.sizes[alias.map[4]], bytes * 2);
+        assert!(alias.device_local[alias.map[4]]);
+        for i in 0..4 {
+            assert_ne!(alias.map[i], alias.map[4]);
+        }
+        let no_alias = crate::memplan::plan_no_alias(&plan, &groups, None);
+        assert_eq!(
+            no_alias.physical_bytes() - alias.physical_bytes(),
+            bytes * 2
+        );
+    }
+}
+
+#[cfg(test)]
 mod device_id_tests {
     use super::parse_device_id;
 
@@ -3932,9 +3996,9 @@ impl Session {
                             .collect(),
                         crate::compile::WeightFormat::F32 => unreachable!(),
                     };
-                    self.upload_buffer(buf_ref, &packed);
+                    self.upload_parameter_bytes(buf_ref, &packed);
                 } else {
-                    self.upload_buffer(buf_ref, bytemuck::cast_slice(data));
+                    self.upload_parameter_bytes(buf_ref, bytemuck::cast_slice(data));
                 }
 
                 // If this source param feeds a derived param, fill the
@@ -3996,10 +4060,14 @@ impl Session {
                                         .collect(),
                                     _ => unreachable!(),
                                 };
-                                self.upload_buffer(*derived_buf, &packed);
+                                self.upload_parameter_bytes(*derived_buf, &packed);
                             } else {
                                 // f32: direct copy into GPU buffer
-                                let buf_f32 = self.plan.buffers[derived_buf.0 as usize] / 4;
+                                let buf_f32 =
+                                    self.plan.param_types.get(derived_buf).map_or(
+                                        self.plan.buffers[derived_buf.0 as usize] / 4,
+                                        |ty| ty.num_elements(),
+                                    );
                                 let rows = buf_f32.checked_div(total_cols).unwrap_or(0);
                                 let mut col_offset = 0usize;
                                 for src in sources {
@@ -4191,6 +4259,24 @@ impl Session {
         panic!("unknown input: {}", name);
     }
 
+    fn upload_parameter_bytes(&self, buffer: BufferRef, data: &[u8]) {
+        let capacity = self.plan.buffers[buffer.0 as usize];
+        let logical = self
+            .plan
+            .param_types
+            .get(&buffer)
+            .map_or(capacity, |ty| ty.size_bytes());
+        if data.len() == logical && logical < capacity {
+            let mut padded = vec![0; capacity];
+            padded[..logical].copy_from_slice(data);
+            self.upload_buffer(buffer, &padded);
+        } else {
+            // Retain compatibility with callers supplying a full padded slot;
+            // every other short/mismatched upload remains an error.
+            self.upload_buffer(buffer, data);
+        }
+    }
+
     fn upload_buffer(&self, buf_ref: BufferRef, data: &[u8]) {
         let buffer = &self.buffers[buf_ref.0 as usize];
         let expected = self.plan.buffers[buf_ref.0 as usize];
@@ -4232,6 +4318,9 @@ impl Session {
     /// Write `data` into a GPU buffer, staging through a host-visible
     /// allocation when the destination is device-local.
     fn write_raw_buffer(&self, buffer: &blade_graphics::Buffer, data: &[u8], host_visible: bool) {
+        if data.is_empty() {
+            return;
+        }
         if host_visible {
             unsafe {
                 std::ptr::copy_nonoverlapping(data.as_ptr(), buffer.data(), data.len());
@@ -4266,6 +4355,9 @@ impl Session {
     }
 
     fn read_raw_f32(&self, buffer: &blade_graphics::Buffer, out: &mut [f32], host_visible: bool) {
+        if out.is_empty() {
+            return;
+        }
         if host_visible {
             unsafe {
                 std::ptr::copy_nonoverlapping(
@@ -4514,6 +4606,10 @@ impl Session {
     /// directly through the mapped pointer. Device-local buffers
     /// (intermediates, parameter gradients) take a staging round-trip.
     pub fn read_buffer(&self, buf_ref: BufferRef, out: &mut [f32]) {
+        assert!(
+            std::mem::size_of_val(out) <= self.plan.buffers[buf_ref.0 as usize],
+            "read_buffer: F32 view exceeds buffer capacity"
+        );
         self.read_raw_f32(
             &self.buffers[buf_ref.0 as usize],
             out,
@@ -4544,12 +4640,23 @@ impl Session {
             .map(|entry| entry.1)
     }
 
-    /// Read a parameter buffer's contents by name.
+    /// Read an F32 parameter buffer's contents by name.
     pub fn read_param(&self, name: &str, out: &mut [f32]) {
         let buf_ref = self
             .param_buffer(name)
             .unwrap_or_else(|| panic!("unknown param: {}", name));
+        self.assert_f32_parameter(buf_ref);
         self.read_buffer(buf_ref, out);
+    }
+
+    fn assert_f32_parameter(&self, buffer: BufferRef) {
+        assert!(
+            self.plan
+                .param_types
+                .get(&buffer)
+                .is_none_or(|ty| ty.dtype == crate::graph::DType::F32),
+            "parameter read requires F32 storage"
+        );
     }
 
     fn read_f32_buffers(
@@ -4637,7 +4744,8 @@ impl Session {
                     ),
                     "parameter {name:?} is not an F32 buffer",
                 );
-                let byte_len = self.plan.buffers[buf_ref.0 as usize];
+                self.assert_f32_parameter(buf_ref);
+                let byte_len = self.param_size(name).expect("parameter exists") * 4;
                 (self.buffers[buf_ref.0 as usize], byte_len)
             })
             .collect();
@@ -4676,13 +4784,14 @@ impl Session {
             .collect()
     }
 
-    /// Element count for a parameter (in `f32` elements). Returns
+    /// Logical element count for a parameter, independent of storage/padding. Returns
     /// `None` if the name doesn't exist.
     pub fn param_size(&self, name: &str) -> Option<usize> {
         let buf_ref = self.param_buffer(name)?;
-        // BufferRef indexes into self.plan.buffers; entry is byte size.
-        let bytes = self.plan.buffers[buf_ref.0 as usize];
-        Some(bytes / std::mem::size_of::<f32>())
+        Some(self.plan.param_types.get(&buf_ref).map_or(
+            self.plan.buffers[buf_ref.0 as usize] / std::mem::size_of::<f32>(),
+            |ty| ty.num_elements(),
+        ))
     }
 
     /// Returns true iff the parameter has an associated gradient buffer
@@ -4699,8 +4808,8 @@ impl Session {
 
     /// Read the Adam first-moment buffer (`m`) for a parameter into
     /// `out`. `out.len()` must equal the parameter's element count.
-    /// Panics if the parameter has no Adam state (no gradient, or
-    /// optimizer wasn't initialised). Used together with
+    /// Returns zeros without allocating before optimizer initialization.
+    /// Panics if the parameter has no gradient. Used together with
     /// [`Session::write_adam_m`] / [`Session::write_adam_v`] /
     /// [`Session::set_adam_step_count`] to carry optimizer state
     /// across a session rebuild — e.g. when the parameter table
@@ -4709,7 +4818,6 @@ impl Session {
         let idx = self
             .adam_state_index(name)
             .unwrap_or_else(|| panic!("no Adam state for param: {name}"));
-        let buf = &self.adam_state[idx].0;
         let n = self.param_size(name).expect("param exists; size known");
         assert_eq!(
             out.len(),
@@ -4717,7 +4825,11 @@ impl Session {
             "read_adam_m: out.len()={} but param '{name}' has {n} elements",
             out.len()
         );
-        self.read_raw_f32(buf, out, !self.optimizer_device);
+        if let Some(&(buffer, _)) = self.adam_state.get(idx) {
+            self.read_raw_f32(&buffer, out, !self.optimizer_device);
+        } else {
+            out.fill(0.0);
+        }
     }
 
     /// Read the Adam second-moment buffer (`v`) for a parameter. See
@@ -4726,7 +4838,6 @@ impl Session {
         let idx = self
             .adam_state_index(name)
             .unwrap_or_else(|| panic!("no Adam state for param: {name}"));
-        let buf = &self.adam_state[idx].1;
         let n = self.param_size(name).expect("param exists; size known");
         assert_eq!(
             out.len(),
@@ -4734,13 +4845,30 @@ impl Session {
             "read_adam_v: out.len()={} but param '{name}' has {n} elements",
             out.len()
         );
-        self.read_raw_f32(buf, out, !self.optimizer_device);
+        if let Some(&(_, buffer)) = self.adam_state.get(idx) {
+            self.read_raw_f32(&buffer, out, !self.optimizer_device);
+        } else {
+            out.fill(0.0);
+        }
     }
 
     /// Read both Adam moment buffers for several parameters with one GPU
     /// transfer through cached download memory. Results have the same order
     /// as `names`.
     pub fn read_adam_states(&self, names: &[&str]) -> Vec<(Vec<f32>, Vec<f32>)> {
+        if self.adam_state.is_empty() {
+            return names
+                .iter()
+                .map(|name| {
+                    assert!(
+                        self.adam_state_index(name).is_some(),
+                        "no Adam state for param: {name}"
+                    );
+                    let n = self.param_size(name).expect("parameter exists");
+                    (vec![0.0; n], vec![0.0; n])
+                })
+                .collect();
+        }
         let buffers: Vec<_> = names
             .iter()
             .flat_map(|name| {
@@ -4774,7 +4902,6 @@ impl Session {
         let idx = self
             .adam_state_index(name)
             .unwrap_or_else(|| panic!("no Adam state for param: {name}"));
-        let buf = &self.adam_state[idx].0;
         let n = self.param_size(name).expect("param exists; size known");
         assert_eq!(
             data.len(),
@@ -4782,7 +4909,12 @@ impl Session {
             "write_adam_m: data.len()={} but param '{name}' has {n} elements",
             data.len()
         );
-        self.write_raw_buffer(buf, bytemuck::cast_slice(data), !self.optimizer_device);
+        self.ensure_adam_state();
+        self.write_raw_buffer(
+            &self.adam_state[idx].0,
+            bytemuck::cast_slice(data),
+            !self.optimizer_device,
+        );
     }
 
     /// Write the Adam second-moment buffer for a parameter. See
@@ -4792,7 +4924,6 @@ impl Session {
         let idx = self
             .adam_state_index(name)
             .unwrap_or_else(|| panic!("no Adam state for param: {name}"));
-        let buf = &self.adam_state[idx].1;
         let n = self.param_size(name).expect("param exists; size known");
         assert_eq!(
             data.len(),
@@ -4800,7 +4931,12 @@ impl Session {
             "write_adam_v: data.len()={} but param '{name}' has {n} elements",
             data.len()
         );
-        self.write_raw_buffer(buf, bytemuck::cast_slice(data), !self.optimizer_device);
+        self.ensure_adam_state();
+        self.write_raw_buffer(
+            &self.adam_state[idx].1,
+            bytemuck::cast_slice(data),
+            !self.optimizer_device,
+        );
     }
 
     /// Current Adam step counter (`t`). Adam's bias correction uses
@@ -4824,6 +4960,56 @@ impl Session {
             .param_grad_pairs
             .iter()
             .position(|&(p, _)| p == param_buf)
+    }
+
+    fn ensure_adam_state(&mut self) {
+        if !self.adam_state.is_empty() || self.plan.param_grad_pairs.is_empty() {
+            return;
+        }
+        for &(param, _) in &self.plan.param_grad_pairs {
+            Self::optimizer_len(&self.plan, param);
+        }
+        let bytes = self
+            .plan
+            .param_grad_pairs
+            .iter()
+            .try_fold(0usize, |sum, &(p, _)| {
+                sum.checked_add(self.plan.buffers[p.0 as usize].max(4).checked_mul(2)?)
+            })
+            .expect("Adam state size overflow");
+        ensure_device_memory_budget(&self.gpu, bytes, "Adam state");
+        self.wait();
+        let mut device_buffers = Vec::new();
+        self.adam_state = self
+            .plan
+            .param_grad_pairs
+            .iter()
+            .enumerate()
+            .map(|(index, &(param, _))| {
+                let size = self.plan.buffers[param.0 as usize].max(4) as u64;
+                let mut create = |suffix| {
+                    create_optimizer_buffer(
+                        &self.gpu,
+                        &format!("adam_{suffix}_{index}"),
+                        size,
+                        self.optimizer_device,
+                        &mut device_buffers,
+                    )
+                };
+                (create("m"), create("v"))
+            })
+            .collect();
+        if !device_buffers.is_empty() {
+            self.encoder.start();
+            {
+                let mut transfer = self.encoder.transfer("zero_adam");
+                for (buffer, size) in device_buffers {
+                    transfer.fill_buffer(buffer.at(0), size, 0);
+                }
+            }
+            self.sync_point = Some(self.gpu.submit(&mut self.encoder));
+            self.wait();
+        }
     }
 
     /// Bulk read of per-parameter gradient L2 norms (Frobenius for
@@ -4851,7 +5037,7 @@ impl Session {
         out
     }
 
-    /// Bulk read of per-parameter weight L2 norms. Same shape as
+    /// Bulk read of F32 per-parameter weight L2 norms. Same shape as
     /// `read_all_param_grad_norms`. Useful for computing
     /// gradient-to-weight ratios as a stability indicator.
     pub fn read_all_param_norms(&self) -> Vec<(String, f32)> {
@@ -5024,8 +5210,8 @@ impl Session {
             {
                 let pipeline = self.pipelines.scalar(ShaderEntry::GradAccum);
                 let mut pass = self.encoder.compute("grad_accum");
-                for (idx, &(_, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
-                    let len = (self.plan.buffers[grad_buf.0 as usize] / 4) as u32;
+                for (idx, &(param_buf, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
+                    let len = Self::optimizer_len(&self.plan, param_buf);
                     let mut pc = pass.with(pipeline);
                     pc.bind(
                         0,
@@ -5071,7 +5257,7 @@ impl Session {
                 let pipeline = self.pipelines.scalar(ShaderEntry::AdaptiveGradClip);
                 let mut pass = self.encoder.compute("adaptive_grad_clip");
                 for (idx, &(param_buf, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
-                    let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
+                    let len = Self::optimizer_len(&self.plan, param_buf);
                     let mut pc = pass.with(pipeline);
                     pc.bind(
                         0,
@@ -5124,7 +5310,7 @@ impl Session {
                     for (idx, &(param_buf, grad_buf)) in
                         self.plan.param_grad_pairs.iter().enumerate()
                     {
-                        let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
+                        let len = Self::optimizer_len(&self.plan, param_buf);
                         {
                             let mut pc = pass.with(pipeline);
                             pc.bind(
@@ -5162,7 +5348,7 @@ impl Session {
                     for (idx, &(param_buf, grad_buf)) in
                         self.plan.param_grad_pairs.iter().enumerate()
                     {
-                        let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
+                        let len = Self::optimizer_len(&self.plan, param_buf);
                         let mut pc = pass.with(pipeline);
                         pc.bind(
                             0,
@@ -5202,7 +5388,7 @@ impl Session {
                 let pipeline = self.pipelines.scalar(ShaderEntry::SgdUpdate);
                 let mut pass = self.encoder.compute("sgd_update");
                 for (idx, &(param_buf, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
-                    let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
+                    let len = Self::optimizer_len(&self.plan, param_buf);
                     let effective_lr = learning_rate
                         * Self::lr_multiplier_for_buf(
                             &self.plan.param_buffers,
@@ -5238,7 +5424,7 @@ impl Session {
                 let pipeline = self.pipelines.scalar(ShaderEntry::AdamUpdate);
                 let mut pass = self.encoder.compute("adam_update");
                 for (idx, &(param_buf, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
-                    let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
+                    let len = Self::optimizer_len(&self.plan, param_buf);
                     let effective_lr = lr
                         * Self::lr_multiplier_for_buf(
                             &self.plan.param_buffers,
@@ -5291,6 +5477,21 @@ impl Session {
 
         self.last_submit_ns = crate::profiler::now_ns();
         self.sync_point = Some(self.gpu.submit(&mut self.encoder));
+    }
+
+    fn optimizer_len(plan: &ExecutionPlan, param: BufferRef) -> u32 {
+        let len = match plan.param_types.get(&param) {
+            Some(ty) => {
+                assert_eq!(
+                    ty.dtype,
+                    crate::graph::DType::F32,
+                    "optimizer/clip/accumulation requires F32 trainable parameter storage"
+                );
+                ty.num_elements()
+            }
+            None => plan.buffers[param.0 as usize] / 4,
+        };
+        u32::try_from(len).expect("optimizer parameter exceeds u32 element limit")
     }
 
     /// The buffer the optimizer/clip should read for param `idx`'s
@@ -6294,95 +6495,40 @@ impl Session {
             ShaderEntry::Conv2dGemm
             | ShaderEntry::Conv2dGemmSmall
             | ShaderEntry::Conv2dGemmCoopGen(..) => {
-                let p = &dispatch.params;
-                let kernel_hw = p[5] * p[6];
                 pc.bind(
                     0,
                     &Conv2dData {
                         src: buf(dispatch.input_buffers[0]),
                         weight: buf(dispatch.input_buffers[1]),
                         dst: buf(dispatch.output_buffer),
-                        params: Conv2dParams {
-                            batch: p[0],
-                            in_channels: p[1],
-                            in_h: p[2],
-                            in_w: p[3],
-                            out_channels: p[4],
-                            kernel_h: p[5],
-                            kernel_w: p[6],
-                            stride: p[7],
-                            padding_h: p[8],
-                            out_h: p[9],
-                            out_w: p[10],
-                            padding_w: p[11],
-                            inv_kernel_w: 1.0 / p[6] as f32,
-                            inv_kernel_hw: 1.0 / kernel_hw as f32,
-                            inv_col_w: 1.0 / p[10] as f32, // 1/out_w
-                            inv_go_spatial: 0.0,
-                        },
+                        params: Conv2dParams::from(dispatch),
                     },
                 );
             }
             ShaderEntry::Conv2dGradInputGemm
             | ShaderEntry::Conv2dGradInputGemmSmall
             | ShaderEntry::Conv2dGradInputGemmCoopGen(..) => {
-                let p = &dispatch.params;
-                let kernel_hw = p[5] * p[6];
                 pc.bind(
                     0,
                     &Conv2dGradInputData {
                         grad_out: buf(dispatch.input_buffers[0]),
                         weight: buf(dispatch.input_buffers[1]),
                         dst: buf(dispatch.output_buffer),
-                        params: Conv2dParams {
-                            batch: p[0],
-                            in_channels: p[1],
-                            in_h: p[2],
-                            in_w: p[3],
-                            out_channels: p[4],
-                            kernel_h: p[5],
-                            kernel_w: p[6],
-                            stride: p[7],
-                            padding_h: p[8],
-                            out_h: p[9],
-                            out_w: p[10],
-                            padding_w: p[11],
-                            inv_kernel_w: 1.0 / p[6] as f32,
-                            inv_kernel_hw: 1.0 / kernel_hw as f32,
-                            inv_col_w: 1.0 / p[3] as f32, // 1/in_w
-                            inv_go_spatial: 0.0,
-                        },
+                        params: Conv2dParams::from(dispatch),
                     },
                 );
             }
-            ShaderEntry::Conv2dGradWeightGemm | ShaderEntry::Conv2dGradWeightGemmSmall => {
-                let p = &dispatch.params;
-                let kernel_hw = p[5] * p[6];
-                let go_spatial = p[9] * p[10]; // out_h * out_w
+            ShaderEntry::Conv2dGradWeightGemm
+            | ShaderEntry::Conv2dGradWeightGemmSmall
+            | ShaderEntry::Conv2dGradWeightGemmSplit
+            | ShaderEntry::Conv2dGradWeightGemmSplitSmall => {
                 pc.bind(
                     0,
                     &Conv2dGradWeightData {
                         grad_out: buf(dispatch.input_buffers[0]),
                         src: buf(dispatch.input_buffers[1]),
                         dst: buf(dispatch.output_buffer),
-                        params: Conv2dParams {
-                            batch: p[0],
-                            in_channels: p[1],
-                            in_h: p[2],
-                            in_w: p[3],
-                            out_channels: p[4],
-                            kernel_h: p[5],
-                            kernel_w: p[6],
-                            stride: p[7],
-                            padding_h: p[8],
-                            out_h: p[9],
-                            out_w: p[10],
-                            padding_w: p[11],
-                            inv_kernel_w: 1.0 / p[6] as f32,
-                            inv_kernel_hw: 1.0 / kernel_hw as f32,
-                            inv_col_w: 1.0 / p[10] as f32, // 1/out_w
-                            inv_go_spatial: 1.0 / go_spatial as f32,
-                        },
+                        params: Conv2dParams::from(dispatch),
                     },
                 );
             }
@@ -6556,7 +6702,7 @@ impl Session {
         let pipeline = self.pipelines.scalar(ShaderEntry::SgdUpdate);
         let mut pass = self.encoder.compute("sgd_update");
         for &(param_buf, grad_buf) in &self.plan.param_grad_pairs {
-            let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
+            let len = Self::optimizer_len(&self.plan, param_buf);
             let mut pc = pass.with(pipeline);
             pc.bind(
                 0,
@@ -6658,19 +6804,18 @@ impl Session {
     /// `max_norm`, scales every buffer in place by `max_norm / norm`.
     /// Returns `(pre_clip_norm, did_clip)`.
     ///
-    /// Used internally by `step()` when `pending_grad_clip` is set.
-    /// Public for diagnostic / unit-test use.
+    /// Diagnostic/fallback helper; `step()` uses GPU clipping instead.
     pub fn clip_grad_norm_cpu(&mut self, max_norm: f32) -> (f32, bool) {
         if max_norm <= 0.0 {
             return (0.0, false);
         }
+        self.wait();
         // Sum of squares across all gradient buffers.
         let mut total_sq: f64 = 0.0;
         let mut buffers: Vec<(BufferRef, Vec<f32>)> =
             Vec::with_capacity(self.plan.param_grad_pairs.len());
-        for &(_param_buf, grad_buf) in &self.plan.param_grad_pairs {
-            let bytes = self.plan.buffers[grad_buf.0 as usize];
-            let n = bytes / 4;
+        for &(param_buf, grad_buf) in &self.plan.param_grad_pairs {
+            let n = Self::optimizer_len(&self.plan, param_buf) as usize;
             let mut data = vec![0.0f32; n];
             self.read_buffer(grad_buf, &mut data);
             for &v in &data {
@@ -6689,7 +6834,11 @@ impl Session {
             for v in &mut data {
                 *v *= scale;
             }
-            self.upload_buffer(grad_buf, bytemuck::cast_slice(&data));
+            self.write_raw_buffer(
+                &self.buffers[grad_buf.0 as usize],
+                bytemuck::cast_slice(&data),
+                self.logical_host_visible(grad_buf),
+            );
         }
         (total_norm, true)
     }
@@ -6756,7 +6905,7 @@ impl Session {
         let _span = tracing::info_span!("sgd_step_cpu").entered();
         self.wait();
         for &(param_buf, grad_buf) in &self.plan.param_grad_pairs {
-            let size = self.plan.buffers[param_buf.0 as usize] / 4;
+            let size = Self::optimizer_len(&self.plan, param_buf) as usize;
             let mut param = vec![0.0f32; size];
             let mut grad = vec![0.0f32; size];
             self.read_buffer(param_buf, &mut param);
@@ -6764,13 +6913,18 @@ impl Session {
             for i in 0..size {
                 param[i] -= learning_rate * grad[i];
             }
-            self.upload_buffer(param_buf, bytemuck::cast_slice(&param));
+            self.write_raw_buffer(
+                &self.buffers[param_buf.0 as usize],
+                bytemuck::cast_slice(&param),
+                self.logical_host_visible(param_buf),
+            );
         }
     }
 
     /// Apply Adam optimizer updates to all parameters on the GPU.
     pub fn adam_step(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32) {
         let _span = tracing::info_span!("adam_step").entered();
+        self.ensure_adam_state();
         self.adam_step += 1;
         self.wait();
         self.encoder.start();
@@ -6779,7 +6933,7 @@ impl Session {
         let pipeline = self.pipelines.scalar(ShaderEntry::AdamUpdate);
         let mut pass = self.encoder.compute("adam_update");
         for (idx, &(param_buf, grad_buf)) in self.plan.param_grad_pairs.iter().enumerate() {
-            let len = (self.plan.buffers[param_buf.0 as usize] / 4) as u32;
+            let len = Self::optimizer_len(&self.plan, param_buf);
             let (ref m_buf, ref v_buf) = self.adam_state[idx];
             let (grouped_grad_norm, grad_group_size) = Self::adam_grouped_grad_norm_binding(
                 self.adam_grouped_grad_norm.as_ref(),
@@ -6829,6 +6983,7 @@ impl Session {
     /// [`set_learning_rate`](Self::set_learning_rate), or stop optimizer
     /// updates via [`clear_optimizer`](Self::clear_optimizer).
     pub fn set_adam(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32) {
+        self.ensure_adam_state();
         self.pending_adam = Some((lr, beta1, beta2, eps, AdaptiveOptimizer::Adam));
         // Switching optimizers: Adam wins, SGD stops applying.
         self.pending_lr = None;
@@ -6841,6 +6996,7 @@ impl Session {
     /// the optimizer ordering used by DreamerV3. Its two state tensors are
     /// checkpoint-compatible with Adam's `m` and `v` buffers.
     pub fn set_laprop(&mut self, lr: f32, beta1: f32, beta2: f32, eps: f32) {
+        self.ensure_adam_state();
         self.pending_adam = Some((lr, beta1, beta2, eps, AdaptiveOptimizer::LaProp));
         self.pending_lr = None;
     }
@@ -6924,6 +7080,7 @@ impl Session {
     /// Forward+backward still runs (gradients are computed) but no SGD
     /// or Adam pass is appended. Useful when freezing parameters for
     /// evaluation or pinning the model after a warmup phase.
+    /// Retains allocated moments and counters so reconfiguration can resume.
     pub fn clear_optimizer(&mut self) {
         self.pending_lr = None;
         self.pending_adam = None;
@@ -7045,20 +7202,40 @@ impl Session {
             .plan
             .param_grad_pairs
             .iter()
-            .map(|&(p, _)| self.plan.buffers[p.0 as usize] * 2)
+            .take(self.adam_state.len())
+            .map(|&(p, _)| self.plan.buffers[p.0 as usize].max(4) * 2)
             .sum();
+        let grad_accumulator_bytes = self
+            .plan
+            .param_grad_pairs
+            .iter()
+            .take(self.grad_accum_bufs.len())
+            .map(|&(_, g)| self.plan.buffers[g.0 as usize].max(4))
+            .sum();
+        let clip_bytes = usize::from(self.grad_clip_acc.is_some()) * 4;
+        let optimizer_aux_bytes = clip_bytes
+            + self
+                .adam_grouped_grad_norm
+                .as_ref()
+                .map_or(0, |state| (state.len * 4).max(4));
         MemorySummary {
             total_buffer_bytes: total,
             adam_state_bytes: adam_bytes,
+            grad_accumulator_bytes,
+            optimizer_aux_bytes,
             num_buffers: self.plan.buffers.len(),
             largest_buffer_bytes: largest,
-            allocated_buffer_bytes: self.alias.physical_bytes(),
+            allocated_buffer_bytes: self.alias.sizes.iter().map(|&size| size.max(4)).sum(),
             num_allocations: self.alias.sizes.len(),
-            device_local_bytes: self.alias.device_local_bytes()
+            device_local_bytes: self
+                .alias
+                .sizes
+                .iter()
+                .zip(&self.alias.device_local)
+                .filter_map(|(&size, &device)| device.then_some(size.max(4)))
+                .sum::<usize>()
                 + if self.optimizer_device {
-                    adam_bytes
-                        + self.grad_accum_bufs.len() * adam_bytes / 2
-                        + usize::from(self.grad_clip_acc.is_some()) * 4
+                    adam_bytes + grad_accumulator_bytes + clip_bytes
                 } else {
                     0
                 },
@@ -7096,304 +7273,6 @@ impl Session {
     /// GPU device and driver name.
     pub fn device_information(&self) -> &blade_graphics::DeviceInformation {
         self.gpu.device_information()
-    }
-
-    /// Save a training checkpoint (parameters + Adam state) to a safetensors file.
-    ///
-    /// Saves all parameter values, Adam first/second moment buffers (if any),
-    /// and the Adam step counter as metadata.
-    #[allow(clippy::pattern_type_mismatch)]
-    pub fn save_checkpoint(&mut self, path: &std::path::Path) -> std::io::Result<()> {
-        use safetensors::tensor::{Dtype, TensorView};
-
-        struct CheckpointTensor {
-            name: String,
-            buffer: blade_graphics::Buffer,
-            offset: usize,
-            byte_len: usize,
-            dtype: Dtype,
-            shape: Vec<usize>,
-        }
-
-        let wall_start = std::time::Instant::now();
-        let wait_start = std::time::Instant::now();
-        self.wait();
-        let wait_duration = wait_start.elapsed();
-        let collection_start = std::time::Instant::now();
-        let mut tensors = Vec::new();
-        let mut total_bytes = 0_usize;
-
-        // Collect parameter data
-        for (name, buf_ref) in &self.plan.param_buffers {
-            let byte_len = self.plan.buffers[buf_ref.0 as usize];
-            let (dtype, shape) = match self.plan.weight_buffers.get(buf_ref).map(|entry| entry.0) {
-                Some(crate::compile::WeightFormat::F16) => (Dtype::F16, vec![byte_len / 2]),
-                Some(crate::compile::WeightFormat::Q4 | crate::compile::WeightFormat::Q8) => {
-                    // Safetensors has no standard Q4/Q8 block dtype. Preserve
-                    // the exact packed representation as bytes rather than
-                    // falsely labelling it F32.
-                    (Dtype::U8, vec![byte_len])
-                }
-                Some(crate::compile::WeightFormat::F32) | None => (Dtype::F32, vec![byte_len / 4]),
-            };
-            let offset = total_bytes.next_multiple_of(4);
-            tensors.push(CheckpointTensor {
-                name: name.clone(),
-                buffer: self.buffers[buf_ref.0 as usize],
-                offset,
-                byte_len,
-                dtype,
-                shape,
-            });
-            total_bytes = offset + byte_len;
-        }
-
-        // Collect Adam moment buffers (parallel to param_grad_pairs)
-        for (idx, &(param_buf, _)) in self.plan.param_grad_pairs.iter().enumerate() {
-            if idx >= self.adam_state.len() {
-                break;
-            }
-            let name = self
-                .plan
-                .param_buffers
-                .iter()
-                .find(|(_, br)| *br == param_buf)
-                .map(|(n, _)| n.clone())
-                .unwrap_or_else(|| format!("param_{}", param_buf.0));
-            let byte_len = self.plan.buffers[param_buf.0 as usize];
-            for (suffix, buf) in [
-                ("adam_m", &self.adam_state[idx].0),
-                ("adam_v", &self.adam_state[idx].1),
-            ] {
-                let offset = total_bytes.next_multiple_of(4);
-                tensors.push(CheckpointTensor {
-                    name: format!("{suffix}.{name}"),
-                    buffer: *buf,
-                    offset,
-                    byte_len,
-                    dtype: Dtype::F32,
-                    shape: vec![byte_len / 4],
-                });
-                total_bytes = offset + byte_len;
-            }
-        }
-        let collection_duration = collection_start.elapsed();
-
-        // Host-visible parameter allocations are optimized for GPU access and
-        // CPU writes; reading them directly is extremely slow on a discrete
-        // GPU. Snapshot every tensor through one GPU transfer instead.
-        let readback_start = std::time::Instant::now();
-        let staging = self.gpu.create_buffer(blade_graphics::BufferDesc {
-            name: "checkpoint_readback",
-            size: (total_bytes as u64).max(4),
-            memory: blade_graphics::Memory::Download,
-        });
-        let mut encoder = self
-            .gpu
-            .create_command_encoder(blade_graphics::CommandEncoderDesc {
-                name: "checkpoint_readback",
-                buffer_count: 1,
-                manual_barriers: false,
-            });
-        encoder.start();
-        {
-            let mut transfer = encoder.transfer("checkpoint_readback");
-            for tensor in &tensors {
-                let aligned_len = tensor.byte_len / 4 * 4;
-                if aligned_len != 0 {
-                    transfer.copy_buffer_to_buffer(
-                        tensor.buffer.at(0),
-                        staging.at(tensor.offset as u64),
-                        aligned_len as u64,
-                    );
-                }
-            }
-        }
-        let sync = self.gpu.submit(&mut encoder);
-        let _ = self.gpu.wait_for(&sync, !0);
-        for tensor in &tensors {
-            let aligned_len = tensor.byte_len / 4 * 4;
-            let tail_len = tensor.byte_len - aligned_len;
-            if tail_len != 0 {
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        tensor.buffer.data().add(aligned_len),
-                        staging.data().add(tensor.offset + aligned_len),
-                        tail_len,
-                    );
-                }
-            }
-        }
-        let readback_duration = readback_start.elapsed();
-
-        // Build tensor views
-        let view_start = std::time::Instant::now();
-        let staging_data = unsafe { std::slice::from_raw_parts(staging.data(), total_bytes) };
-        let views: Vec<(String, TensorView<'_>)> = tensors
-            .iter()
-            .map(|tensor| {
-                let data = &staging_data[tensor.offset..tensor.offset + tensor.byte_len];
-                (
-                    tensor.name.clone(),
-                    TensorView::new(tensor.dtype, tensor.shape.clone(), data).expect("tensor view"),
-                )
-            })
-            .collect();
-        let view_duration = view_start.elapsed();
-
-        // Metadata
-        let mut metadata = HashMap::new();
-        metadata.insert("meganeura_checkpoint_format".to_string(), "2".to_string());
-        metadata.insert("adam_step".to_string(), self.adam_step.to_string());
-
-        let persist_start = std::time::Instant::now();
-        let result = safetensors::tensor::serialize_to_file(views, &Some(metadata), path)
-            .map_err(|e| std::io::Error::other(e.to_string()));
-        let persist_duration = persist_start.elapsed();
-        let bytes = if result.is_ok() {
-            std::fs::metadata(path).map_or(0, |file| file.len())
-        } else {
-            0
-        };
-        self.gpu.destroy_command_encoder(&mut encoder);
-        self.gpu.destroy_buffer(staging);
-        log::info!(
-            "checkpoint timing: wall={:.3}s wait={:.3}s collect={:.3}s \
-             readback={:.3}s views={:.3}s persist={:.3}s bytes={bytes}",
-            wall_start.elapsed().as_secs_f64(),
-            wait_duration.as_secs_f64(),
-            collection_duration.as_secs_f64(),
-            readback_duration.as_secs_f64(),
-            view_duration.as_secs_f64(),
-            persist_duration.as_secs_f64(),
-        );
-        result
-    }
-
-    /// Load a training checkpoint from a safetensors file.
-    ///
-    /// Restores parameter values and Adam optimizer state. The session must
-    /// have been created from the same graph (same parameter names/sizes).
-    #[allow(clippy::pattern_type_mismatch)]
-    pub fn load_checkpoint(&mut self, path: &std::path::Path) -> std::io::Result<()> {
-        use safetensors::tensor::Dtype;
-
-        self.wait();
-        let file_data = std::fs::read(path)?;
-        let (header_size, metadata) = safetensors::SafeTensors::read_metadata(&file_data)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-        let st = safetensors::SafeTensors::deserialize(&file_data)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-        let _ = header_size;
-        let checkpoint_format = metadata
-            .metadata()
-            .as_ref()
-            .and_then(|meta| meta.get("meganeura_checkpoint_format"))
-            .map(|value| {
-                value.parse::<u32>().map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("invalid meganeura_checkpoint_format {value:?}"),
-                    )
-                })
-            })
-            .transpose()?
-            .unwrap_or(1);
-
-        // Restore parameters
-        for (name, buf_ref) in &self.plan.param_buffers {
-            if let Ok(tensor) = st.tensor(name) {
-                let expected_len = self.plan.buffers[buf_ref.0 as usize];
-                if tensor.data().len() != expected_len {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!(
-                            "checkpoint tensor {name:?} has {} bytes, expected {expected_len}",
-                            tensor.data().len(),
-                        ),
-                    ));
-                }
-                if checkpoint_format >= 2 {
-                    let expected_dtype =
-                        match self.plan.weight_buffers.get(buf_ref).map(|entry| entry.0) {
-                            Some(crate::compile::WeightFormat::F16) => Dtype::F16,
-                            Some(
-                                crate::compile::WeightFormat::Q4 | crate::compile::WeightFormat::Q8,
-                            ) => Dtype::U8,
-                            Some(crate::compile::WeightFormat::F32) | None => Dtype::F32,
-                        };
-                    if tensor.dtype() != expected_dtype {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            format!(
-                                "checkpoint tensor {name:?} has dtype {:?}, expected {:?}",
-                                tensor.dtype(),
-                                expected_dtype,
-                            ),
-                        ));
-                    }
-                }
-                self.upload_buffer(*buf_ref, tensor.data());
-            } else {
-                log::warn!("checkpoint missing parameter: {name}");
-            }
-        }
-
-        // Restore Adam moment buffers
-        for (idx, &(param_buf, _)) in self.plan.param_grad_pairs.iter().enumerate() {
-            if idx >= self.adam_state.len() {
-                break;
-            }
-            let name = self
-                .plan
-                .param_buffers
-                .iter()
-                .find(|(_, br)| *br == param_buf)
-                .map(|(n, _)| n.as_str())
-                .unwrap_or("");
-            for (suffix, buf) in [
-                ("adam_m", &self.adam_state[idx].0),
-                ("adam_v", &self.adam_state[idx].1),
-            ] {
-                let key = format!("{suffix}.{name}");
-                if let Ok(tensor) = st.tensor(&key) {
-                    let expected_len = self.plan.buffers[param_buf.0 as usize];
-                    if tensor.data().len() != expected_len {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            format!(
-                                "checkpoint tensor {key:?} has {} bytes, expected {expected_len}",
-                                tensor.data().len(),
-                            ),
-                        ));
-                    }
-                    if checkpoint_format >= 2 && tensor.dtype() != Dtype::F32 {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            format!(
-                                "checkpoint tensor {key:?} has dtype {:?}, expected F32",
-                                tensor.dtype(),
-                            ),
-                        ));
-                    }
-                    self.write_raw_buffer(buf, tensor.data(), !self.optimizer_device);
-                }
-            }
-        }
-
-        // Restore adam_step from metadata
-        if let Some(ref meta) = *metadata.metadata() {
-            if let Some(step_str) = meta.get("adam_step") {
-                self.adam_step = step_str.parse::<u32>().map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("invalid adam_step {step_str:?}"),
-                    )
-                })?;
-            }
-        }
-
-        Ok(())
     }
 }
 

--- a/src/runtime/checkpoint.rs
+++ b/src/runtime/checkpoint.rs
@@ -1,0 +1,805 @@
+use super::Session;
+use crate::{
+    compile::{BufferRef, ExecutionPlan},
+    graph::{DType, TensorType},
+};
+use safetensors::{
+    SafeTensors,
+    tensor::{Dtype, TensorView},
+};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    io,
+};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LogicalLayout {
+    parameters: BTreeMap<String, TensorType>,
+    adam_parameters: Vec<String>,
+}
+
+struct Parameter {
+    name: String,
+    buffer: BufferRef,
+    ty: TensorType,
+    byte_len: usize,
+}
+
+fn invalid(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn logical_bytes(ty: &TensorType) -> io::Result<usize> {
+    let elements = ty
+        .shape
+        .iter()
+        .try_fold(1usize, |n, &dim| n.checked_mul(dim));
+    elements
+        .and_then(|n| match ty.dtype {
+            DType::F32 | DType::U32 => n.checked_mul(4),
+            DType::F16 => n.checked_mul(2),
+            DType::Q4_0 => n.div_ceil(32).checked_mul(20),
+            DType::Q8_0 => n.div_ceil(32).checked_mul(36),
+        })
+        .ok_or_else(|| invalid("checkpoint logical shape overflows byte size"))
+}
+
+fn parameters(plan: &ExecutionPlan) -> io::Result<Vec<Parameter>> {
+    let mut seen = HashSet::new();
+    plan.param_buffers
+        .iter()
+        .map(|&(ref name, buffer)| {
+            if !seen.insert(name) {
+                return Err(invalid(format!("duplicate parameter name {name:?}")));
+            }
+            let ty = plan.param_types.get(&buffer).ok_or_else(|| {
+                invalid(format!(
+                    "logical type missing for {name:?}; recompile the execution plan"
+                ))
+            })?;
+            let byte_len = logical_bytes(ty)?;
+            if byte_len > plan.buffers[buffer.0 as usize] {
+                return Err(invalid(format!(
+                    "logical parameter {name:?} exceeds its allocation"
+                )));
+            }
+            Ok(Parameter {
+                name: name.clone(),
+                buffer,
+                ty: ty.clone(),
+                byte_len,
+            })
+        })
+        .collect()
+}
+
+fn tensor_layout(ty: &TensorType) -> io::Result<(Dtype, Vec<usize>)> {
+    Ok(match ty.dtype {
+        DType::F32 => (Dtype::F32, ty.shape.clone()),
+        DType::F16 => (Dtype::F16, ty.shape.clone()),
+        DType::U32 => (Dtype::U32, ty.shape.clone()),
+        DType::Q4_0 | DType::Q8_0 => (Dtype::U8, vec![logical_bytes(ty)?]),
+    })
+}
+
+#[derive(Clone, Copy)]
+enum Target {
+    Parameter(BufferRef),
+    Moment { index: usize, second: bool },
+}
+
+struct Write<'a> {
+    target: Target,
+    data: &'a [u8],
+}
+
+struct Restore<'a> {
+    writes: Vec<Write<'a>>,
+    adam_step: Option<u32>,
+    reset_moments: bool,
+}
+
+fn validate_tensor(
+    tensor: &TensorView<'_>,
+    name: &str,
+    bytes: usize,
+    layout: Option<(Dtype, Vec<usize>)>,
+) -> io::Result<()> {
+    if tensor.data().len() != bytes {
+        return Err(invalid(format!(
+            "checkpoint tensor {name:?} has {} bytes, expected {bytes}",
+            tensor.data().len()
+        )));
+    }
+    if let Some((dtype, shape)) = layout {
+        if tensor.dtype() != dtype || tensor.shape() != shape {
+            return Err(invalid(format!(
+                "checkpoint tensor {name:?} has {:?}{:?}, expected {dtype:?}{shape:?}",
+                tensor.dtype(),
+                tensor.shape()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Pure preflight: no session, GPU allocation or mutation is reachable here.
+fn validate<'a>(plan: &ExecutionPlan, data: &'a [u8]) -> io::Result<Restore<'a>> {
+    let (_, header) = SafeTensors::read_metadata(data).map_err(|e| invalid(e.to_string()))?;
+    let tensors = SafeTensors::deserialize(data).map_err(|e| invalid(e.to_string()))?;
+    let metadata = header.metadata().as_ref();
+    let get = |key: &str| metadata.and_then(|m| m.get(key));
+    let version = get("meganeura_checkpoint_format")
+        .map(|v| {
+            v.parse::<u32>()
+                .map_err(|_| invalid(format!("invalid meganeura_checkpoint_format {v:?}")))
+        })
+        .transpose()?
+        .unwrap_or(1);
+    if !(1..=3).contains(&version) {
+        return Err(invalid(format!("unsupported checkpoint format {version}")));
+    }
+    let adam_step = get("adam_step")
+        .map(|v| {
+            v.parse::<u32>()
+                .map_err(|_| invalid(format!("invalid adam_step {v:?}")))
+        })
+        .transpose()?;
+    let params = parameters(plan)?;
+    let mut writes = Vec::new();
+    if version == 3 {
+        let layout: LogicalLayout = serde_json::from_str(
+            get("meganeura_logical_layout")
+                .ok_or_else(|| invalid("checkpoint missing meganeura_logical_layout"))?,
+        )
+        .map_err(|e| invalid(e.to_string()))?;
+        if adam_step.is_none() {
+            return Err(invalid("checkpoint missing adam_step"));
+        }
+        let expected_types: BTreeMap<_, _> = params
+            .iter()
+            .map(|p| (p.name.clone(), p.ty.clone()))
+            .collect();
+        if layout.parameters != expected_types {
+            return Err(invalid(
+                "checkpoint parameter names, logical shapes or storage types do not match the plan",
+            ));
+        }
+        let mut expected_names = HashSet::new();
+        for param in &params {
+            expected_names.insert(param.name.clone());
+            let tensor = tensors
+                .tensor(&param.name)
+                .map_err(|_| invalid(format!("checkpoint missing parameter {:?}", param.name)))?;
+            validate_tensor(
+                &tensor,
+                &param.name,
+                param.byte_len,
+                Some(tensor_layout(&param.ty)?),
+            )?;
+            writes.push(Write {
+                target: Target::Parameter(param.buffer),
+                data: tensor.data(),
+            });
+        }
+        for name in layout.adam_parameters {
+            let param = params
+                .iter()
+                .find(|p| p.name == name)
+                .ok_or_else(|| invalid(format!("unknown Adam parameter {name:?}")))?;
+            if param.ty.dtype != DType::F32 {
+                return Err(invalid(format!("Adam parameter {name:?} is not F32")));
+            }
+            for (suffix, second) in [("adam_m", false), ("adam_v", true)] {
+                let key = format!("{suffix}.{name}");
+                if !expected_names.insert(key.clone()) {
+                    return Err(invalid(format!("duplicate checkpoint tensor {key:?}")));
+                }
+                let tensor = tensors
+                    .tensor(&key)
+                    .map_err(|_| invalid(format!("checkpoint missing tensor {key:?}")))?;
+                validate_tensor(
+                    &tensor,
+                    &key,
+                    param.byte_len,
+                    Some((Dtype::F32, param.ty.shape.clone())),
+                )?;
+                if let Some(index) = plan
+                    .param_grad_pairs
+                    .iter()
+                    .position(|&(p, _)| p == param.buffer)
+                {
+                    writes.push(Write {
+                        target: Target::Moment { index, second },
+                        data: tensor.data(),
+                    });
+                }
+            }
+        }
+        if expected_names.len() != tensors.len()
+            || tensors
+                .names()
+                .iter()
+                .any(|n| !expected_names.contains(n.as_str()))
+        {
+            return Err(invalid("checkpoint contains unexpected tensors"));
+        }
+    } else {
+        // Legacy files used flattened physical allocations. Preserve their
+        // partial-load behavior, but validate every applicable write first.
+        for param in &params {
+            if let Ok(tensor) = tensors.tensor(&param.name) {
+                let bytes = plan.buffers[param.buffer.0 as usize];
+                let (dtype, _) = tensor_layout(&param.ty)?;
+                let shape = vec![bytes / dtype.size()];
+                validate_tensor(
+                    &tensor,
+                    &param.name,
+                    bytes,
+                    (version == 2).then_some((dtype, shape)),
+                )?;
+                writes.push(Write {
+                    target: Target::Parameter(param.buffer),
+                    data: tensor.data(),
+                });
+            } else {
+                log::warn!("legacy checkpoint missing parameter: {}", param.name);
+            }
+        }
+        for (index, &(param_buffer, _)) in plan.param_grad_pairs.iter().enumerate() {
+            let param = params
+                .iter()
+                .find(|p| p.buffer == param_buffer)
+                .ok_or_else(|| invalid("unnamed optimizer parameter"))?;
+            for (suffix, second) in [("adam_m", false), ("adam_v", true)] {
+                let name = format!("{suffix}.{}", param.name);
+                if let Ok(tensor) = tensors.tensor(&name) {
+                    if param.ty.dtype != DType::F32 {
+                        return Err(invalid(format!(
+                            "Adam parameter {:?} is not F32",
+                            param.name
+                        )));
+                    }
+                    let bytes = plan.buffers[param_buffer.0 as usize];
+                    validate_tensor(
+                        &tensor,
+                        &name,
+                        bytes,
+                        (version == 2).then_some((Dtype::F32, vec![bytes / 4])),
+                    )?;
+                    writes.push(Write {
+                        target: Target::Moment { index, second },
+                        data: tensor.data(),
+                    });
+                }
+            }
+        }
+    }
+    Ok(Restore {
+        writes,
+        adam_step,
+        reset_moments: version == 3,
+    })
+}
+
+fn restored_weight_staging(
+    plan: &ExecutionPlan,
+    writes: &[Write<'_>],
+) -> io::Result<HashMap<BufferRef, Vec<f32>>> {
+    use crate::compile::WeightFormat;
+    let mut staging = HashMap::new();
+    for &(buffer, _, _) in &plan.derived_params {
+        let Some(&(format, rows, cols)) = plan.weight_buffers.get(&buffer) else {
+            continue;
+        };
+        let Some(write) = writes
+            .iter()
+            .find(|w| matches!(w.target, Target::Parameter(b) if b == buffer))
+        else {
+            continue;
+        };
+        let values = match format {
+            WeightFormat::F16 => write
+                .data
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|&b| half::f16::from_bits(u16::from_le_bytes(b)).to_f32())
+                .collect(),
+            WeightFormat::Q4 | WeightFormat::Q8 => {
+                let elements = rows
+                    .checked_mul(cols)
+                    .ok_or_else(|| invalid("derived weight size overflow"))?;
+                let block_bytes = if format == WeightFormat::Q4 { 20 } else { 36 };
+                let bytes = (elements / 32)
+                    .checked_mul(block_bytes)
+                    .ok_or_else(|| invalid("derived weight size overflow"))?;
+                if !rows.is_multiple_of(32) || write.data.len() < bytes {
+                    return Err(invalid("invalid packed derived weight layout"));
+                }
+                if format == WeightFormat::Q4 {
+                    super::dequantize_q4_0(write.data, rows, cols)
+                } else {
+                    super::dequantize_q8_0(write.data, rows, cols)
+                }
+            }
+            WeightFormat::F32 => continue,
+        };
+        staging.insert(buffer, values);
+    }
+    Ok(staging)
+}
+
+impl Session {
+    /// Save a training checkpoint (parameters + Adam state) to a safetensors file.
+    ///
+    /// Format 3 stores logical shapes/storage types, parameter payloads without
+    /// device padding, allocated Adam/LaProp moments and the step counter.
+    /// Packed Q4/Q8 tensors remain bytes with an explicit logical-type manifest.
+    /// This is not a complete session snapshot: optimizer configuration,
+    /// accumulation windows, clip cadence and diagnostic totals are not saved.
+    #[allow(clippy::pattern_type_mismatch)]
+    pub fn save_checkpoint(&mut self, path: &std::path::Path) -> std::io::Result<()> {
+        struct CheckpointTensor {
+            name: String,
+            buffer: blade_graphics::Buffer,
+            offset: usize,
+            byte_len: usize,
+            dtype: Dtype,
+            shape: Vec<usize>,
+            host_visible: bool,
+        }
+
+        let wall_start = std::time::Instant::now();
+        let wait_start = std::time::Instant::now();
+        self.wait();
+        let wait_duration = wait_start.elapsed();
+        let collection_start = std::time::Instant::now();
+        let mut tensors = Vec::new();
+        let mut total_bytes = 0_usize;
+        let params = parameters(&self.plan)?;
+        let mut layout = LogicalLayout {
+            parameters: params
+                .iter()
+                .map(|p| (p.name.clone(), p.ty.clone()))
+                .collect(),
+            adam_parameters: Vec::new(),
+        };
+
+        // Collect parameter data
+        for param in &params {
+            let byte_len = param.byte_len;
+            let (dtype, shape) = tensor_layout(&param.ty)?;
+            let offset = total_bytes
+                .checked_add(3)
+                .ok_or_else(|| invalid("checkpoint size overflow"))?
+                / 4
+                * 4;
+            tensors.push(CheckpointTensor {
+                name: param.name.clone(),
+                buffer: self.buffers[param.buffer.0 as usize],
+                offset,
+                byte_len,
+                dtype,
+                shape,
+                host_visible: self.logical_host_visible(param.buffer),
+            });
+            total_bytes = offset
+                .checked_add(byte_len)
+                .ok_or_else(|| invalid("checkpoint size overflow"))?;
+        }
+
+        // Collect Adam moment buffers (parallel to param_grad_pairs)
+        for (idx, &(param_buf, _)) in self.plan.param_grad_pairs.iter().enumerate() {
+            if idx >= self.adam_state.len() {
+                break;
+            }
+            let param = params
+                .iter()
+                .find(|p| p.buffer == param_buf)
+                .ok_or_else(|| invalid("unnamed optimizer parameter"))?;
+            if param.ty.dtype != DType::F32 {
+                return Err(invalid(format!(
+                    "Adam parameter {:?} is not F32",
+                    param.name
+                )));
+            }
+            layout.adam_parameters.push(param.name.clone());
+            let byte_len = param.byte_len;
+            for (suffix, buf) in [
+                ("adam_m", &self.adam_state[idx].0),
+                ("adam_v", &self.adam_state[idx].1),
+            ] {
+                let offset = total_bytes
+                    .checked_add(3)
+                    .ok_or_else(|| invalid("checkpoint size overflow"))?
+                    / 4
+                    * 4;
+                tensors.push(CheckpointTensor {
+                    name: format!("{suffix}.{}", param.name),
+                    buffer: *buf,
+                    offset,
+                    byte_len,
+                    dtype: Dtype::F32,
+                    shape: param.ty.shape.clone(),
+                    host_visible: !self.optimizer_device,
+                });
+                total_bytes = offset
+                    .checked_add(byte_len)
+                    .ok_or_else(|| invalid("checkpoint size overflow"))?;
+            }
+        }
+        let mut names = HashSet::new();
+        for tensor in &tensors {
+            if !names.insert(&tensor.name) {
+                return Err(invalid(format!(
+                    "checkpoint tensor name collision: {:?}",
+                    tensor.name
+                )));
+            }
+            if tensor.byte_len % 4 != 0 && !tensor.host_visible {
+                return Err(invalid("unaligned device-only checkpoint tensor"));
+            }
+        }
+        let mut metadata = HashMap::new();
+        metadata.insert("meganeura_checkpoint_format".to_string(), "3".to_string());
+        metadata.insert("adam_step".to_string(), self.adam_step.to_string());
+        metadata.insert(
+            "meganeura_logical_layout".to_string(),
+            serde_json::to_string(&layout).map_err(io::Error::other)?,
+        );
+        let collection_duration = collection_start.elapsed();
+
+        // Host-visible parameter allocations are optimized for GPU access and
+        // CPU writes; reading them directly is extremely slow on a discrete
+        // GPU. Snapshot every tensor through one GPU transfer instead.
+        let readback_start = std::time::Instant::now();
+        let staging = self.gpu.create_buffer(blade_graphics::BufferDesc {
+            name: "checkpoint_readback",
+            size: (total_bytes as u64).max(4),
+            memory: blade_graphics::Memory::Download,
+        });
+        let mut encoder = self
+            .gpu
+            .create_command_encoder(blade_graphics::CommandEncoderDesc {
+                name: "checkpoint_readback",
+                buffer_count: 1,
+                manual_barriers: false,
+            });
+        encoder.start();
+        {
+            let mut transfer = encoder.transfer("checkpoint_readback");
+            for tensor in &tensors {
+                let aligned_len = tensor.byte_len / 4 * 4;
+                if aligned_len != 0 {
+                    transfer.copy_buffer_to_buffer(
+                        tensor.buffer.at(0),
+                        staging.at(tensor.offset as u64),
+                        aligned_len as u64,
+                    );
+                }
+            }
+        }
+        let sync = self.gpu.submit(&mut encoder);
+        let _ = self.gpu.wait_for(&sync, !0);
+        for tensor in &tensors {
+            let aligned_len = tensor.byte_len / 4 * 4;
+            let tail_len = tensor.byte_len - aligned_len;
+            if tail_len != 0 {
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        tensor.buffer.data().add(aligned_len),
+                        staging.data().add(tensor.offset + aligned_len),
+                        tail_len,
+                    );
+                }
+            }
+        }
+        let readback_duration = readback_start.elapsed();
+
+        // Build tensor views
+        let view_start = std::time::Instant::now();
+        let staging_data = unsafe { std::slice::from_raw_parts(staging.data(), total_bytes) };
+        let views: Vec<(String, TensorView<'_>)> = tensors
+            .iter()
+            .map(|tensor| {
+                let data = &staging_data[tensor.offset..tensor.offset + tensor.byte_len];
+                (
+                    tensor.name.clone(),
+                    TensorView::new(tensor.dtype, tensor.shape.clone(), data).expect("tensor view"),
+                )
+            })
+            .collect();
+        let view_duration = view_start.elapsed();
+
+        let persist_start = std::time::Instant::now();
+        let result = safetensors::tensor::serialize_to_file(views, &Some(metadata), path)
+            .map_err(|e| std::io::Error::other(e.to_string()));
+        let persist_duration = persist_start.elapsed();
+        let bytes = if result.is_ok() {
+            std::fs::metadata(path).map_or(0, |file| file.len())
+        } else {
+            0
+        };
+        self.gpu.destroy_command_encoder(&mut encoder);
+        self.gpu.destroy_buffer(staging);
+        log::info!(
+            "checkpoint timing: wall={:.3}s wait={:.3}s collect={:.3}s \
+             readback={:.3}s views={:.3}s persist={:.3}s bytes={bytes}",
+            wall_start.elapsed().as_secs_f64(),
+            wait_duration.as_secs_f64(),
+            collection_duration.as_secs_f64(),
+            readback_duration.as_secs_f64(),
+            view_duration.as_secs_f64(),
+            persist_duration.as_secs_f64(),
+        );
+        result
+    }
+
+    /// Restore a checkpoint after validating every applicable tensor and metadata field.
+    ///
+    /// Format 3 requires the same named logical parameter shapes/storage types,
+    /// but permits different device padding. Inference sessions validate and
+    /// ignore saved moments; training sessions restore them lazily. Parameters
+    /// without saved moments get zero moments, not earlier target state.
+    /// Formats 1/2 retain legacy physical-size and partial-load compatibility.
+    ///
+    /// Validation/I/O errors leave tensors, moments and counters unchanged.
+    /// This is not rollback after device loss/allocation failure. Optimizer
+    /// configuration and accumulation/clip/diagnostic state are not restored;
+    /// use a fresh session or explicitly manage those training-loop boundaries.
+    pub fn load_checkpoint(&mut self, path: &std::path::Path) -> io::Result<()> {
+        let data = std::fs::read(path)?;
+        let restore = validate(&self.plan, &data)?;
+        for write in &restore.writes {
+            let (capacity, host_visible) = match write.target {
+                Target::Parameter(param) => (
+                    self.plan.buffers[param.0 as usize],
+                    self.logical_host_visible(param),
+                ),
+                Target::Moment { index, .. } => (
+                    self.plan.buffers[self.plan.param_grad_pairs[index].0.0 as usize],
+                    !self.optimizer_device,
+                ),
+            };
+            if capacity % 4 != 0 && !host_visible {
+                return Err(invalid("unaligned device-only checkpoint destination"));
+            }
+        }
+        let staging = restored_weight_staging(&self.plan, &restore.writes)?;
+        let moment_indices: HashSet<_> = restore
+            .writes
+            .iter()
+            .filter_map(|w| match w.target {
+                Target::Moment { index, .. } => Some(index),
+                _ => None,
+            })
+            .collect();
+        self.wait();
+        if !moment_indices.is_empty() {
+            self.ensure_adam_state();
+        }
+        if restore.reset_moments {
+            for (index, &(m, v)) in self.adam_state.iter().enumerate() {
+                if moment_indices.contains(&index) {
+                    continue;
+                }
+                let param = self.plan.param_grad_pairs[index].0;
+                let zeros = vec![0; self.plan.buffers[param.0 as usize].max(4)];
+                self.write_raw_buffer(&m, &zeros, !self.optimizer_device);
+                self.write_raw_buffer(&v, &zeros, !self.optimizer_device);
+            }
+        }
+        for write in restore.writes {
+            let (buffer, capacity, host_visible) = match write.target {
+                Target::Parameter(param) => (
+                    self.buffers[param.0 as usize],
+                    self.plan.buffers[param.0 as usize],
+                    self.logical_host_visible(param),
+                ),
+                Target::Moment { index, second } => {
+                    let param = self.plan.param_grad_pairs[index].0;
+                    let (m, v) = self.adam_state[index];
+                    (
+                        if second { v } else { m },
+                        self.plan.buffers[param.0 as usize],
+                        !self.optimizer_device,
+                    )
+                }
+            };
+            if write.data.len() == capacity {
+                self.write_raw_buffer(&buffer, write.data, host_visible);
+            } else {
+                let mut padded = vec![0; capacity];
+                padded[..write.data.len()].copy_from_slice(write.data);
+                self.write_raw_buffer(&buffer, &padded, host_visible);
+            }
+        }
+        if let Some(step) = restore.adam_step {
+            self.adam_step = step;
+        }
+        self.weight_staging.extend(staging);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Tensors = BTreeMap<String, (Dtype, Vec<usize>, Vec<u8>)>;
+
+    fn plan() -> ExecutionPlan {
+        let mut graph = crate::Graph::new();
+        let a = graph.parameter("a", &[2, 3]);
+        let b = graph.parameter("b", &[2, 3]);
+        let sum = graph.add(a, b);
+        let loss = graph.mean_all(sum);
+        graph.set_outputs(vec![loss]);
+        crate::compile::compile(&crate::autodiff::differentiate(&graph))
+    }
+
+    fn fixture(plan: &ExecutionPlan) -> (Tensors, HashMap<String, String>) {
+        let params = parameters(plan).unwrap();
+        let layout = LogicalLayout {
+            parameters: params
+                .iter()
+                .map(|p| (p.name.clone(), p.ty.clone()))
+                .collect(),
+            adam_parameters: params.iter().map(|p| p.name.clone()).collect(),
+        };
+        let mut tensors = BTreeMap::new();
+        for p in params {
+            for name in [
+                p.name.clone(),
+                format!("adam_m.{}", p.name),
+                format!("adam_v.{}", p.name),
+            ] {
+                tensors.insert(name, (Dtype::F32, p.ty.shape.clone(), vec![0; p.byte_len]));
+            }
+        }
+        (
+            tensors,
+            HashMap::from([
+                ("meganeura_checkpoint_format".into(), "3".into()),
+                ("adam_step".into(), "7".into()),
+                (
+                    "meganeura_logical_layout".into(),
+                    serde_json::to_string(&layout).unwrap(),
+                ),
+            ]),
+        )
+    }
+
+    fn encode(tensors: &Tensors, metadata: HashMap<String, String>) -> Vec<u8> {
+        let views: Vec<_> = tensors
+            .iter()
+            .map(|(name, entry)| {
+                (
+                    name.clone(),
+                    TensorView::new(entry.0, entry.1.clone(), &entry.2).unwrap(),
+                )
+            })
+            .collect();
+        safetensors::tensor::serialize(views, &Some(metadata)).unwrap()
+    }
+
+    #[test]
+    fn logical_checkpoint_preflight_rejects_incomplete_and_mismatched_records() {
+        let plan = plan();
+        let (tensors, metadata) = fixture(&plan);
+        let data = encode(&tensors, metadata);
+        let restore = validate(&plan, &data).unwrap();
+        assert_eq!(restore.writes.len(), 6);
+        assert_eq!(restore.adam_step, Some(7));
+        assert!(validate(&plan, &data[..data.len() - 1]).is_err());
+        assert!(validate(&plan, &data[..7]).is_err());
+        for case in 0..15 {
+            let (mut tensors, mut metadata) = fixture(&plan);
+            match case {
+                0 => {
+                    metadata.insert("adam_step".into(), "-1".into());
+                }
+                1 => {
+                    metadata.insert("meganeura_checkpoint_format".into(), "4".into());
+                }
+                2 => {
+                    tensors.remove("b");
+                }
+                3 => {
+                    tensors.get_mut("b").unwrap().1 = vec![3, 2];
+                }
+                4 => {
+                    tensors.get_mut("b").unwrap().0 = Dtype::I32;
+                }
+                5 => {
+                    tensors.insert("adam_v.b".into(), (Dtype::F32, vec![5], vec![0; 20]));
+                }
+                6 => {
+                    tensors.remove("adam_v.b");
+                }
+                7 => {
+                    tensors.insert("extra".into(), (Dtype::F32, vec![1], vec![0; 4]));
+                }
+                8..=10 => {
+                    let mut layout: LogicalLayout =
+                        serde_json::from_str(&metadata["meganeura_logical_layout"]).unwrap();
+                    match case {
+                        8 => layout.parameters.get_mut("b").unwrap().shape = vec![3, 2],
+                        9 => layout.adam_parameters.push("b".into()),
+                        _ => layout.adam_parameters.push("unknown".into()),
+                    }
+                    metadata.insert(
+                        "meganeura_logical_layout".into(),
+                        serde_json::to_string(&layout).unwrap(),
+                    );
+                }
+                11 => {
+                    metadata.remove("meganeura_logical_layout");
+                }
+                12 => {
+                    metadata.remove("adam_step");
+                }
+                13 => {
+                    metadata.insert("meganeura_checkpoint_format".into(), "bad".into());
+                }
+                _ => {
+                    metadata.insert("meganeura_checkpoint_format".into(), "0".into());
+                }
+            }
+            assert!(
+                validate(&plan, &encode(&tensors, metadata)).is_err(),
+                "corruption case {case} accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn logical_checkpoint_is_independent_of_padding_and_inference_moment_allocation() {
+        let mut plan = plan();
+        let (mut tensors, metadata) = fixture(&plan);
+        let data = encode(&tensors, metadata.clone());
+        for &(_, buffer) in &plan.param_buffers {
+            plan.buffers[buffer.0 as usize] += 128;
+        }
+        assert_eq!(validate(&plan, &data).unwrap().writes.len(), 6);
+        plan.param_grad_pairs.clear();
+        assert_eq!(validate(&plan, &data).unwrap().writes.len(), 2);
+        tensors.remove("adam_v.b");
+        assert!(validate(&plan, &encode(&tensors, metadata)).is_err());
+    }
+
+    #[test]
+    fn checkpoint_logical_byte_counts_are_checked() {
+        assert!(logical_bytes(&TensorType::f32(vec![usize::MAX])).is_err());
+        assert!(logical_bytes(&TensorType::f32(vec![usize::MAX, 2])).is_err());
+        assert_eq!(logical_bytes(&TensorType::f16(vec![3])).unwrap(), 6);
+        assert_eq!(
+            logical_bytes(&TensorType::new(vec![32, 33], DType::Q4_0)).unwrap(),
+            660
+        );
+        assert_eq!(
+            logical_bytes(&TensorType::new(vec![32, 33], DType::Q8_0)).unwrap(),
+            1188
+        );
+    }
+
+    #[test]
+    fn legacy_checkpoint_partial_loads_remain_preflighted() {
+        for version in [1, 2] {
+            let plan = plan();
+            let (mut tensors, mut metadata) = fixture(&plan);
+            metadata.insert("meganeura_checkpoint_format".into(), version.to_string());
+            metadata.remove("meganeura_logical_layout");
+            tensors.remove("b");
+            for entry in tensors.values_mut() {
+                entry.1 = vec![entry.2.len() / 4];
+            }
+            let data = encode(&tensors, metadata.clone());
+            assert_eq!(validate(&plan, &data).unwrap().writes.len(), 5);
+            tensors.insert("adam_v.b".into(), (Dtype::F32, vec![9], vec![0; 36]));
+            assert!(validate(&plan, &encode(&tensors, metadata)).is_err());
+        }
+    }
+}

--- a/src/runtime/tuning.rs
+++ b/src/runtime/tuning.rs
@@ -1,40 +1,93 @@
 use super::{Gpu, Pipelines, Session, Variant, ensure_device_memory_budget};
 use crate::compile::{BufferRef, Dispatch, ShaderEntry};
 use crate::tune::{
-    MatmulTile, TuneClass, TuneDecision, TuneError, TuneOptions, TuneOutcome, TuneReport, decide,
-    measure_pairs,
+    MatmulTile, TuneClass, TuneDecision, TuneError, TuneOptions, TuneOutcome, TunePreparationTimes,
+    TuneQualificationTimes, TuneReport, TuneScratchStats, TuneScratchUsage, TuneStaging,
+    TuneStagingReuse, decide, measure_pairs,
 };
 use blade_graphics as bg;
-use std::{collections::HashMap, time::Instant};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+struct PhaseTimer<'a> {
+    start: Instant,
+    elapsed: &'a mut Option<Duration>,
+}
+
+impl<'a> PhaseTimer<'a> {
+    fn new(elapsed: &'a mut Option<Duration>) -> Self {
+        Self {
+            start: Instant::now(),
+            elapsed,
+        }
+    }
+}
+
+impl Drop for PhaseTimer<'_> {
+    fn drop(&mut self) {
+        *self.elapsed.get_or_insert(Duration::ZERO) += self.start.elapsed();
+    }
+}
 
 impl Pipelines {
-    fn ensure_scalar_tile(&mut self, gpu: &Gpu, entry: &ShaderEntry, tile: MatmulTile) {
+    fn ensure_tune_tile(
+        &mut self,
+        gpu: &Gpu,
+        entry: &ShaderEntry,
+        tile: MatmulTile,
+    ) -> Result<(), String> {
         let key = tile_variant(entry, tile);
         if self.map.contains_key(&key) {
-            return;
+            return Ok(());
         }
-        let module = match tile {
-            MatmulTile::Tile32 => crate::codegen::generate_module_small(entry.shader_group()),
-            MatmulTile::Tile64 => crate::codegen::generate_module(entry.shader_group()),
-        };
-        let shader = gpu.create_shader(bg::ShaderDesc {
-            source: &module.source,
-            naga_module: Some(module.module),
-        });
-        let layout = super::shader_data_layout(entry);
+        let selected_entry = tile.shader(entry);
+        let module = tile_module(entry, tile);
+        let shader = gpu
+            .try_create_shader(bg::ShaderDesc {
+                source: &module.source,
+                naga_module: Some(module.module),
+            })
+            .map_err(|error| error.to_string())?;
+        let layout = super::shader_data_layout(&selected_entry);
         let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-            name: entry.entry_point(),
+            name: selected_entry.entry_point(),
             data_layouts: &[&layout],
-            compute: shader.at(entry.entry_point()),
+            compute: shader.at(selected_entry.entry_point()),
         });
         self.map.insert(key, pipeline);
+        Ok(())
+    }
+}
+
+fn tile_module(entry: &ShaderEntry, tile: MatmulTile) -> crate::codegen::ShaderModule {
+    let selected_entry = tile.shader(entry);
+    if selected_entry != *entry {
+        crate::codegen::generate_module(selected_entry.shader_group())
+    } else {
+        match tile {
+            MatmulTile::Tile32 => crate::codegen::generate_module_small(entry.shader_group()),
+            MatmulTile::Tile64 => crate::codegen::generate_module(entry.shader_group()),
+            MatmulTile::CooperativeF32 { .. } => crate::codegen::generate_module_coop(
+                entry.shader_group(),
+                &tile.coop_config().expect("cooperative candidate"),
+            ),
+        }
     }
 }
 
 fn tile_variant(entry: &ShaderEntry, tile: MatmulTile) -> Variant {
+    if matches!(
+        entry,
+        ShaderEntry::Conv2dGradInputGemm | ShaderEntry::Conv2dGradWeightGemm
+    ) {
+        return Variant::Scalar(tile.shader(entry));
+    }
     match tile {
         MatmulTile::Tile32 => Variant::SmallTile(entry.clone()),
         MatmulTile::Tile64 => Variant::Scalar(entry.clone()),
+        MatmulTile::CooperativeF32 { .. } => Variant::Coop(entry.clone()),
     }
 }
 
@@ -42,17 +95,78 @@ struct SearchClass {
     key: TuneClass,
     initial: MatmulTile,
     members: Vec<usize>,
+    challengers: Vec<MatmulTile>,
+}
+
+struct SelectionSwap {
+    index: usize,
+    class: TuneClass,
+    left: MatmulTile,
+    right: MatmulTile,
+}
+
+fn selection_swaps(
+    left: &[Dispatch],
+    right: &[Dispatch],
+    left_classes: &[SearchClass],
+    right_classes: &[SearchClass],
+) -> Result<Vec<SelectionSwap>, TuneError> {
+    if left.len() != right.len() {
+        return Err(TuneError("tuning swap requires matching dispatch layouts"));
+    }
+    let by_index = |classes: &[SearchClass]| {
+        let mut indices = vec![None; left.len()];
+        for (class_index, class) in classes.iter().enumerate() {
+            for &index in &class.members {
+                indices[index] = Some(class_index);
+            }
+        }
+        indices
+    };
+    let left_indices = by_index(left_classes);
+    let right_indices = by_index(right_classes);
+    let mut swaps = Vec::new();
+    for (index, (a, b)) in left.iter().zip(right).enumerate() {
+        if a == b {
+            continue;
+        }
+        let (Some(ai), Some(bi)) = (left_indices[index], right_indices[index]) else {
+            return Err(TuneError(
+                "tuning swap only permits eligible f32 tile changes",
+            ));
+        };
+        let (ac, bc) = (&left_classes[ai], &right_classes[bi]);
+        if ac.key != bc.key || !ac.initial.fits(&bc.key) || !bc.initial.fits(&ac.key) {
+            return Err(TuneError("tuning swap requires identical legal classes"));
+        }
+        let (mut normalized_a, mut normalized_b) = (a.clone(), b.clone());
+        ac.initial.apply(&mut normalized_a, &ac.key);
+        ac.initial.apply(&mut normalized_b, &bc.key);
+        if normalized_a != normalized_b {
+            return Err(TuneError(
+                "tuning swap cannot change bindings, fusion or provenance",
+            ));
+        }
+        swaps.push(SelectionSwap {
+            index,
+            class: ac.key.clone(),
+            left: ac.initial,
+            right: bc.initial,
+        });
+    }
+    Ok(swaps)
 }
 
 fn collect_classes(
     plan: &crate::compile::ExecutionPlan,
     alias: &crate::memplan::AliasPlan,
+    coop_config: Option<&crate::codegen::CoopConfig>,
 ) -> (Vec<SearchClass>, usize) {
     let mut classes: Vec<SearchClass> = Vec::new();
     let mut indices = HashMap::new();
     let mut excluded = 0;
     for (index, dispatch) in plan.dispatches.iter().enumerate() {
-        let Some(mut key) = TuneClass::from_dispatch(dispatch) else {
+        let Some(mut key) = TuneClass::from_dispatch(dispatch, coop_config) else {
             excluded += 1;
             continue;
         };
@@ -76,23 +190,16 @@ fn collect_classes(
             let slot = if i + 1 == physical.len() { 3 } else { i };
             key.device_local[slot] = alias.device_local[p];
         }
-        let Some(sizes) = key.buffer_sizes() else {
-            excluded += 1;
-            continue;
-        };
-        if bindings
+        key.binding_bytes = bindings
             .iter()
-            .zip(sizes)
-            .any(|(b, size)| plan.buffers[b.0 as usize] < size)
-        {
+            .map(|b| plan.buffers[b.0 as usize])
+            .collect();
+        let initial = MatmulTile::selected(dispatch, coop_config).expect("checked class geometry");
+        if !initial.fits(&key) {
             excluded += 1;
             continue;
         }
-        let initial = if dispatch.use_small_tiles {
-            MatmulTile::Tile32
-        } else {
-            MatmulTile::Tile64
-        };
+        let challengers = key.challengers(initial, coop_config);
         let next_index = classes.len();
         let class_index = *indices.entry((key.clone(), initial)).or_insert(next_index);
         if class_index == next_index {
@@ -100,6 +207,7 @@ fn collect_classes(
                 key,
                 initial,
                 members: Vec::new(),
+                challengers,
             });
         }
         classes[class_index].members.push(index);
@@ -108,15 +216,81 @@ fn collect_classes(
     // contractions. Stable ties keep the source dispatch order deterministic.
     classes.sort_by_key(|c| {
         std::cmp::Reverse(
-            c.members.len() as u128 * c.key.m as u128 * c.key.n as u128 * c.key.k as u128,
+            c.members.len() as u128
+                * c.key.m as u128
+                * c.key.n as u128
+                * c.key.k as u128
+                * c.key.batch_dispatches() as u128,
         )
     });
     (classes, excluded)
 }
 
 impl Session {
-    /// Bounded scalar-tile search with default options; logs skips and returns
-    /// per-class evidence. Use [`Self::tune_with`] for budgets and full reporting.
+    /// Exchange eligible f32 tile choices without exchanging tensor state.
+    ///
+    /// This supports controlled crossover experiments, not automatic confirmation,
+    /// arbitrary report application, or persistent/cross-device winner reuse.
+    /// Sessions must share the exact GPU context, cooperative policy after smoke
+    /// tests, allocation layout, generator knobs and scheduling groups. Dispatches
+    /// may differ only in complete legal tile selection. Callers remain
+    /// responsible for matching inputs, weights, optimizer settings and training age.
+    ///
+    /// Preflights the entire swap, prepares missing pipelines, then waits for both
+    /// sessions before installing choices. No step, upload, readback or optimizer
+    /// update occurs. On error choices and tensors remain unchanged; successfully
+    /// prepared pipelines can remain cached. Preparation and waits belong outside
+    /// whole-step timers. Returns the changed dispatch count per session.
+    pub fn swap_tuning_with(&mut self, other: &mut Self) -> Result<usize, TuneError> {
+        if !std::sync::Arc::ptr_eq(&self.gpu, &other.gpu)
+            || self.coop_config != other.coop_config
+            || self.plan.buffers != other.plan.buffers
+            || self.plan.knobs != other.plan.knobs
+            || self.alias.map != other.alias.map
+            || self.alias.sizes != other.alias.sizes
+            || self.alias.device_local != other.alias.device_local
+            || self.groups != other.groups
+        {
+            return Err(TuneError(
+                "tuning swap requires compatible sessions on one context",
+            ));
+        }
+        let left_classes = collect_classes(&self.plan, &self.alias, self.coop_config.as_ref()).0;
+        let right_classes =
+            collect_classes(&other.plan, &other.alias, other.coop_config.as_ref()).0;
+        let swaps = selection_swaps(
+            &self.plan.dispatches,
+            &other.plan.dispatches,
+            &left_classes,
+            &right_classes,
+        )?;
+        for swap in &swaps {
+            for (session, tile) in [(&mut *self, swap.right), (&mut *other, swap.left)] {
+                if let Err(error) =
+                    session
+                        .pipelines
+                        .ensure_tune_tile(&session.gpu, &swap.class.shader, tile)
+                {
+                    log::warn!("tuning swap pipeline preparation: {error}");
+                    return Err(TuneError(
+                        "tuning swap pipeline preparation failed; see log",
+                    ));
+                }
+            }
+        }
+        self.wait();
+        other.wait();
+        for swap in &swaps {
+            swap.right
+                .apply(&mut self.plan.dispatches[swap.index], &swap.class);
+            swap.left
+                .apply(&mut other.plan.dispatches[swap.index], &swap.class);
+        }
+        Ok(swaps.len())
+    }
+
+    /// Bounded f32 tile search with default options; logs skips and returns
+    /// per-comparison evidence. Use [`Self::tune_with`] for budgets and full reporting.
     ///
     /// Unlike the former family-wide tuner, this never calls `step()` and
     /// never reads or writes live tensor, optimizer, accumulator, or KV state.
@@ -127,9 +301,10 @@ impl Session {
             .outcomes
     }
 
-    /// Search the two existing scalar f32 matmul tiles for exact eligible
-    /// classes. The old occupancy threshold is only the initial choice;
-    /// measurements can select either size regardless of that threshold.
+    /// Search scalar tiles and advertised, smoke-tested native-f32 cooperative
+    /// matmul, plus scalar convolution derivatives, for exact eligible classes.
+    /// Occupancy/large-shape thresholds only
+    /// choose the starting implementation; they do not remove challengers.
     ///
     /// Each class uses private scratch with matching memory placement and two
     /// deterministic nonzero input patterns (including tiny f32 operands).
@@ -137,17 +312,33 @@ impl Session {
     /// dots before alternating, batched `encode+submit+wait` measurements.
     /// The result is an isolated-kernel choice, not an end-to-end speed claim.
     ///
-    /// Forward MatMul+Add is supported; other prologues/epilogues, horizontal
-    /// packs, cooperative, reduced-storage, GEMV and overlapping-binding
+    /// Forward MatMul+Add and unpacked NCHW scalar convolution dX/dW are supported;
+    /// convolution keys include batch, channels, spatial extents, kernel, stride
+    /// and padding. Index decomposition uses exact integer arithmetic.
+    /// Forward/cooperative convolutions remain excluded.
+    /// Other prologues/epilogues, horizontal
+    /// packs, f16-input cooperative, reduced-storage, GEMV and overlapping-binding
     /// dispatches are excluded. Winners live in this session, not the plan cache.
     /// Only selected dispatch geometry and pipeline resources change. No graph
     /// execution occurs, including when an optimizer or external buffer is bound.
-    /// A soft deadline may be exceeded by one in-flight operation; incomplete
-    /// measurements always retain the original choice.
+    /// Cooperative padding must fit each binding's declared size; the live
+    /// allocation/alias plan is never resized. Up to two sequential challenger
+    /// comparisons per class reuse the latest fully qualified winner as the
+    /// incumbent. A soft deadline may be exceeded by one in-flight operation;
+    /// an incomplete comparison always retains its incumbent.
     pub fn tune_with(&mut self, options: TuneOptions) -> Result<TuneReport, TuneError> {
         options.validate()?;
         let start = Instant::now();
-        let (classes, excluded_dispatches) = collect_classes(&self.plan, &self.alias);
+        let (mut classes, mut excluded_dispatches) =
+            collect_classes(&self.plan, &self.alias, self.coop_config.as_ref());
+        classes.retain(|class| {
+            if options.scope.includes(&class.key) {
+                true
+            } else {
+                excluded_dispatches += class.members.len();
+                false
+            }
+        });
         let mut report = TuneReport {
             options: options.clone(),
             eligible_classes: classes.len(),
@@ -155,57 +346,65 @@ impl Session {
             class_limit_reached: classes.len() > options.max_classes,
             ..Default::default()
         };
+        let gpu = std::sync::Arc::clone(&self.gpu);
+        let mut staging = Staging::new(&gpu, options.staging, options.staging_reuse);
         for class in classes.iter().take(options.max_classes) {
             if start.elapsed() >= options.max_time {
                 report.time_budget_exhausted = true;
                 break;
             }
-            let mut outcome = TuneOutcome {
-                class: class.key.clone(),
-                dispatches: class.members.len(),
-                initial: class.initial,
-                selected: class.initial,
-                decision: TuneDecision::KeepBaseline,
-                qualified: false,
-                elapsed: std::time::Duration::ZERO,
-                compile_time: std::time::Duration::ZERO,
-                baseline_ms: Vec::new(),
-                candidate_ms: Vec::new(),
-                baseline_median_ms: None,
-                candidate_median_ms: None,
-                noise_margin_ms: None,
-            };
-            let class_start = Instant::now();
-            self.measure_scalar_class(class, &options, start, &mut outcome);
-            outcome.elapsed = class_start.elapsed();
-            if outcome.selected != outcome.initial {
-                for &index in &class.members {
-                    outcome
-                        .selected
-                        .apply(&mut self.plan.dispatches[index], &class.key);
+            report.visited_classes += 1;
+            let mut incumbent = class.initial;
+            for &candidate in &class.challengers {
+                if start.elapsed() >= options.max_time {
+                    report.time_budget_exhausted = true;
+                    break;
                 }
+                let mut outcome =
+                    TuneOutcome::new(class.key.clone(), class.members.len(), incumbent, candidate);
+                let class_start = Instant::now();
+                self.measure_candidate(class, &options, start, &mut outcome, &mut staging);
+                outcome.elapsed = class_start.elapsed();
+                if outcome.selected != outcome.initial {
+                    for &index in &class.members {
+                        outcome
+                            .selected
+                            .apply(&mut self.plan.dispatches[index], &class.key);
+                    }
+                    incumbent = outcome.selected;
+                }
+                log::info!(
+                    "tune: {:?} {}x{}x{} ({} dispatches): {:?} vs {:?} -> {:?}, {:?}, medians {:?}/{:?} ms",
+                    class.key.shader,
+                    class.key.m,
+                    class.key.n,
+                    class.key.k,
+                    class.members.len(),
+                    outcome.initial,
+                    outcome.candidate,
+                    outcome.selected,
+                    outcome.decision,
+                    outcome.baseline_median_ms,
+                    outcome.candidate_median_ms
+                );
+                if let Some(ref failure) = outcome.failure {
+                    log::warn!("tune: {failure}");
+                }
+                report.outcomes.push(outcome);
             }
-            log::info!(
-                "tune: {:?} {}x{}x{} ({} dispatches): {:?} -> {:?}, {:?}, medians {:?}/{:?} ms",
-                class.key.shader,
-                class.key.m,
-                class.key.n,
-                class.key.k,
-                class.members.len(),
-                outcome.initial,
-                outcome.selected,
-                outcome.decision,
-                outcome.baseline_median_ms,
-                outcome.candidate_median_ms
-            );
-            report.outcomes.push(outcome);
         }
+        if staging.buffer.is_some() {
+            let _timer = PhaseTimer::new(&mut report.final_cleanup);
+            staging.clear();
+        }
+        report.scratch = Some(staging.stats);
         report.elapsed = start.elapsed();
         report.time_budget_exhausted |= report.elapsed >= options.max_time;
         log::info!(
-            "tune: {}/{} classes visited; {} dispatches excluded; {:.3}s; class limit={}, time limit={}",
-            report.outcomes.len(),
+            "tune: {}/{} classes visited, {} comparisons; {} dispatches excluded; {:.3}s; class limit={}, time limit={}",
+            report.visited_classes,
             report.eligible_classes,
+            report.outcomes.len(),
             report.excluded_dispatches,
             report.elapsed.as_secs_f64(),
             report.class_limit_reached,
@@ -214,17 +413,138 @@ impl Session {
         Ok(report)
     }
 
-    fn measure_scalar_class(
+    /// Measure up to four explicit split-K counts for one eligible scalar dW
+    /// class, without changing the live plan, allocations or tensor state.
+    /// Every challenger uses the current unsplit tile as its control.
+    ///
+    /// Reuses tile-search deadlines, staging, phase accounting, paired timing
+    /// and decision guards. Partial buffers and the largest upload/readback are
+    /// charged to `max_scratch_bytes`. `dispatches_per_sample` counts complete
+    /// sequences, including the final SumRows and its dependency barrier.
+    /// Full f64 final/partial checks supplement the ordinary finite/parity gates.
+    ///
+    /// Selections must be legal in advance; duplicates and more than four counts
+    /// are errors. `max_classes == 0` skips work; scope must include this class.
+    /// Pipeline preparation may populate the cache. A FasterCandidate result is
+    /// evidence for a rebuilt-plan experiment, not installation or a whole-step
+    /// speed claim. Inspect `candidate_split_k` as well as the tile and decision.
+    pub fn measure_conv_weight_splits(
+        &mut self,
+        dispatch_index: usize,
+        splits: &[u32],
+        options: TuneOptions,
+    ) -> Result<TuneReport, TuneError> {
+        options.validate()?;
+        let start = Instant::now();
+        if splits.is_empty()
+            || splits.len() > 4
+            || splits
+                .iter()
+                .enumerate()
+                .any(|(i, s)| splits[..i].contains(s))
+        {
+            return Err(TuneError("provide one to four distinct split-K counts"));
+        }
+        let class = collect_classes(&self.plan, &self.alias, self.coop_config.as_ref())
+            .0
+            .into_iter()
+            .find(|c| c.members.contains(&dispatch_index))
+            .filter(|c| c.key.shader == ShaderEntry::Conv2dGradWeightGemm)
+            .ok_or(TuneError(
+                "split-K measurement requires an eligible scalar dW class",
+            ))?;
+        if !options.scope.includes(&class.key) {
+            return Err(TuneError(
+                "tuning scope excludes the requested split-K class",
+            ));
+        }
+        for &count in splits {
+            split_dispatches(&self.plan.dispatches[dispatch_index], &class.key, count)?;
+        }
+        let mut report = TuneReport {
+            options: options.clone(),
+            eligible_classes: 1,
+            excluded_dispatches: self.plan.dispatches.len() - class.members.len(),
+            class_limit_reached: options.max_classes == 0,
+            ..Default::default()
+        };
+        let gpu = std::sync::Arc::clone(&self.gpu);
+        let mut staging = Staging::new(&gpu, options.staging, options.staging_reuse);
+        if options.max_classes != 0 {
+            for &count in splits {
+                if start.elapsed() >= options.max_time {
+                    break;
+                }
+                report.visited_classes = 1;
+                let mut outcome = TuneOutcome::new(
+                    class.key.clone(),
+                    class.members.len(),
+                    class.initial,
+                    class.initial,
+                );
+                outcome.candidate_split_k = Some(count);
+                let comparison_start = Instant::now();
+                self.measure_candidate(&class, &options, start, &mut outcome, &mut staging);
+                outcome.elapsed = comparison_start.elapsed();
+                report.outcomes.push(outcome);
+            }
+        }
+        if staging.buffer.is_some() {
+            let _timer = PhaseTimer::new(&mut report.final_cleanup);
+            staging.clear();
+        }
+        report.scratch = Some(staging.stats);
+        report.elapsed = start.elapsed();
+        report.time_budget_exhausted = report.elapsed >= options.max_time;
+        Ok(report)
+    }
+
+    fn measure_candidate(
         &mut self,
         class: &SearchClass,
         options: &TuneOptions,
         start: Instant,
         outcome: &mut TuneOutcome,
+        staging: &mut Staging<'_>,
     ) {
-        let sizes = class
+        let phases = outcome
+            .phase_times
+            .as_mut()
+            .expect("new outcome has phase timers");
+        let preparation = PhaseTimer::new(&mut phases.preparation);
+        phases.preparation_breakdown = Some(Default::default());
+        let prep = phases.preparation_breakdown.as_mut().unwrap();
+        let checks = PhaseTimer::new(&mut prep.checks);
+        let logical_sizes = class
             .key
             .buffer_sizes()
             .expect("class collection checked extents");
+        let baseline_sizes = outcome
+            .initial
+            .buffer_sizes(&class.key)
+            .expect("legal incumbent");
+        let candidate_sizes = outcome
+            .candidate
+            .buffer_sizes(&class.key)
+            .expect("legal challenger");
+        let mut sizes: Vec<_> = baseline_sizes
+            .into_iter()
+            .zip(candidate_sizes)
+            .map(|(a, b)| a.max(b))
+            .collect();
+        let output_index = sizes.len() - 1;
+        let mut dispatch = self.plan.dispatches[class.members[0]].clone();
+        dispatch.input_buffers = (0..output_index).map(|i| BufferRef(i as u32)).collect();
+        dispatch.output_buffer = BufferRef(output_index as u32);
+        let mut variants = [vec![dispatch.clone()], vec![dispatch]];
+        outcome.initial.apply(&mut variants[0][0], &class.key);
+        outcome.candidate.apply(&mut variants[1][0], &class.key);
+        if let Some(splits) = outcome.candidate_split_k {
+            let (sequence, partial_bytes) = split_dispatches(&variants[1][0], &class.key, splits)
+                .expect("explicit split-K counts were preflighted");
+            variants[1] = sequence;
+            sizes.push(partial_bytes);
+        }
         let Some(bytes) = scratch_bytes(&sizes) else {
             outcome.decision = TuneDecision::ScratchLimit;
             return;
@@ -233,46 +553,113 @@ impl Session {
             outcome.decision = TuneDecision::ScratchLimit;
             return;
         }
+        drop(checks);
+        {
+            let _timer = PhaseTimer::new(&mut prep.staging);
+            staging.discard_unmatched(*sizes.iter().max().unwrap());
+        }
+        let checks = PhaseTimer::new(&mut prep.checks);
         let memory = self.gpu.memory_stats();
         if memory.budget != 0
-            && bytes as u64 > super::safe_device_memory_remaining(memory.usage, memory.budget)
+            && (bytes - staging.stats.retained_staging_bytes) as u64
+                > super::safe_device_memory_remaining(memory.usage, memory.budget)
         {
             outcome.decision = TuneDecision::DeviceMemoryBudget;
             return;
         }
-        for tile in [class.initial, class.initial.other()] {
+        drop(checks);
+        for tile in [outcome.initial, outcome.candidate] {
             if start.elapsed() >= options.max_time {
                 outcome.decision = TuneDecision::TimeBudget;
                 return;
             }
-            let compile_start = Instant::now();
-            self.pipelines
-                .ensure_scalar_tile(&self.gpu, &class.key.shader, tile);
-            outcome.compile_time += compile_start.elapsed();
+            let compiled = {
+                let _timer = PhaseTimer::new(&mut prep.pipelines);
+                self.pipelines
+                    .ensure_tune_tile(&self.gpu, &class.key.shader, tile)
+            };
+            outcome.compile_time = prep.pipelines.unwrap();
+            if let Err(error) = compiled {
+                outcome.decision = TuneDecision::ShaderRejected;
+                outcome.failure = Some(format!("{tile:?}: {error}"));
+                return;
+            }
+        }
+        if outcome.candidate_split_k.is_some() {
+            for dispatch in &variants[1] {
+                if start.elapsed() >= options.max_time {
+                    outcome.decision = TuneDecision::TimeBudget;
+                    return;
+                }
+                let compiled = {
+                    let _timer = PhaseTimer::new(&mut prep.pipelines);
+                    self.pipelines
+                        .ensure_tune_tile(&self.gpu, &dispatch.shader, MatmulTile::Tile64)
+                };
+                outcome.compile_time = prep.pipelines.unwrap();
+                if let Err(error) = compiled {
+                    outcome.decision = TuneDecision::ShaderRejected;
+                    outcome.failure = Some(error);
+                    return;
+                }
+            }
         }
         if start.elapsed() >= options.max_time {
             outcome.decision = TuneDecision::TimeBudget;
             return;
         }
-        let mut scratch = Scratch::new(&self.gpu, &class.key, &sizes, bytes);
-        let mut dispatch = self.plan.dispatches[class.members[0]].clone();
-        dispatch.input_buffers = (0..sizes.len() - 1).map(|i| BufferRef(i as u32)).collect();
-        dispatch.output_buffer = BufferRef((sizes.len() - 1) as u32);
-        let mut variants = [dispatch.clone(), dispatch];
-        class.initial.apply(&mut variants[0], &class.key);
-        class.initial.other().apply(&mut variants[1], &class.key);
-        let pipelines = [
-            &self.pipelines.map[&tile_variant(&class.key.shader, class.initial)],
-            &self.pipelines.map[&tile_variant(&class.key.shader, class.initial.other())],
-        ];
+        let mut scratch = Scratch::new(
+            &class.key,
+            &sizes,
+            output_index,
+            bytes,
+            staging,
+            prep,
+            &mut phases.cleanup,
+        );
+        outcome.scratch = Some(TuneScratchUsage {
+            binding_bytes: sizes.clone(),
+            staging_bytes: scratch.staging.stats.retained_staging_bytes,
+            staging_reused: scratch.staging_reused,
+        });
+        let bindings = PhaseTimer::new(&mut prep.bindings);
+        let sequences: Vec<Vec<_>> = variants
+            .iter()
+            .enumerate()
+            .map(|(i, sequence)| {
+                sequence
+                    .iter()
+                    .map(|dispatch| {
+                        let key = if i == 1 && outcome.candidate_split_k.is_some() {
+                            Variant::Scalar(dispatch.shader.clone())
+                        } else {
+                            tile_variant(&class.key.shader, [outcome.initial, outcome.candidate][i])
+                        };
+                        (&self.pipelines.map[&key], dispatch)
+                    })
+                    .collect()
+            })
+            .collect();
+        drop(bindings);
+        drop(preparation);
+        phases.qualification_breakdown = Some(Default::default());
+        let details = phases.qualification_breakdown.as_mut().unwrap();
+        let qualification = PhaseTimer::new(&mut phases.qualification);
         for pattern in 0..2 {
             if start.elapsed() >= options.max_time {
                 outcome.decision = TuneDecision::TimeBudget;
                 return;
             }
-            let inputs = test_inputs(&sizes, pattern);
+            let inputs = {
+                let _timer = PhaseTimer::new(&mut details.input_preparation);
+                let mut inputs = test_inputs(&logical_sizes, pattern);
+                for (index, data) in inputs.iter_mut().enumerate() {
+                    data.resize(sizes[index] / 4, 0.0);
+                }
+                inputs
+            };
             for (index, data) in inputs.iter().enumerate() {
-                scratch.upload(index, data);
+                scratch.upload(index, data, Some(&mut *details));
             }
             let mut reference = Vec::new();
             for variant in 0..2 {
@@ -280,23 +667,90 @@ impl Session {
                     outcome.decision = TuneDecision::TimeBudget;
                     return;
                 }
-                scratch.upload(sizes.len() - 1, &vec![f32::NAN; sizes[sizes.len() - 1] / 4]);
-                scratch.run(pipelines[variant], &variants[variant], 1);
-                let output = scratch.read_output();
-                let scale = if pattern == 0 { 1.0 } else { 1.0e-12 };
-                if !qualify_output(&class.key, &inputs, &output, scale)
-                    || (variant == 1 && !outputs_agree(&reference, &output, scale))
+                for (index, &bytes) in sizes.iter().enumerate().skip(output_index) {
+                    let sentinel = {
+                        let _timer = PhaseTimer::new(&mut details.input_preparation);
+                        vec![f32::NAN; bytes / 4]
+                    };
+                    scratch.upload(index, &sentinel, Some(&mut *details));
+                }
                 {
+                    let _timer = PhaseTimer::new(&mut details.dispatch);
+                    scratch.run(&sequences[variant], 1);
+                }
+                let output = scratch.read_output(details);
+                let scale = if pattern == 0 { 1.0 } else { 1.0e-12 };
+                let valid = {
+                    let _timer = PhaseTimer::new(&mut details.validation);
+                    qualify_output(&class.key, &inputs, &output, scale)
+                        && (variant == 0 || outputs_agree(&reference, &output, scale))
+                };
+                if !valid {
                     outcome.decision = TuneDecision::InvalidOutput;
+                    outcome.failure = Some(format!(
+                        "variant {variant}, {:?}, input pattern {pattern}: reference or cross-variant mismatch",
+                        [outcome.initial, outcome.candidate][variant]
+                    ));
                     return;
+                }
+                if let Some(splits) = outcome.candidate_split_k {
+                    let final_check = {
+                        let _timer = PhaseTimer::new(&mut details.validation);
+                        qualify_weight_range(
+                            &class.key,
+                            &inputs,
+                            &output,
+                            scale,
+                            0..class.key.k as usize,
+                        )
+                    };
+                    if let Err(error) = final_check {
+                        outcome.decision = TuneDecision::InvalidOutput;
+                        outcome.failure = Some(format!(
+                            "variant {variant}, pattern {pattern}, final: {error}"
+                        ));
+                        return;
+                    }
+                    if variant == 1 {
+                        let partials = scratch.read_buffer(
+                            output_index + 1,
+                            sizes[output_index + 1] / 4,
+                            details,
+                        );
+                        let _timer = PhaseTimer::new(&mut details.validation);
+                        for split in 0..splits {
+                            if start.elapsed() >= options.max_time {
+                                outcome.decision = TuneDecision::TimeBudget;
+                                return;
+                            }
+                            let elements = class.key.output_elements();
+                            let offset = split as usize * elements;
+                            if let Err(error) = qualify_weight_range(
+                                &class.key,
+                                &inputs,
+                                &partials[offset..offset + elements],
+                                scale,
+                                split_range(class.key.k, splits, split),
+                            ) {
+                                outcome.decision = TuneDecision::InvalidOutput;
+                                outcome.failure = Some(format!(
+                                    "pattern {pattern}, partial {split}/{splits}: {error}"
+                                ));
+                                return;
+                            }
+                        }
+                    }
                 }
                 reference = output;
             }
         }
         outcome.qualified = true;
+        drop(qualification);
+        let warmup = PhaseTimer::new(&mut phases.warmup);
         // Time ordinary-magnitude data, not a zero-filled or subnormal workload.
-        for (index, data) in test_inputs(&sizes, 0).iter().enumerate() {
-            scratch.upload(index, data);
+        for (index, data) in test_inputs(&logical_sizes, 0).iter_mut().enumerate() {
+            data.resize(sizes[index] / 4, 0.0);
+            scratch.upload(index, data, None);
         }
         for _ in 0..options.warmup_runs {
             for variant in 0..2 {
@@ -304,26 +758,130 @@ impl Session {
                     outcome.decision = TuneDecision::TimeBudget;
                     return;
                 }
-                scratch.run(pipelines[variant], &variants[variant], 1);
+                scratch.run(&sequences[variant], 1);
             }
         }
+        drop(warmup);
+        let sampling = PhaseTimer::new(&mut phases.sampling);
         (outcome.baseline_ms, outcome.candidate_ms) =
             measure_pairs(options.sample_pairs, |alternative| {
                 if start.elapsed() >= options.max_time {
                     return None;
                 }
                 let index = usize::from(alternative);
-                let ms = scratch.run(
-                    pipelines[index],
-                    &variants[index],
-                    options.dispatches_per_sample,
-                );
+                let ms = scratch.run(&sequences[index], options.dispatches_per_sample);
                 // Do not accept a last pair that only finished after the deadline.
                 (start.elapsed() < options.max_time)
                     .then_some(ms / options.dispatches_per_sample as f64)
             });
+        drop(sampling);
+        drop(scratch);
         decide(outcome, options);
     }
+}
+
+fn split_dispatches(
+    dispatch: &Dispatch,
+    class: &TuneClass,
+    splits: u32,
+) -> Result<(Vec<Dispatch>, usize), TuneError> {
+    let mut plan = crate::compile::compile(&crate::Graph::new());
+    plan.buffers = class
+        .buffer_sizes()
+        .ok_or(TuneError("invalid split-K extents"))?;
+    let mut dispatch = dispatch.clone();
+    dispatch.input_buffers = vec![BufferRef(0), BufferRef(1)];
+    dispatch.output_buffer = BufferRef(2);
+    plan.dispatches.push(dispatch);
+    let bytes = plan.split_conv_weight_gradients(&[(0, splits)], usize::MAX)?;
+    Ok((plan.dispatches, bytes))
+}
+
+fn split_range(k: u32, splits: u32, split: u32) -> std::ops::Range<usize> {
+    let tiles = k.div_ceil(16);
+    let first = split * (tiles / splits) + split.min(tiles % splits);
+    let last = first + tiles / splits + u32::from(split < tiles % splits);
+    first as usize * 16..(last as usize * 16).min(k as usize)
+}
+
+fn qualify_weight_range(
+    class: &TuneClass,
+    inputs: &[Vec<f32>],
+    output: &[f32],
+    scale: f64,
+    range: std::ops::Range<usize>,
+) -> Result<(), String> {
+    if output.len() != class.output_elements() {
+        return Err("incorrect output length".into());
+    }
+    let mut error = 0.0;
+    let mut norm = 0.0;
+    for (index, &actual) in output.iter().enumerate() {
+        let reference = weight_reference_dot(
+            class,
+            inputs,
+            index / class.n as usize,
+            index % class.n as usize,
+            range.clone(),
+        );
+        if !reference.is_finite() || !close(reference, actual, scale) {
+            return Err(format!(
+                "element {index}: {actual:e}, f64 reference {reference:e}"
+            ));
+        }
+        error += (f64::from(actual) - reference).powi(2);
+        norm += reference * reference;
+    }
+    if !(norm > 0.0 && (error / norm).sqrt() <= 2e-4) {
+        return Err(format!(
+            "reference norm {norm:e}, relative L2 {}",
+            (error / norm).sqrt()
+        ));
+    }
+    Ok(())
+}
+
+fn weight_reference_dot(
+    class: &TuneClass,
+    inputs: &[Vec<f32>],
+    row: usize,
+    col: usize,
+    range: std::ops::Range<usize>,
+) -> f64 {
+    let s = class.conv2d.expect("weight-gradient reference");
+    let [ci, h, w, co, kh, kw, stride, ph, oh, ow, pw] = [
+        s.in_channels,
+        s.in_h,
+        s.in_w,
+        s.out_channels,
+        s.kernel_h,
+        s.kernel_w,
+        s.stride,
+        s.padding_h,
+        s.out_h,
+        s.out_w,
+        s.padding_w,
+    ]
+    .map(|v| v as usize);
+    let channel = col / (kh * kw);
+    let (y, x) = (col / kw % kh, col % kw);
+    let mut value = 0.0;
+    for k in range {
+        let (batch, oy, ox) = (k / (oh * ow), k / ow % oh, k % ow);
+        let Some(iy) = (oy * stride + y).checked_sub(ph) else {
+            continue;
+        };
+        let Some(ix) = (ox * stride + x).checked_sub(pw) else {
+            continue;
+        };
+        if iy >= h || ix >= w {
+            continue;
+        }
+        let a = ((batch * co + row) * oh + oy) * ow + ox;
+        let b = ((batch * ci + channel) * h + iy) * w + ix;
+        value += inputs[0][a] as f64 * inputs[1][b] as f64;
+    }
+    value
 }
 
 fn scratch_bytes(sizes: &[usize]) -> Option<usize> {
@@ -332,26 +890,128 @@ fn scratch_bytes(sizes: &[usize]) -> Option<usize> {
         .try_fold(*sizes.iter().max()?, |sum, size| sum.checked_add(*size))
 }
 
-struct Scratch<'a> {
-    gpu: &'a Gpu,
-    buffers: Vec<bg::Buffer>,
-    staging: bg::Buffer,
-    output_elements: usize,
-    encoder: bg::CommandEncoder,
+fn reuse_staging(policy: TuneStagingReuse, retained: usize, requested: usize) -> bool {
+    policy == TuneStagingReuse::SameSize && retained != 0 && retained == requested
 }
 
-impl<'a> Scratch<'a> {
-    fn new(gpu: &'a Gpu, class: &TuneClass, sizes: &[usize], bytes: usize) -> Self {
-        ensure_device_memory_budget(gpu, bytes, "scalar-tile tuning scratch");
+struct Staging<'gpu> {
+    gpu: &'gpu Gpu,
+    memory: TuneStaging,
+    reuse: TuneStagingReuse,
+    buffer: Option<bg::Buffer>,
+    stats: TuneScratchStats,
+}
+
+impl<'gpu> Staging<'gpu> {
+    fn new(gpu: &'gpu Gpu, memory: TuneStaging, reuse: TuneStagingReuse) -> Self {
+        Self {
+            gpu,
+            memory,
+            reuse,
+            buffer: None,
+            stats: Default::default(),
+        }
+    }
+
+    fn clear(&mut self) {
+        if let Some(buffer) = self.buffer.take() {
+            self.gpu.destroy_buffer(buffer);
+            self.stats.staging_releases += 1;
+            self.stats.retained_staging_bytes = 0;
+        }
+    }
+
+    fn discard_unmatched(&mut self, bytes: usize) {
+        if !reuse_staging(self.reuse, self.stats.retained_staging_bytes, bytes) {
+            self.clear();
+        }
+    }
+
+    fn acquire(&mut self, bytes: usize) -> bool {
+        if self.buffer.is_some() {
+            assert!(reuse_staging(
+                self.reuse,
+                self.stats.retained_staging_bytes,
+                bytes
+            ));
+            self.stats.staging_reuses += 1;
+            return true;
+        }
+        self.buffer = Some(self.gpu.create_buffer(bg::BufferDesc {
+            name: "tune_staging",
+            size: bytes as u64,
+            memory: match self.memory {
+                TuneStaging::Shared => bg::Memory::Shared,
+                TuneStaging::Download => bg::Memory::Download,
+            },
+        }));
+        self.stats.staging_allocations += 1;
+        self.stats.retained_staging_bytes = bytes;
+        false
+    }
+
+    fn buffer(&self) -> bg::Buffer {
+        self.buffer.expect("comparison owns initialized staging")
+    }
+}
+
+impl Drop for Staging<'_> {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+struct Scratch<'gpu, 'trial> {
+    gpu: &'gpu Gpu,
+    buffers: Vec<bg::Buffer>,
+    staging: &'trial mut Staging<'gpu>,
+    staging_reused: bool,
+    output_index: usize,
+    output_elements: usize,
+    encoder: bg::CommandEncoder,
+    cleanup: &'trial mut Option<Duration>,
+}
+
+impl<'gpu, 'trial> Scratch<'gpu, 'trial> {
+    fn new(
+        class: &TuneClass,
+        sizes: &[usize],
+        output_index: usize,
+        bytes: usize,
+        staging: &'trial mut Staging<'gpu>,
+        preparation: &mut TunePreparationTimes,
+        cleanup: &'trial mut Option<Duration>,
+    ) -> Self {
+        let gpu = staging.gpu;
+        assert!(
+            staging.buffer.is_none()
+                || reuse_staging(
+                    staging.reuse,
+                    staging.stats.retained_staging_bytes,
+                    *sizes.iter().max().unwrap()
+                )
+        );
+        let checks = PhaseTimer::new(&mut preparation.checks);
+        ensure_device_memory_budget(
+            gpu,
+            bytes - staging.stats.retained_staging_bytes,
+            "kernel tuning scratch",
+        );
+        drop(checks);
+        let buffers_time = PhaseTimer::new(&mut preparation.buffers);
         let buffers = sizes
             .iter()
             .enumerate()
             .map(|(i, &size)| {
-                let slot = if i + 1 == sizes.len() { 3 } else { i };
+                let device_local = if i > output_index {
+                    true
+                } else {
+                    class.device_local[if i == output_index { 3 } else { i }]
+                };
                 gpu.create_buffer(bg::BufferDesc {
                     name: "tune_scratch",
                     size: size as u64,
-                    memory: if class.device_local[slot] {
+                    memory: if device_local {
                         bg::Memory::DeviceTransient
                     } else {
                         bg::Memory::Shared
@@ -359,50 +1019,77 @@ impl<'a> Scratch<'a> {
                 })
             })
             .collect();
-        let staging = gpu.create_buffer(bg::BufferDesc {
-            name: "tune_staging",
-            size: *sizes.iter().max().unwrap() as u64,
-            memory: bg::Memory::Shared,
-        });
+        drop(buffers_time);
+        let staging_time = PhaseTimer::new(&mut preparation.staging);
+        let staging_reused = staging.acquire(*sizes.iter().max().unwrap());
+        staging.stats.peak_bytes = staging.stats.peak_bytes.max(bytes);
+        drop(staging_time);
+        let encoder_time = PhaseTimer::new(&mut preparation.encoder);
         let encoder = gpu.create_command_encoder(bg::CommandEncoderDesc {
-            name: "scalar_tile_tune",
+            name: "kernel_tune",
             buffer_count: 1,
             manual_barriers: false,
         });
+        drop(encoder_time);
         Self {
             gpu,
             buffers,
             staging,
-            output_elements: sizes[sizes.len() - 1] / 4,
+            staging_reused,
+            output_index,
+            output_elements: class.output_elements(),
             encoder,
+            cleanup,
         }
     }
 
-    fn upload(&mut self, index: usize, data: &[f32]) {
+    fn upload(&mut self, index: usize, data: &[f32], times: Option<&mut TuneQualificationTimes>) {
+        let (host, transfer) = times
+            .map(|t| (&mut t.upload_host_copy, &mut t.upload_transfer))
+            .unzip();
+        let host = host.map(PhaseTimer::new);
         unsafe {
-            std::ptr::copy_nonoverlapping(data.as_ptr(), self.staging.data().cast(), data.len());
+            std::ptr::copy_nonoverlapping(
+                data.as_ptr(),
+                self.staging.buffer().data().cast(),
+                data.len(),
+            );
         }
+        drop(host);
+        let _transfer = transfer.map(PhaseTimer::new);
         self.encoder.start();
         self.encoder.transfer("tune_upload").copy_buffer_to_buffer(
-            self.staging.at(0),
+            self.staging.buffer().at(0),
             self.buffers[index].at(0),
             std::mem::size_of_val(data) as u64,
         );
         self.submit_wait();
     }
 
-    fn read_output(&mut self) -> Vec<f32> {
+    fn read_output(&mut self, times: &mut TuneQualificationTimes) -> Vec<f32> {
+        self.read_buffer(self.output_index, self.output_elements, times)
+    }
+
+    fn read_buffer(
+        &mut self,
+        index: usize,
+        elements: usize,
+        times: &mut TuneQualificationTimes,
+    ) -> Vec<f32> {
+        let transfer = PhaseTimer::new(&mut times.readback_transfer);
         self.encoder.start();
         self.encoder
             .transfer("tune_readback")
             .copy_buffer_to_buffer(
-                self.buffers.last().unwrap().at(0),
-                self.staging.at(0),
-                (self.output_elements * 4) as u64,
+                self.buffers[index].at(0),
+                self.staging.buffer().at(0),
+                (elements * 4) as u64,
             );
         self.submit_wait();
+        drop(transfer);
+        let _host = PhaseTimer::new(&mut times.readback_host_copy);
         unsafe {
-            std::slice::from_raw_parts(self.staging.data().cast::<f32>(), self.output_elements)
+            std::slice::from_raw_parts(self.staging.buffer().data().cast::<f32>(), elements)
                 .to_vec()
         }
     }
@@ -412,24 +1099,29 @@ impl<'a> Scratch<'a> {
         let _ = self.gpu.wait_for(&sync, !0);
     }
 
-    fn run(&mut self, pipeline: &bg::ComputePipeline, dispatch: &Dispatch, repeats: u32) -> f64 {
+    fn run(&mut self, sequence: &[(&bg::ComputePipeline, &Dispatch)], repeats: u32) -> f64 {
         let start = Instant::now();
         self.encoder.start();
         for _ in 0..repeats {
-            let mut pass = self.encoder.compute("tune_matmul");
-            let mut pc = pass.with(pipeline);
-            Session::bind_dispatch(&self.buffers, dispatch, &mut pc);
-            pc.dispatch(dispatch.workgroups);
+            for &(pipeline, dispatch) in sequence {
+                let mut pass = self.encoder.compute("tune_kernel");
+                let mut pc = pass.with(pipeline);
+                Session::bind_dispatch(&self.buffers, dispatch, &mut pc);
+                pc.dispatch(dispatch.workgroups);
+            }
         }
         self.submit_wait();
         start.elapsed().as_secs_f64() * 1e3
     }
 }
 
-impl Drop for Scratch<'_> {
+impl Drop for Scratch<'_, '_> {
     fn drop(&mut self) {
+        let _timer = PhaseTimer::new(self.cleanup);
         self.gpu.destroy_command_encoder(&mut self.encoder);
-        self.gpu.destroy_buffer(self.staging);
+        if self.staging.reuse == TuneStagingReuse::Fresh {
+            self.staging.clear();
+        }
         for buffer in self.buffers.drain(..) {
             self.gpu.destroy_buffer(buffer);
         }
@@ -452,7 +1144,9 @@ fn test_inputs(sizes: &[usize], pattern: u32) -> Vec<Vec<f32>> {
                     bits = bits.wrapping_mul(0x85eb_ca6b);
                     bits ^= bits >> 13;
                     // All operands differ, including addend; no all-zero qualification.
-                    ((bits % 1024) as f32 - 511.5) * (scale / 1024.0)
+                    // Exercise full mantissas, not just values already exact
+                    // in a reduced-mantissa matrix implementation.
+                    ((bits >> 8) as f32 / 16_777_216.0 - 0.5) * scale
                 })
                 .collect()
         })
@@ -473,6 +1167,51 @@ fn outputs_agree(reference: &[f32], actual: &[f32], scale: f64) -> bool {
 }
 
 fn reference_dot(class: &TuneClass, inputs: &[Vec<f32>], row: usize, col: usize) -> f64 {
+    if let Some(s) = class.conv2d {
+        let [ci, w, co, kh, kw, stride, ph, oh, ow, pw] = [
+            s.in_channels,
+            s.in_w,
+            s.out_channels,
+            s.kernel_h,
+            s.kernel_w,
+            s.stride,
+            s.padding_h,
+            s.out_h,
+            s.out_w,
+            s.padding_w,
+        ]
+        .map(|v| v as usize);
+        let mut value = 0.0;
+        if class.shader == ShaderEntry::Conv2dGradInputGemm {
+            // Flatten batch and channel into the reference row, never into K.
+            let (batch, channel) = (row / ci, row % ci);
+            for out_channel in 0..co {
+                for y in 0..kh {
+                    for x in 0..kw {
+                        let Some(oy) = (col / w + ph).checked_sub(y) else {
+                            continue;
+                        };
+                        let Some(ox) = (col % w + pw).checked_sub(x) else {
+                            continue;
+                        };
+                        if !oy.is_multiple_of(stride)
+                            || !ox.is_multiple_of(stride)
+                            || oy / stride >= oh
+                            || ox / stride >= ow
+                        {
+                            continue;
+                        }
+                        let a = ((batch * co + out_channel) * oh + oy / stride) * ow + ox / stride;
+                        let b = ((out_channel * ci + channel) * kh + y) * kw + x;
+                        value += inputs[0][a] as f64 * inputs[1][b] as f64;
+                    }
+                }
+            }
+        } else {
+            value = weight_reference_dot(class, inputs, row, col, 0..class.k as usize);
+        }
+        return value;
+    }
     let (m, n, k) = (class.m as usize, class.n as usize, class.k as usize);
     let mut value = if class.has_addend() {
         inputs[2][row * n + col] as f64
@@ -496,30 +1235,43 @@ fn reference_dot(class: &TuneClass, inputs: &[Vec<f32>], row: usize, col: usize)
 }
 
 fn qualify_output(class: &TuneClass, inputs: &[Vec<f32>], output: &[f32], scale: f64) -> bool {
-    if output.iter().any(|x| !x.is_finite()) {
+    if output.len() != class.output_elements() || output.iter().any(|x| !x.is_finite()) {
         return false;
     }
     let (m, n) = (class.m as usize, class.n as usize);
     // Explicit tile boundaries and last row/column, then scattered dots.
-    let edges = [0, 1, 31, 32, 63, 64, usize::MAX];
+    let edges = [0, 1, 7, 8, 15, 16, 31, 32, 63, 64, usize::MAX];
     for i in 0..32 {
-        let row = if i == 7 {
+        let row = if i == edges.len() {
             m - 1
-        } else if i == 8 {
+        } else if i == edges.len() + 1 {
             0
         } else if i < edges.len() {
             edges[i].min(m - 1)
         } else {
             i * 104729 % m
         };
-        let col = if i == 7 {
+        let col = if i == edges.len() {
             n - 1
-        } else if i == 8 {
+        } else if i == edges.len() + 1 {
             0
         } else if i < edges.len() {
             edges[edges.len() - 1 - i].min(n - 1)
         } else {
             i * 130363 % n
+        };
+        let row = if class.conv2d.is_some() {
+            // Exercise first/last batches explicitly, then scattered batches.
+            let batches = class.batch_dispatches() as usize;
+            row + (if i % 2 == 0 {
+                0
+            } else if i < 13 {
+                batches - 1
+            } else {
+                i * 8191 % batches
+            }) * m
+        } else {
+            row
         };
         if !close(
             reference_dot(class, inputs, row, col),
@@ -537,9 +1289,561 @@ mod tests {
     use super::*;
 
     #[test]
+    fn retained_control_rejections_match_independent_f32_accumulation() {
+        for (params, pattern, index, observed) in [
+            (
+                [1u32, 3, 224, 224, 64, 7, 7, 2, 3, 112, 112, 3],
+                0,
+                177,
+                -7.426374e-3f32,
+            ),
+            (
+                [1u32, 256, 56, 56, 64, 1, 1, 1, 0, 56, 56, 0],
+                1,
+                6391,
+                1.4238133e-14f32,
+            ),
+        ] {
+            let [batch, ci, h, w, co, kh, kw, stride, ph, oh, ow, pw] = params;
+            let dispatch = Dispatch {
+                shader: ShaderEntry::Conv2dGradWeightGemmSmall,
+                input_buffers: vec![BufferRef(0), BufferRef(1)],
+                output_buffer: BufferRef(2),
+                params: params.to_vec(),
+                workgroups: [(ci * kh * kw).div_ceil(32), co.div_ceil(32), 1],
+                ..Default::default()
+            };
+            let class = TuneClass::from_dispatch(&dispatch, None).unwrap();
+            let inputs = test_inputs(&class.buffer_sizes().unwrap(), pattern);
+            let n = ci * kh * kw;
+            let (channel_out, column) = (index / n, index % n);
+            let (channel_in, ky, kx) = (column / (kh * kw), column / kw % kh, column % kw);
+            let (mut exact, mut separate, mut fused) = (0.0f64, 0.0f32, 0.0f32);
+            // Scatter from input coordinates, independently of the K gather.
+            for b in 0..batch {
+                for iy in 0..h {
+                    for ix in 0..w {
+                        let Some(y) = (iy + ph).checked_sub(ky) else {
+                            continue;
+                        };
+                        let Some(x) = (ix + pw).checked_sub(kx) else {
+                            continue;
+                        };
+                        if y % stride != 0
+                            || x % stride != 0
+                            || y / stride >= oh
+                            || x / stride >= ow
+                        {
+                            continue;
+                        }
+                        let a = inputs[0][(((b * co + channel_out) * oh + y / stride) * ow
+                            + x / stride) as usize];
+                        let v = inputs[1][(((b * ci + channel_in) * h + iy) * w + ix) as usize];
+                        exact += f64::from(a) * f64::from(v);
+                        separate += a * v;
+                        fused = a.mul_add(v, fused);
+                    }
+                }
+            }
+            assert_eq!(
+                exact,
+                reference_dot(&class, &inputs, channel_out as usize, column as usize)
+            );
+            assert!(!close(
+                exact,
+                observed,
+                if pattern == 0 { 1.0 } else { 1e-12 }
+            ));
+            assert!(
+                observed.to_bits() == separate.to_bits() || observed.to_bits() == fused.to_bits(),
+                "observed={observed:e}, separate={separate:e}, fused={fused:e}"
+            );
+            eprintln!(
+                "element {index}: observed={observed:e}, separate={separate:e}, fused={fused:e}, f64={exact:e}"
+            );
+        }
+    }
+
+    #[test]
+    fn split_scratch_contract_and_full_partial_oracles_reject_corruption() {
+        let dispatch = Dispatch {
+            shader: ShaderEntry::Conv2dGradWeightGemmSmall,
+            workgroups: [1, 1, 1],
+            input_buffers: vec![BufferRef(0), BufferRef(1)],
+            output_buffer: BufferRef(2),
+            params: vec![2, 2, 1, 41, 3, 1, 1, 1, 0, 1, 41, 0],
+            requires_full_precision: true,
+            ..Default::default()
+        };
+        let class = TuneClass::from_dispatch(&dispatch, None).unwrap();
+        let sizes = class.buffer_sizes().unwrap();
+        for splits in [2, 3, 6] {
+            let (sequence, partial_bytes) = split_dispatches(&dispatch, &class, splits).unwrap();
+            assert_eq!(partial_bytes, sizes[2] * splits as usize);
+            assert_eq!(sequence.len(), 2);
+            assert_eq!(sequence[0].output_buffer, BufferRef(3));
+            assert_eq!(sequence[1].input_buffers, [BufferRef(3)]);
+            assert_eq!(sequence[1].output_buffer, BufferRef(2));
+            let mut allocation = sizes.clone();
+            allocation.push(partial_bytes);
+            assert_eq!(
+                scratch_bytes(&allocation),
+                Some(984 + 656 + 24 + partial_bytes + 984)
+            );
+            for pattern in 0..2 {
+                let inputs = test_inputs(&sizes, pattern);
+                let scale = if pattern == 0 { 1.0 } else { 1e-12 };
+                let mut previous = 0;
+                for split in 0..splits {
+                    let range = split_range(class.k, splits, split);
+                    assert_eq!(range.start, previous);
+                    previous = range.end;
+                    // Direct forward scatter for this 1x1 fixture, independently
+                    // indexed in NCHW and restricted to the selected spatial range.
+                    let mut expected = vec![0.0f64; class.output_elements()];
+                    for batch in 0..2 {
+                        for co in 0..3 {
+                            for x in 0..41 {
+                                if range.contains(&(batch * 41 + x)) {
+                                    for ci in 0..2 {
+                                        expected[co * 2 + ci] +=
+                                            f64::from(inputs[0][(batch * 3 + co) * 41 + x])
+                                                * f64::from(inputs[1][(batch * 2 + ci) * 41 + x]);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    let mut output: Vec<_> = expected.iter().map(|&v| v as f32).collect();
+                    assert!(
+                        qualify_weight_range(&class, &inputs, &output, scale, range.clone())
+                            .is_ok()
+                    );
+                    *output.last_mut().unwrap() = f32::NAN;
+                    assert!(
+                        qualify_weight_range(&class, &inputs, &output, scale, range.clone())
+                            .is_err()
+                    );
+                    output.fill(0.0);
+                    assert!(qualify_weight_range(&class, &inputs, &output, scale, range).is_err());
+                }
+                assert_eq!(previous, class.k as usize);
+            }
+        }
+        for splits in [0, 1, 7, u32::MAX] {
+            assert!(split_dispatches(&dispatch, &class, splits).is_err());
+        }
+        assert_eq!(scratch_bytes(&[4, 8, 12, 128]), Some(280));
+    }
+
+    #[test]
+    fn swap_preflight_checks_complete_layout_before_any_change() {
+        let mut graph = crate::Graph::new();
+        let x = graph.input("x", &[128, 512]);
+        let w = graph.parameter("w", &[512, 512]);
+        let h = graph.matmul(x, w);
+        let y = graph.matmul(h, w);
+        graph.set_outputs(vec![y]);
+        let mut left = crate::compile::compile_with(&graph, &Default::default());
+        super::super::select_variants(&mut left, None, false, false);
+        let alias = crate::memplan::AliasPlan::identity(&left.buffers);
+        let classes = collect_classes(&left, &alias, None).0;
+        let mut right = left.clone();
+        for class in &classes {
+            for &index in &class.members {
+                MatmulTile::Tile32.apply(&mut right.dispatches[index], &class.key);
+            }
+        }
+        let right_classes = collect_classes(&right, &alias, None).0;
+        let swaps = selection_swaps(
+            &left.dispatches,
+            &right.dispatches,
+            &classes,
+            &right_classes,
+        )
+        .unwrap();
+        assert_eq!(swaps.len(), 2);
+        let original_left = left.dispatches.clone();
+        let mut invalid = right.dispatches.clone();
+        invalid[1].origin.push(12345);
+        assert!(selection_swaps(&left.dispatches, &invalid, &classes, &right_classes).is_err());
+        invalid[1] = right.dispatches[1].clone();
+        invalid[1].input_buffers.swap(0, 1);
+        assert!(selection_swaps(&left.dispatches, &invalid, &classes, &right_classes).is_err());
+        assert_eq!(left.dispatches, original_left);
+        for swap in swaps {
+            swap.right
+                .apply(&mut left.dispatches[swap.index], &swap.class);
+            swap.left
+                .apply(&mut right.dispatches[swap.index], &swap.class);
+        }
+        assert_eq!(right.dispatches, original_left);
+        assert!(
+            selection_swaps(
+                &left.dispatches,
+                &right.dispatches[..1],
+                &classes,
+                &right_classes
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    #[ignore = "GPU state/crossover qualification; does not select winners by timing"]
+    fn tuning_swap_keeps_distinct_training_states_and_next_updates() {
+        for convolution in [false, true] {
+            check_distinct_training_swap(convolution);
+        }
+    }
+
+    fn check_distinct_training_swap(convolution: bool) {
+        use crate::{CoopPolicy, SessionConfig, SessionOptions};
+        let gpu = std::sync::Arc::new(crate::init_gpu_context().unwrap());
+        let mut graph = crate::Graph::new();
+        let input_len = if convolution {
+            2 * 17 * 3 * 11
+        } else {
+            33 * 17
+        };
+        let x = graph.input(
+            "x",
+            &if convolution {
+                vec![input_len]
+            } else {
+                vec![33, 17]
+            },
+        );
+        let w = graph.parameter(
+            "w",
+            &if convolution {
+                vec![17 * 65]
+            } else {
+                vec![17, 65]
+            },
+        );
+        let y = if convolution {
+            graph.conv2d_hw(x, w, 2, 17, 3, 11, 65, 1, 1, 1, 0, 0)
+        } else {
+            graph.matmul(x, w)
+        };
+        let loss = graph.mean_all(y);
+        graph.set_outputs(vec![loss]);
+        let make = |input: f32, steps: usize| {
+            let (mut s, _) = crate::build(
+                &graph,
+                SessionConfig {
+                    gpu: Some(gpu.clone()),
+                    runtime: SessionOptions {
+                        debug: true,
+                        coop: CoopPolicy::Disabled,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            );
+            s.set_input("x", &vec![input; input_len]);
+            s.set_parameter("w", &vec![0.125; 17 * 65]);
+            s.set_adam(0.001, 0.9, 0.999, 1e-8);
+            s.set_grad_clip_norm(0.05);
+            s.set_grad_clip_every(3);
+            s.set_grad_accumulate(2);
+            for _ in 0..steps {
+                s.step();
+                s.wait();
+            }
+            s
+        };
+        let (mut a, mut a_control) = (make(0.25, 1), make(0.25, 1));
+        let (mut b, mut b_control) = (make(-0.125, 2), make(-0.125, 2));
+        let initial_parameters = a.read_params(&["w"]);
+        let state = |s: &Session| {
+            let mut values = vec![s.adam_step_count()];
+            for (index, &bytes) in s.plan.buffers.iter().enumerate() {
+                let mut data = vec![0.0; bytes / 4];
+                s.read_buffer(BufferRef(index as u32), &mut data);
+                values.extend(data.into_iter().map(f32::to_bits));
+            }
+            for (m, v) in s.read_adam_states(&["w"]) {
+                values.extend(m.into_iter().chain(v).map(f32::to_bits));
+            }
+            values
+        };
+        let class = collect_classes(&b.plan, &b.alias, None).0.remove(0);
+        let alternative = if class.initial == MatmulTile::Tile32 {
+            MatmulTile::Tile64
+        } else {
+            MatmulTile::Tile32
+        };
+        b.pipelines
+            .ensure_tune_tile(&gpu, &class.key.shader, alternative)
+            .unwrap();
+        for &index in &class.members {
+            alternative.apply(&mut b.plan.dispatches[index], &class.key);
+        }
+        let (a_keys, b_keys) = (a.dispatch_pipeline_keys(), b.dispatch_pipeline_keys());
+        assert_ne!(a_keys, b_keys);
+        for _ in 0..4 {
+            let (before_a, before_b) = (state(&a), state(&b));
+            assert_ne!(before_a, before_b);
+            assert!(a.swap_tuning_with(&mut b).unwrap() > 0);
+            assert_eq!(state(&a), before_a);
+            assert_eq!(state(&b), before_b);
+            for s in [&mut a, &mut b, &mut a_control, &mut b_control] {
+                s.step();
+                s.wait();
+            }
+            assert_eq!(state(&a), state(&a_control));
+            assert_eq!(state(&b), state(&b_control));
+        }
+        assert_eq!(a.dispatch_pipeline_keys(), a_keys);
+        assert_eq!(b.dispatch_pipeline_keys(), b_keys);
+        assert_ne!(
+            a.read_params(&["w"]),
+            initial_parameters,
+            "optimizer must make a real update"
+        );
+        let before = state(&a);
+        b.plan.knobs.flash_ept_cap += 1;
+        assert!(a.swap_tuning_with(&mut b).is_err());
+        assert_eq!(state(&a), before);
+        assert_eq!(a.dispatch_pipeline_keys(), a_keys);
+    }
+
+    #[test]
+    fn swap_preflight_obeys_native_precision_and_complete_geometry() {
+        let mut graph = crate::Graph::new();
+        let x = graph.input("x", &[32, 32]);
+        let w = graph.parameter("w", &[32, 32]);
+        let y = graph.matmul(x, w);
+        graph.set_outputs(vec![y]);
+        let mut left = crate::compile::compile_with(&graph, &Default::default());
+        super::super::select_variants(&mut left, None, false, false);
+        let alias = crate::memplan::AliasPlan::identity(&left.buffers);
+        for tile_size in [8, 16] {
+            let config = crate::codegen::CoopConfig {
+                tile_size,
+                use_f16_input: false,
+                compensated: false,
+            };
+            let classes = collect_classes(&left, &alias, Some(&config)).0;
+            let mut right = left.clone();
+            MatmulTile::CooperativeF32 { tile_size }
+                .apply(&mut right.dispatches[0], &classes[0].key);
+            let right_classes = collect_classes(&right, &alias, Some(&config)).0;
+            let swaps = selection_swaps(
+                &left.dispatches,
+                &right.dispatches,
+                &classes,
+                &right_classes,
+            )
+            .unwrap();
+            assert_eq!(swaps.len(), 1);
+            let mut selected = left.dispatches[0].clone();
+            swaps[0].right.apply(&mut selected, &swaps[0].class);
+            assert_eq!(selected, right.dispatches[0]);
+            assert!(selected.scalar_fallback.is_some());
+            let reduced = crate::codegen::CoopConfig {
+                use_f16_input: true,
+                ..config
+            };
+            assert!(
+                selection_swaps(
+                    &left.dispatches,
+                    &right.dispatches,
+                    &classes,
+                    &collect_classes(&right, &alias, Some(&reduced)).0
+                )
+                .is_err()
+            );
+            right.dispatches[0].workgroups[0] += 1;
+            assert!(
+                selection_swaps(
+                    &left.dispatches,
+                    &right.dispatches,
+                    &classes,
+                    &collect_classes(&right, &alias, Some(&config)).0
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn phase_timer_records_partial_time_on_early_exit() {
+        fn exit_early(elapsed: &mut Option<Duration>) -> Result<(), ()> {
+            let _timer = PhaseTimer {
+                start: Instant::now() - Duration::from_millis(10),
+                elapsed,
+            };
+            Err(())
+        }
+        let mut elapsed = None;
+        assert!(exit_early(&mut elapsed).is_err());
+        assert!(elapsed.unwrap() >= Duration::from_millis(10));
+        let first = elapsed.unwrap();
+        assert!(exit_early(&mut elapsed).is_err());
+        assert!(elapsed.unwrap() >= first + Duration::from_millis(10));
+    }
+
+    #[test]
+    #[ignore = "GPU staging round-trip qualification, not a performance assertion"]
+    fn tuning_staging_round_trips_all_bits_and_declared_extents() {
+        let gpu = crate::init_gpu_context().unwrap();
+        for (m, n, k) in [(3, 7, 5), (33, 65, 17), (2048, 1000, 1)] {
+            for device_local in [false, true] {
+                let class = TuneClass {
+                    shader: ShaderEntry::MatMulAT,
+                    m,
+                    n,
+                    k,
+                    conv2d: None,
+                    requires_full_precision: true,
+                    device_local: [device_local; 4],
+                    binding_bytes: Vec::new(),
+                };
+                let sizes = class.buffer_sizes().unwrap();
+                let bytes = scratch_bytes(&sizes).unwrap();
+                let patterns = [
+                    0,
+                    0x8000_0000,
+                    1,
+                    0x0080_0000,
+                    0x3f80_0000,
+                    0xbf80_0000,
+                    0x7f80_0000,
+                    0x7fc0_1234,
+                ];
+                let data: Vec<_> = (0..m as usize * n as usize)
+                    .map(|i| f32::from_bits(patterns[i % patterns.len()]))
+                    .collect();
+                for staging in [TuneStaging::Shared, TuneStaging::Download] {
+                    let mut staging = Staging::new(&gpu, staging, TuneStagingReuse::Fresh);
+                    let mut prep = TunePreparationTimes::default();
+                    let mut cleanup = None;
+                    let mut scratch = Scratch::new(
+                        &class,
+                        &sizes,
+                        sizes.len() - 1,
+                        bytes,
+                        &mut staging,
+                        &mut prep,
+                        &mut cleanup,
+                    );
+                    let mut times = TuneQualificationTimes::default();
+                    scratch.upload(sizes.len() - 1, &data, Some(&mut times));
+                    let read = scratch.read_output(&mut times);
+                    assert_eq!(read.len(), data.len());
+                    assert!(
+                        read.iter()
+                            .zip(&data)
+                            .all(|(a, b)| a.to_bits() == b.to_bits())
+                    );
+                    for time in [
+                        times.upload_host_copy,
+                        times.upload_transfer,
+                        times.readback_transfer,
+                        times.readback_host_copy,
+                    ] {
+                        assert!(time.is_some_and(|time| !time.is_zero()));
+                    }
+                    assert_eq!(times.validation, None);
+                    assert_eq!(times.dispatch, None);
+                    drop(scratch);
+                    assert!(cleanup.is_some_and(|time| !time.is_zero()));
+                }
+            }
+        }
+    }
+
+    #[test]
     fn scratch_cap_counts_staging_and_checks_overflow() {
         assert_eq!(scratch_bytes(&[4, 8, 12]), Some(36));
         assert_eq!(scratch_bytes(&[usize::MAX, 4]), None);
+        assert!(reuse_staging(TuneStagingReuse::SameSize, 12, 12));
+        for (retained, requested) in [(0, 0), (0, 12), (12, 8), (8, 12)] {
+            assert!(!reuse_staging(
+                TuneStagingReuse::SameSize,
+                retained,
+                requested
+            ));
+        }
+        assert!(!reuse_staging(TuneStagingReuse::Fresh, 12, 12));
+    }
+
+    #[test]
+    #[ignore = "GPU exact-size reuse and early-return cleanup qualification"]
+    fn staging_reuse_replaces_sizes_and_cleans_up_after_early_returns() {
+        fn trial(staging: &mut Staging<'_>, n: u32, stamp: u32) -> Result<(), ()> {
+            let class = TuneClass {
+                shader: ShaderEntry::MatMul,
+                m: 3,
+                n,
+                k: 5,
+                conv2d: None,
+                requires_full_precision: false,
+                device_local: [true; 4],
+                binding_bytes: Vec::new(),
+            };
+            let sizes = class.buffer_sizes().unwrap();
+            staging.discard_unmatched(*sizes.iter().max().unwrap());
+            let mut prep = TunePreparationTimes::default();
+            let mut cleanup = None;
+            let result = (|| {
+                let mut scratch = Scratch::new(
+                    &class,
+                    &sizes,
+                    sizes.len() - 1,
+                    scratch_bytes(&sizes).unwrap(),
+                    staging,
+                    &mut prep,
+                    &mut cleanup,
+                );
+                let data: Vec<_> = (0..class.m * class.n)
+                    .map(|i| f32::from_bits(0x7fc0_0000 | (stamp + i)))
+                    .collect();
+                let mut times = TuneQualificationTimes::default();
+                scratch.upload(sizes.len() - 1, &data, Some(&mut times));
+                let read = scratch.read_output(&mut times);
+                if read.len() == data.len()
+                    && read
+                        .iter()
+                        .zip(data)
+                        .all(|(a, b)| a.to_bits() == b.to_bits())
+                {
+                    return Err(());
+                }
+                panic!("stale or corrupted staging data");
+            })();
+            assert!(cleanup.is_some());
+            result
+        }
+        let gpu = crate::init_gpu_context().unwrap();
+        for memory in [TuneStaging::Shared, TuneStaging::Download] {
+            for policy in [TuneStagingReuse::Fresh, TuneStagingReuse::SameSize] {
+                let mut staging = Staging::new(&gpu, memory, policy);
+                for (index, n) in [7, 7, 65, 7].into_iter().enumerate() {
+                    assert!(trial(&mut staging, n, index as u32 * 1024).is_err());
+                }
+                let fresh = policy == TuneStagingReuse::Fresh;
+                assert_eq!(staging.stats.staging_allocations, if fresh { 4 } else { 3 });
+                assert_eq!(staging.stats.staging_reuses, if fresh { 0 } else { 1 });
+                assert_eq!(
+                    staging.stats.peak_bytes,
+                    scratch_bytes(&[60, 1300, 780]).unwrap()
+                );
+                assert_eq!(
+                    staging.stats.retained_staging_bytes,
+                    if fresh { 0 } else { 140 }
+                );
+                staging.clear();
+                assert_eq!(staging.stats.retained_staging_bytes, 0);
+                assert_eq!(
+                    staging.stats.staging_allocations,
+                    staging.stats.staging_releases
+                );
+            }
+        }
     }
 
     #[test]
@@ -554,7 +1858,7 @@ mod tests {
         let dispatch = &plan.dispatches[0];
         assert!(dispatch.use_small_tiles);
         assert_eq!(dispatch.workgroups, [3, 2, 1]);
-        assert!(TuneClass::from_dispatch(dispatch).is_some());
+        assert!(TuneClass::from_dispatch(dispatch, None).is_some());
     }
 
     #[test]
@@ -564,8 +1868,10 @@ mod tests {
             m: 2,
             n: 2,
             k: 3,
+            conv2d: None,
             requires_full_precision: false,
             device_local: [false; 4],
+            binding_bytes: Vec::new(),
         };
         let normal = vec![
             vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -615,31 +1921,46 @@ mod tests {
             },
         );
         let mut alias = crate::memplan::AliasPlan::identity(&plan.buffers);
-        let (classes, excluded) = collect_classes(&plan, &alias);
+        let (classes, excluded) = collect_classes(&plan, &alias, None);
         assert_eq!(excluded, 0);
         assert_eq!(classes.len(), 1);
         assert_eq!(classes[0].members.len(), 2);
         alias.device_local[plan.dispatches[1].output_buffer.0 as usize] = true;
-        assert_eq!(collect_classes(&plan, &alias).0.len(), 2);
+        assert_eq!(collect_classes(&plan, &alias, None).0.len(), 2);
         plan.dispatches[0].input_buffers[1] = plan.dispatches[0].output_buffer;
-        assert_eq!(collect_classes(&plan, &alias).1, 1);
+        assert_eq!(collect_classes(&plan, &alias, None).1, 1);
     }
 
     #[test]
-    fn both_scalar_tiles_generate_valid_exact_binding_layouts() {
+    fn tuning_tiles_generate_valid_exact_binding_layouts() {
         for entry in [
             ShaderEntry::MatMul,
             ShaderEntry::FusedMatMulAdd,
             ShaderEntry::MatMulAT,
             ShaderEntry::MatMulBT,
+            ShaderEntry::Conv2dGradInputGemm,
+            ShaderEntry::Conv2dGradWeightGemm,
         ] {
-            for tile in [MatmulTile::Tile32, MatmulTile::Tile64] {
-                let mut module = match tile {
-                    MatmulTile::Tile32 => {
-                        crate::codegen::generate_module_small(entry.shader_group())
-                    }
-                    MatmulTile::Tile64 => crate::codegen::generate_module(entry.shader_group()),
-                };
+            for tile in [
+                MatmulTile::Tile32,
+                MatmulTile::Tile64,
+                MatmulTile::CooperativeF32 { tile_size: 8 },
+                MatmulTile::CooperativeF32 { tile_size: 16 },
+            ] {
+                let convolution = matches!(
+                    entry,
+                    ShaderEntry::Conv2dGradInputGemm | ShaderEntry::Conv2dGradWeightGemm
+                );
+                if convolution && tile.coop_config().is_some() {
+                    continue;
+                }
+                if convolution {
+                    assert_eq!(
+                        tile_variant(&entry, tile),
+                        Variant::Scalar(tile.shader(&entry))
+                    );
+                }
+                let mut module = tile_module(&entry, tile);
                 // Blade assigns resource bindings by ShaderData field name.
                 // Assign distinct test bindings before full offline validation.
                 for (index, (_, var)) in module.module.global_variables.iter_mut().enumerate() {
@@ -684,10 +2005,13 @@ mod tests {
                     .map(|(_, var)| var.name.as_deref().unwrap())
                     .collect();
                 names.sort_unstable();
-                let expected = if entry == ShaderEntry::FusedMatMulAdd {
-                    vec!["matrix_a", "matrix_b", "matrix_c", "params", "src"]
-                } else {
-                    vec!["matrix_a", "matrix_b", "matrix_c", "params"]
+                let expected = match entry {
+                    ShaderEntry::FusedMatMulAdd => {
+                        vec!["matrix_a", "matrix_b", "matrix_c", "params", "src"]
+                    }
+                    ShaderEntry::Conv2dGradInputGemm => vec!["dst", "grad_out", "params", "weight"],
+                    ShaderEntry::Conv2dGradWeightGemm => vec!["dst", "grad_out", "params", "src"],
+                    _ => vec!["matrix_a", "matrix_b", "matrix_c", "params"],
                 };
                 assert_eq!(names, expected);
             }
@@ -707,8 +2031,10 @@ mod tests {
                 m: 3,
                 n: 5,
                 k: 7,
+                conv2d: None,
                 requires_full_precision: true,
                 device_local: [false; 4],
+                binding_bytes: Vec::new(),
             };
             let sizes = class.buffer_sizes().unwrap();
             for pattern in 0..2 {

--- a/src/shaders/conv2d_gemm.wgsl
+++ b/src/shaders/conv2d_gemm.wgsl
@@ -8,6 +8,8 @@
 //
 // Dispatch: [ceil(oH*oW / 64), ceil(Co / 64), batch]
 
+$DIVISOR
+
 struct Params {
     batch: u32,
     in_channels: u32,
@@ -21,10 +23,10 @@ struct Params {
     out_h: u32,
     out_w: u32,
     padding_w: u32,
-    inv_kernel_w: f32,
-    inv_kernel_hw: f32,
-    inv_col_w: f32,
-    inv_go_spatial: f32,
+    kernel_w_multiplier: u32,
+    kernel_hw_multiplier: u32,
+    column_width_multiplier: u32,
+    output_spatial_multiplier: u32,
 }
 
 var<storage> src: array<f32>;              // input [N, Ci, H, W]
@@ -78,13 +80,13 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
 
             var val = 0.0;
             if k_idx < k_total && hw_idx < n_total {
-                // Decompose k_idx → (ci, kh, kw) via reciprocal multiply
-                let ci = u32(f32(k_idx) * params.inv_kernel_hw);
+                // Decompose k_idx → (ci, kh, kw)
+                let ci = divide_exact(k_idx, kernel_hw, params.kernel_hw_multiplier);
                 let k_rem = k_idx - ci * kernel_hw;
-                let kh = u32(f32(k_rem) * params.inv_kernel_w);
+                let kh = divide_exact(k_rem, params.kernel_w, params.kernel_w_multiplier);
                 let kw = k_rem - kh * params.kernel_w;
                 // Decompose hw_idx → (oh, ow)
-                let oh = u32(f32(hw_idx) * params.inv_col_w);
+                let oh = divide_exact(hw_idx, params.out_w, params.column_width_multiplier);
                 let ow = hw_idx - oh * params.out_w;
                 // Input position
                 let ih = i32(oh * params.stride + kh) - i32(params.padding_h);

--- a/src/shaders/conv2d_grad_input_gemm.wgsl
+++ b/src/shaders/conv2d_grad_input_gemm.wgsl
@@ -1,13 +1,16 @@
 // Conv2d backward w.r.t. input via implicit GEMM.
 //
 // grad_input[n] = weight_T @ im2col(grad_out[n])^T
-// where weight_T[ci, co*kH*kW + kh*kW + kw] = weight[co, ci, kh, kw]
-// and im2col of grad_out uses transposed padding (kH-1-pad, kW-1-pad).
+// where weight_T[ci, co*kH*kW + kh*kW + kw] = weight[co, ci, kh, kw].
+// Invert the forward cross-correlation: ih = oh*stride + kh - padding_h.
+// Thus oh = (ih + padding_h - kh)/stride when divisible, without flipping weights.
 //
 // C[Ci, H*W] = A[Ci, K] × B[K, H*W], K = Co*kH*kW, per batch item.
 // BM=64, BN=64, KTILE=16, TM=4, TN=4, workgroup [16,16,1]
 //
 // Dispatch: [ceil(H*W / 64), ceil(Ci / 64), batch]
+
+$DIVISOR
 
 struct Params {
     batch: u32,
@@ -22,10 +25,10 @@ struct Params {
     out_h: u32,
     out_w: u32,
     padding_w: u32,
-    inv_kernel_w: f32,
-    inv_kernel_hw: f32,
-    inv_col_w: f32,
-    inv_go_spatial: f32,
+    kernel_w_multiplier: u32,
+    kernel_hw_multiplier: u32,
+    column_width_multiplier: u32,
+    output_spatial_multiplier: u32,
 }
 
 var<storage> grad_out: array<f32>;         // grad_output [N, Co, oH, oW]
@@ -50,9 +53,8 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
     let m_total = params.in_channels;               // Ci
     let go_spatial = params.out_h * params.out_w;    // oH * oW
 
-    // Transposed padding for the "flipped convolution"
-    let pad_h = i32(params.kernel_h) - 1 - i32(params.padding_h);
-    let pad_w = i32(params.kernel_w) - 1 - i32(params.padding_w);
+    let pad_h = i32(params.padding_h);
+    let pad_w = i32(params.padding_w);
 
     $ACC_DECL
 
@@ -72,13 +74,11 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
 
             var val = 0.0;
             if ci < m_total && k_idx < k_total {
-                // Decompose k_idx → (co, kh, kw) via reciprocal multiply
-                let co = u32(f32(k_idx) * params.inv_kernel_hw);
+                // Decompose k_idx → (co, kernel offset)
+                let co = divide_exact(k_idx, kernel_hw, params.kernel_hw_multiplier);
                 let k_rem = k_idx - co * kernel_hw;
-                let kh = u32(f32(k_rem) * params.inv_kernel_w);
-                let kw = k_rem - kh * params.kernel_w;
                 // Read weight[co, ci, kh, kw]
-                val = weight[(co * m_total + ci) * kernel_hw + kh * params.kernel_w + kw];
+                val = weight[(co * m_total + ci) * kernel_hw + k_rem];
             }
             shared_a[row_local * 16u + col_local] = val;
         }
@@ -96,11 +96,11 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
 
             var val = 0.0;
             if k_idx < k_total && hw_idx < n_total {
-                let co = u32(f32(k_idx) * params.inv_kernel_hw);
+                let co = divide_exact(k_idx, kernel_hw, params.kernel_hw_multiplier);
                 let k_rem = k_idx - co * kernel_hw;
-                let kh = u32(f32(k_rem) * params.inv_kernel_w);
+                let kh = divide_exact(k_rem, params.kernel_w, params.kernel_w_multiplier);
                 let kw = k_rem - kh * params.kernel_w;
-                let ih = u32(f32(hw_idx) * params.inv_col_w);
+                let ih = divide_exact(hw_idx, params.in_w, params.column_width_multiplier);
                 let iw = hw_idx - ih * params.in_w;
 
                 if params.stride == 1u {

--- a/src/shaders/conv2d_grad_weight_gemm.wgsl
+++ b/src/shaders/conv2d_grad_weight_gemm.wgsl
@@ -6,6 +6,8 @@
 // BM=64, BN=64, KTILE=16, TM=4, TN=4, workgroup [16,16,1]
 // Dispatch: [ceil(Ci*kH*kW / 64), ceil(Co / 64), 1]
 
+$DIVISOR
+
 struct Params {
     batch: u32,
     in_channels: u32,
@@ -19,10 +21,10 @@ struct Params {
     out_h: u32,
     out_w: u32,
     padding_w: u32,
-    inv_kernel_w: f32,
-    inv_kernel_hw: f32,
-    inv_col_w: f32,
-    inv_go_spatial: f32,
+    kernel_w_multiplier: u32,
+    kernel_hw_multiplier: u32,
+    column_width_multiplier: u32,
+    output_spatial_multiplier: u32,
 }
 
 var<storage> grad_out: array<f32>;           // [N, Co, oH, oW]
@@ -33,7 +35,7 @@ var<workgroup> shared_a: array<f32, $SHARED_SIZE>;   // A tile: [64, 16]
 var<workgroup> shared_b: array<f32, $SHARED_SIZE>;   // B tile: [16, 64]
 
 @compute @workgroup_size(16, 16)
-fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
+fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>$COUNTS) {
     let tx = lid.x;
     let ty = lid.y;
     let tile_row = wgid.y * $BM_U;   // M (Co) tile start
@@ -49,9 +51,10 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
 
     $ACC_DECL
 
-    var t = 0u;
+    $K_RANGE
+    var t = $K_START;
     loop {
-        if t >= k_total { break; }
+        if t >= $K_END { break; }
 
         // Load A tile: grad_out_flat[Co, N*oH*oW] → shared_a[64, 16]
         // A[co, n*oH*oW + oh*oW + ow] = grad_out[n, co, oh, ow]
@@ -64,11 +67,9 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
 
             var val = 0.0;
             if co < m_total && k_idx < k_total {
-                let n = u32(f32(k_idx) * params.inv_go_spatial);
+                let n = divide_exact(k_idx, go_spatial, params.output_spatial_multiplier);
                 let rem = k_idx - n * go_spatial;
-                let oh = u32(f32(rem) * params.inv_col_w);
-                let ow = rem - oh * params.out_w;
-                val = grad_out[((n * params.out_channels + co) * params.out_h + oh) * params.out_w + ow];
+                val = grad_out[(n * params.out_channels + co) * go_spatial + rem];
             }
             shared_a[row_local * 16u + col_local] = val;
         }
@@ -85,15 +86,15 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
 
             var val = 0.0;
             if k_idx < k_total && col_idx < n_total {
-                // Decompose k_idx → (n, oh, ow) via reciprocal multiply
-                let n = u32(f32(k_idx) * params.inv_go_spatial);
+                // Decompose k_idx → (n, oh, ow)
+                let n = divide_exact(k_idx, go_spatial, params.output_spatial_multiplier);
                 let rem = k_idx - n * go_spatial;
-                let oh = u32(f32(rem) * params.inv_col_w);
+                let oh = divide_exact(rem, params.out_w, params.column_width_multiplier);
                 let ow = rem - oh * params.out_w;
-                // Decompose col_idx → (ci, kh, kw) via reciprocal multiply
-                let ci = u32(f32(col_idx) * params.inv_kernel_hw);
+                // Decompose col_idx → (ci, kh, kw)
+                let ci = divide_exact(col_idx, kernel_hw, params.kernel_hw_multiplier);
                 let k_rem = col_idx - ci * kernel_hw;
-                let kh = u32(f32(k_rem) * params.inv_kernel_w);
+                let kh = divide_exact(k_rem, params.kernel_w, params.kernel_w_multiplier);
                 let kw = k_rem - kh * params.kernel_w;
                 // Input position
                 let ih = i32(oh * params.stride + kh) - i32(params.padding_h);
@@ -124,7 +125,7 @@ fn main(@builtin(workgroup_id) wgid: vec3<u32>, @builtin(local_invocation_id) li
             let co = tile_row + ty * $TM_U + i;
             let cikk = tile_col + tx * $TM_U + j;
             if co < m_total && cikk < n_total {
-                dst[co * n_total + cikk] = s[i][j];
+                dst[$OUTPUT_OFFSET co * n_total + cikk] = s[i][j];
             }
         }
     }

--- a/src/shaders/divisor.wgsl
+++ b/src/shaders/divisor.wgsl
@@ -1,0 +1,20 @@
+fn multiply_high(a: u32, b: u32) -> u32 {
+    let a_low = a & 0xffffu;
+    let a_high = a >> 16u;
+    let b_low = b & 0xffffu;
+    let b_high = b >> 16u;
+    let low = a_low * b_low;
+    let middle0 = a_high * b_low + (low >> 16u);
+    let middle1 = a_low * b_high + (middle0 & 0xffffu);
+    return a_high * b_high + (middle0 >> 16u) + (middle1 >> 16u);
+}
+
+// For d > 1, multiplier = floor(2^32 / d). The estimate is at most one low.
+fn divide_exact(value: u32, divisor: u32, multiplier: u32) -> u32 {
+    if divisor == 1u {
+        return value;
+    }
+    let quotient = multiply_high(value, multiplier);
+    let remainder = value - quotient * divisor;
+    return quotient + u32(remainder >= divisor);
+}

--- a/src/train.rs
+++ b/src/train.rs
@@ -266,9 +266,10 @@ pub struct SessionConfig<'a> {
     /// policy, and the diagnostic switches (aliasing, device-local,
     /// serial dispatch, plan dumps, buffer pinning).
     pub runtime: runtime::SessionOptions,
-    /// Run [`Session::tune`] after construction: bounded scalar-f32 tile
+    /// Run [`Session::tune`] after construction: bounded f32 matmul tile
     /// selection on private, nonzero scratch. Does not execute the graph or
-    /// advance training state. Cooperative/fused kernels remain heuristic.
+    /// advance training state. Native-f32 cooperative tiles are candidates
+    /// where existing allocations fit; f16-input and complex fusions are excluded.
     /// Environment users opt in through `SessionConfig::from_env()`.
     pub tune: bool,
 }

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1,9 +1,12 @@
 //! Bounded, opt-in kernel selection. See [`crate::Session::tune_with`].
 //!
-//! The first search space is deliberately small: two scalar f32 tiles for
-//! unpacked dense matmuls, with no precision or binding-layout changes.
+//! The search space is deliberately small: scalar and native-f32 cooperative
+//! tiles for unpacked dense matmuls, and scalar convolution derivatives,
+//! with no precision or binding-layout changes.
 //! Measurements use synthetic, private scratch, not a live training step.
+//! Explicit split-K probes measure complete sequences without installing them.
 
+use crate::codegen::CoopConfig;
 use crate::compile::{Dispatch, ShaderEntry};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -16,44 +19,259 @@ pub struct TuneClass {
     pub m: u32,
     pub n: u32,
     pub k: u32,
+    /// Physical NCHW convolution contract; absent for dense matrices.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conv2d: Option<TuneConv2d>,
     pub requires_full_precision: bool,
     /// Placement of A, B, addend (false if absent), and output, respectively.
     pub device_local: [bool; 4],
+    /// Declared bytes for A, B, optional addend, output, in binding order.
+    /// Candidates cannot borrow unused capacity from an aliased allocation.
+    pub binding_bytes: Vec<usize>,
 }
 
-/// Scalar f32 implementations with identical bindings and logical extents.
+/// Exact convolution shape, including both spatial padding dimensions.
+/// Small and large scalar tiles share this key, but directions never do.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TuneConv2d {
+    pub batch: u32,
+    pub in_channels: u32,
+    pub in_h: u32,
+    pub in_w: u32,
+    pub out_channels: u32,
+    pub kernel_h: u32,
+    pub kernel_w: u32,
+    pub stride: u32,
+    pub padding_h: u32,
+    pub out_h: u32,
+    pub out_w: u32,
+    pub padding_w: u32,
+}
+
+impl TuneConv2d {
+    fn from_params(params: &[u32]) -> Option<Self> {
+        let &[
+            batch,
+            in_channels,
+            in_h,
+            in_w,
+            out_channels,
+            kernel_h,
+            kernel_w,
+            stride,
+            padding_h,
+            out_h,
+            out_w,
+            padding_w,
+        ] = params
+        else {
+            return None;
+        };
+        let shape = Self {
+            batch,
+            in_channels,
+            in_h,
+            in_w,
+            out_channels,
+            kernel_h,
+            kernel_w,
+            stride,
+            padding_h,
+            out_h,
+            out_w,
+            padding_w,
+        };
+        if [
+            batch,
+            in_channels,
+            in_h,
+            in_w,
+            out_channels,
+            kernel_h,
+            kernel_w,
+            stride,
+            out_h,
+            out_w,
+        ]
+        .contains(&0)
+            || stride > i32::MAX as u32
+        {
+            return None;
+        }
+        for (input, kernel, padding, output) in [
+            (in_h, kernel_h, padding_h, out_h),
+            (in_w, kernel_w, padding_w, out_w),
+        ] {
+            let padded = input.checked_add(padding.checked_mul(2)?)?;
+            // Both gather directions convert coordinates to signed shader integers.
+            if padded > i32::MAX as u32
+                || kernel > i32::MAX as u32
+                || padded
+                    .checked_sub(kernel)?
+                    .checked_div(stride)?
+                    .checked_add(1)?
+                    != output
+            {
+                return None;
+            }
+        }
+        shape.elements()?;
+        Some(shape)
+    }
+
+    /// Input, weight, upstream gradient: physical elements, not an im2col matrix.
+    fn elements(self) -> Option<[u32; 3]> {
+        Some([
+            self.batch
+                .checked_mul(self.in_channels)?
+                .checked_mul(self.in_h)?
+                .checked_mul(self.in_w)?,
+            self.out_channels
+                .checked_mul(self.in_channels)?
+                .checked_mul(self.kernel_h)?
+                .checked_mul(self.kernel_w)?,
+            self.batch
+                .checked_mul(self.out_channels)?
+                .checked_mul(self.out_h)?
+                .checked_mul(self.out_w)?,
+        ])
+    }
+}
+
+/// f32 implementations with identical bindings and logical extents.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum MatmulTile {
     Tile32,
     Tile64,
+    /// Hardware-native f32 operands/accumulators, never f16 staging.
+    CooperativeF32 {
+        tile_size: u32,
+    },
 }
 
 impl MatmulTile {
-    pub(crate) fn other(self) -> Self {
+    pub(crate) fn native_cooperative(config: Option<&CoopConfig>) -> Option<Self> {
+        let config = config?;
+        if config.use_f16_input || config.compensated || !matches!(config.tile_size, 8 | 16) {
+            return None;
+        }
+        Some(Self::CooperativeF32 {
+            tile_size: config.tile_size,
+        })
+    }
+
+    pub(crate) fn selected(dispatch: &Dispatch, config: Option<&CoopConfig>) -> Option<Self> {
+        if dispatch.use_coop {
+            Self::native_cooperative(config)
+        } else if dispatch.use_small_tiles
+            || matches!(
+                dispatch.shader,
+                ShaderEntry::Conv2dGradInputGemmSmall | ShaderEntry::Conv2dGradWeightGemmSmall
+            )
+        {
+            Some(Self::Tile32)
+        } else {
+            Some(Self::Tile64)
+        }
+    }
+
+    pub(crate) fn coop_config(self) -> Option<CoopConfig> {
         match self {
-            Self::Tile32 => Self::Tile64,
-            Self::Tile64 => Self::Tile32,
+            Self::CooperativeF32 { tile_size } => Some(CoopConfig {
+                tile_size,
+                use_f16_input: false,
+                compensated: false,
+            }),
+            _ => None,
         }
     }
 
     pub(crate) fn apply(self, dispatch: &mut Dispatch, class: &TuneClass) {
-        dispatch.use_small_tiles = self == Self::Tile32;
+        dispatch.shader = self.shader(&class.shader);
+        dispatch.use_small_tiles = class.conv2d.is_none() && self == Self::Tile32;
+        dispatch.use_coop = matches!(self, Self::CooperativeF32 { .. });
+        dispatch.use_coop_compensated = false;
+        dispatch.scalar_fallback = dispatch
+            .use_coop
+            .then(|| (dispatch.shader.clone(), Self::Tile64.workgroups(class)));
         dispatch.workgroups = self.workgroups(class);
+    }
+
+    pub(crate) fn shader(self, entry: &ShaderEntry) -> ShaderEntry {
+        match (entry, self) {
+            (&ShaderEntry::Conv2dGradInputGemm, Self::Tile32) => {
+                ShaderEntry::Conv2dGradInputGemmSmall
+            }
+            (&ShaderEntry::Conv2dGradWeightGemm, Self::Tile32) => {
+                ShaderEntry::Conv2dGradWeightGemmSmall
+            }
+            _ => entry.clone(),
+        }
     }
 
     fn workgroups(self, class: &TuneClass) -> [u32; 3] {
         let tile = match self {
             Self::Tile32 => 32,
             Self::Tile64 => 64,
+            Self::CooperativeF32 { tile_size } => {
+                let tile = 2 * tile_size;
+                // Cooperative tiles use X for rows, Y for columns.
+                return [class.m.div_ceil(tile), class.n.div_ceil(tile), 1];
+            }
         };
         // Scalar tiled kernels use X for columns, Y for rows. Derive exact
         // geometry; doubling rounded 64-tile counts overdispatches edges.
-        [class.n.div_ceil(tile), class.m.div_ceil(tile), 1]
+        [
+            class.n.div_ceil(tile),
+            class.m.div_ceil(tile),
+            class.batch_dispatches(),
+        ]
+    }
+
+    pub(crate) fn buffer_sizes(self, class: &TuneClass) -> Option<Vec<usize>> {
+        let mut sizes = class.buffer_sizes()?;
+        if let Self::CooperativeF32 { tile_size } = self {
+            if class.conv2d.is_some()
+                || !matches!(tile_size, 8 | 16)
+                || !class.n.is_multiple_of(16)
+                || (matches!(
+                    class.shader,
+                    ShaderEntry::MatMul | ShaderEntry::FusedMatMulAdd
+                ) && class.k < 4)
+            {
+                return None;
+            }
+            let tile = 2 * tile_size;
+            let padded_m = class.m.div_ceil(tile).checked_mul(tile)?;
+            let padded_n = class.n.div_ceil(tile).checked_mul(tile)?;
+            let bytes = usize::try_from(padded_m.checked_mul(padded_n)?)
+                .ok()?
+                .checked_mul(4)?;
+            *sizes.last_mut()? = bytes;
+            if class.has_addend() {
+                sizes[2] = bytes;
+            }
+        }
+        if self.workgroups(class).iter().any(|&n| n == 0 || n > 65_535) {
+            return None;
+        }
+        Some(sizes)
+    }
+
+    pub(crate) fn fits(self, class: &TuneClass) -> bool {
+        let Some(sizes) = self.buffer_sizes(class) else {
+            return false;
+        };
+        sizes.len() == class.binding_bytes.len()
+            && sizes
+                .iter()
+                .zip(&class.binding_bytes)
+                .all(|(required, available)| required <= available)
     }
 }
 
 impl TuneClass {
-    pub(crate) fn from_dispatch(dispatch: &Dispatch) -> Option<Self> {
+    pub(crate) fn from_dispatch(dispatch: &Dispatch, config: Option<&CoopConfig>) -> Option<Self> {
         let addend = dispatch.shader == ShaderEntry::FusedMatMulAdd;
         if !matches!(
             dispatch.shader,
@@ -61,8 +279,12 @@ impl TuneClass {
                 | ShaderEntry::FusedMatMulAdd
                 | ShaderEntry::MatMulAT
                 | ShaderEntry::MatMulBT
-        ) || dispatch.use_coop
-            || dispatch.use_coop_compensated
+                | ShaderEntry::Conv2dGradInputGemm
+                | ShaderEntry::Conv2dGradInputGemmSmall
+                | ShaderEntry::Conv2dGradWeightGemm
+                | ShaderEntry::Conv2dGradWeightGemmSmall
+        ) || dispatch.use_coop_compensated
+            || (dispatch.use_coop && dispatch.use_small_tiles)
             || dispatch.weight_format.uses_reduced_storage()
             || dispatch.horizontal_batch >= 2
             || dispatch.matmul_prologue.is_some()
@@ -74,45 +296,101 @@ impl TuneClass {
             || dispatch.pointwise.is_some()
             || dispatch.reduction.is_some()
             || dispatch.input_buffers.len() != if addend { 3 } else { 2 }
-            || dispatch.workgroups[2] != 1
-            || dispatch.params.len() != 4
-            || dispatch.params[3] != 0
         {
             return None;
         }
-        let (m, n, k) = match dispatch.shader {
-            ShaderEntry::MatMul | ShaderEntry::FusedMatMulAdd => {
-                (dispatch.params[0], dispatch.params[2], dispatch.params[1])
-            }
-            _ => (dispatch.params[0], dispatch.params[1], dispatch.params[2]),
+        let shader = match dispatch.shader {
+            ShaderEntry::Conv2dGradInputGemmSmall => ShaderEntry::Conv2dGradInputGemm,
+            ShaderEntry::Conv2dGradWeightGemmSmall => ShaderEntry::Conv2dGradWeightGemm,
+            _ => dispatch.shader.clone(),
         };
-        if m == 0 || n == 0 || k == 0 || m.div_ceil(32) > 65_535 || n.div_ceil(32) > 65_535 {
+        let conv2d = if matches!(
+            shader,
+            ShaderEntry::Conv2dGradInputGemm | ShaderEntry::Conv2dGradWeightGemm
+        ) {
+            if dispatch.use_coop || dispatch.use_small_tiles || dispatch.scalar_fallback.is_some() {
+                return None;
+            }
+            Some(TuneConv2d::from_params(&dispatch.params)?)
+        } else {
+            if dispatch.workgroups[2] != 1 || dispatch.params.len() != 4 || dispatch.params[3] != 0
+            {
+                return None;
+            }
+            None
+        };
+        let (m, n, k) = if let Some(s) = conv2d {
+            let kernel = s.kernel_h.checked_mul(s.kernel_w)?;
+            if shader == ShaderEntry::Conv2dGradInputGemm {
+                let n = s.in_h.checked_mul(s.in_w)?;
+                let k = s.out_channels.checked_mul(kernel)?;
+                (s.in_channels, n, k)
+            } else {
+                let n = s.in_channels.checked_mul(kernel)?;
+                let spatial = s.out_h.checked_mul(s.out_w)?;
+                let k = s.batch.checked_mul(spatial)?;
+                (s.out_channels, n, k)
+            }
+        } else if matches!(shader, ShaderEntry::MatMul | ShaderEntry::FusedMatMulAdd) {
+            (dispatch.params[0], dispatch.params[2], dispatch.params[1])
+        } else {
+            (dispatch.params[0], dispatch.params[1], dispatch.params[2])
+        };
+        // Scalar K loops advance by 16, including the final padded tile.
+        if m == 0
+            || n == 0
+            || k == 0
+            || k > u32::MAX - 15
+            || m.div_ceil(32) > 65_535
+            || n.div_ceil(32) > 65_535
+        {
             return None;
         }
         let class = Self {
-            shader: dispatch.shader.clone(),
+            shader,
             m,
             n,
             k,
+            conv2d,
             requires_full_precision: dispatch.requires_full_precision,
             device_local: [false; 4],
+            binding_bytes: Vec::new(),
         };
-        let initial = if dispatch.use_small_tiles {
-            MatmulTile::Tile32
-        } else {
-            MatmulTile::Tile64
-        };
-        (dispatch.workgroups == initial.workgroups(&class)).then_some(class)
+        let initial = MatmulTile::selected(dispatch, config)?;
+        (initial.buffer_sizes(&class).is_some()
+            && dispatch.workgroups == initial.workgroups(&class))
+        .then_some(class)
     }
 
     pub(crate) fn has_addend(&self) -> bool {
         self.shader == ShaderEntry::FusedMatMulAdd
     }
 
+    pub(crate) fn batch_dispatches(&self) -> u32 {
+        if self.shader == ShaderEntry::Conv2dGradInputGemm {
+            self.conv2d.expect("convolution class").batch
+        } else {
+            1
+        }
+    }
+
+    pub(crate) fn output_elements(&self) -> usize {
+        self.m as usize * self.n as usize * self.batch_dispatches() as usize
+    }
+
     /// A, B, optional addend, output sizes. Reject u32 shader-index overflow,
     /// not just host allocation overflow.
     pub(crate) fn buffer_sizes(&self) -> Option<Vec<usize>> {
         let bytes = |a: u32, b: u32| usize::try_from(a.checked_mul(b)?).ok()?.checked_mul(4);
+        if let Some(s) = self.conv2d {
+            let [input, weight, upstream] = s.elements()?;
+            let (b, output) = if self.shader == ShaderEntry::Conv2dGradInputGemm {
+                (weight, input)
+            } else {
+                (input, weight)
+            };
+            return Some(vec![bytes(upstream, 1)?, bytes(b, 1)?, bytes(output, 1)?]);
+        }
         let mut sizes = vec![bytes(self.m, self.k)?, bytes(self.k, self.n)?];
         if self.has_addend() {
             sizes.push(bytes(self.m, self.n)?);
@@ -120,21 +398,94 @@ impl TuneClass {
         sizes.push(bytes(self.m, self.n)?);
         Some(sizes)
     }
+
+    /// A small deterministic tournament: scalar alternative first, then
+    /// native f32 where it fits. Capability/precision/padding are legality;
+    /// occupancy and the static large-shape veto do not exclude candidates.
+    pub(crate) fn challengers(
+        &self,
+        initial: MatmulTile,
+        config: Option<&CoopConfig>,
+    ) -> Vec<MatmulTile> {
+        [
+            Some(MatmulTile::Tile64),
+            Some(MatmulTile::Tile32),
+            MatmulTile::native_cooperative(config),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|&tile| tile != initial && tile.fits(self))
+        .collect()
+    }
+}
+
+/// Restrict an experiment without changing any candidate's legality or precision.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TuneScope {
+    /// Historical search domain, also used for missing report settings.
+    #[default]
+    Dense,
+    /// Scalar input and weight gradients only; no forward or cooperative convolution.
+    ConvDerivatives,
+    All,
+}
+
+impl TuneScope {
+    pub(crate) fn includes(self, class: &TuneClass) -> bool {
+        self == Self::All || (class.conv2d.is_some() == (self == Self::ConvDerivatives))
+    }
+}
+
+/// Placement of the private upload/readback buffer, never the kernel bindings.
+/// Its default preserves historical reports; new [`TuneOptions`] use Download.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TuneStaging {
+    /// Original bidirectional, GPU-preferred shared staging.
+    #[default]
+    Shared,
+    /// Host-read-optimized staging; still used for uploads as well as readbacks.
+    Download,
+}
+
+/// Lifetime of one private staging buffer, never of bindings or qualified data.
+/// Its default preserves historical reports; new [`TuneOptions`] use SameSize.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TuneStagingReuse {
+    /// Allocate and destroy staging for every comparison (historical policy).
+    #[default]
+    Fresh,
+    /// Keep one exact-size buffer between comparisons within this tuning call.
+    /// Release on a size change and before returning; never retain extra capacity.
+    SameSize,
 }
 
 /// Resource bounds and decision policy for [`crate::Session::tune_with`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TuneOptions {
+    /// Defaults to All. Historical missing settings retain Dense.
+    #[serde(default)]
+    pub scope: TuneScope,
     pub max_classes: usize,
-    /// GPU scratch including the shared upload/readback buffer, not pipelines.
+    /// GPU scratch including the upload/readback buffer, not pipelines.
     pub max_scratch_bytes: usize,
+    /// Defaults to Download. Does not alter scratch binding placement,
+    /// validation or kernel candidates.
+    /// Missing historical settings deserialize to the original shared staging.
+    #[serde(default)]
+    pub staging: TuneStaging,
+    /// Defaults to SameSize. Reuses only private staging, without changing
+    /// validation or scratch bounds.
+    /// Historical missing settings retain Fresh.
+    #[serde(default)]
+    pub staging_reuse: TuneStagingReuse,
     /// Soft wall-clock deadline, including compilation and qualification.
     /// An in-flight driver call, GPU submission, or validation cannot be preempted.
     pub max_time: Duration,
     pub warmup_runs: u32,
     /// Complete, alternating baseline/candidate pairs required for a decision.
     pub sample_pairs: usize,
-    /// Separate, barrier-delimited dispatches in each timed submission.
+    /// Separate, barrier-delimited dispatches in each timed submission;
+    /// complete sequences for explicit split-K measurements.
     pub dispatches_per_sample: u32,
     /// Required fractional improvement, in addition to a noise margin.
     pub min_improvement: f64,
@@ -143,8 +494,11 @@ pub struct TuneOptions {
 impl Default for TuneOptions {
     fn default() -> Self {
         Self {
+            scope: TuneScope::All,
             max_classes: 8,
             max_scratch_bytes: 64 * 1024 * 1024,
+            staging: TuneStaging::Download,
+            staging_reuse: TuneStagingReuse::SameSize,
             max_time: Duration::from_secs(2),
             warmup_runs: 1,
             sample_pairs: 6,
@@ -193,21 +547,105 @@ pub enum TuneDecision {
     TimeBudget,
     ScratchLimit,
     DeviceMemoryBudget,
+    ShaderRejected,
 }
 
-/// Evidence for one exact class. Times are batched scratch wall times per
-/// dispatch, not GPU timestamps or predicted whole-step latency.
+/// Non-overlapping host wall-time phases within one candidate comparison.
+/// `None` means the phase was not reached; an early exit records partial time.
+/// Their sum excludes final decision bookkeeping. Historical reports did not
+/// measure cleanup; missing measurements are not zero cost.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TunePhaseTimes {
+    /// Legality/budget checks, pipeline setup, scratch allocation and bindings.
+    /// Includes [`TuneOutcome::compile_time`]; do not add that timer again.
+    pub preparation: Option<Duration>,
+    /// Nested accounting, already inside `preparation`.
+    #[serde(default)]
+    pub preparation_breakdown: Option<TunePreparationTimes>,
+    /// Input generation, uploads, trial dispatches, readbacks and CPU checks.
+    pub qualification: Option<Duration>,
+    /// Nested accounting, already inside `qualification`; never add it twice.
+    /// `None` means an older report or qualification was not reached.
+    #[serde(default)]
+    pub qualification_breakdown: Option<TuneQualificationTimes>,
+    /// Restoring ordinary-magnitude scratch inputs and warming both variants.
+    pub warmup: Option<Duration>,
+    /// Paired timing loop, including incomplete/discarded pairs and host checks.
+    /// Not the sum of accepted per-dispatch samples or GPU timestamp duration.
+    pub sampling: Option<Duration>,
+    /// Destruction of private comparison resources, including early exits.
+    /// Retained staging is released separately in [`TuneReport::final_cleanup`].
+    #[serde(default)]
+    pub cleanup: Option<Duration>,
+}
+
+/// Disjoint host wall times within preparation, not GPU timestamps.
+/// `None` means historical/unreached work; repeated operations accumulate.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TunePreparationTimes {
+    pub checks: Option<Duration>,
+    /// Same measurement as [`TuneOutcome::compile_time`]; do not add it twice.
+    pub pipelines: Option<Duration>,
+    /// Candidate binding allocations with matching memory placement.
+    pub buffers: Option<Duration>,
+    /// Private staging allocation/reuse and release of a previous size.
+    pub staging: Option<Duration>,
+    pub encoder: Option<Duration>,
+    /// Dispatch cloning, geometry and pipeline lookup, not GPU execution.
+    pub bindings: Option<Duration>,
+}
+
+/// Accumulated, disjoint host wall times within qualification, not GPU timestamps.
+/// Repeated operations add to each field; `None` means the operation was not
+/// reached. Early returns preserve partial time. Bookkeeping and destruction
+/// outside these scopes remain in the enclosing qualification time.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TuneQualificationTimes {
+    /// Deterministic inputs, padding and NaN output sentinels.
+    pub input_preparation: Option<Duration>,
+    /// CPU copy into mapped staging memory.
+    pub upload_host_copy: Option<Duration>,
+    /// Upload encoding, transfer, submission and wait.
+    pub upload_transfer: Option<Duration>,
+    /// Candidate encoding, dispatch, submission and wait.
+    pub dispatch: Option<Duration>,
+    /// Readback encoding, transfer, submission and wait.
+    pub readback_transfer: Option<Duration>,
+    /// Host vector allocation and CPU copy out of mapped staging memory.
+    pub readback_host_copy: Option<Duration>,
+    /// Full-output finite/parity scans and sampled f64 reference dots.
+    pub validation: Option<Duration>,
+}
+
+/// Evidence for one candidate comparison within an exact class. Times are
+/// batched scratch wall times per dispatch (per complete sequence when
+/// `candidate_split_k` is present), not GPU timestamps or whole-step latency.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TuneOutcome {
     pub class: TuneClass,
     pub dispatches: usize,
     pub initial: MatmulTile,
+    pub candidate: MatmulTile,
     pub selected: MatmulTile,
+    /// Experimental two-pass dW challenger; baseline is unsplit with the same
+    /// tile. Times are per complete sequence. `decision` reports the result;
+    /// no live plan is changed and `selected` still describes only the tile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_split_k: Option<u32>,
     pub decision: TuneDecision,
     pub qualified: bool,
-    /// Total class cost, including pipeline setup, qualification and timing.
+    /// Shader rejection or the candidate/input pattern that failed qualification.
+    pub failure: Option<String>,
+    /// Total comparison cost, including pipeline setup, qualification and timing.
     pub elapsed: Duration,
     pub compile_time: Duration,
+    /// Phase accounting is absent in reports written before this instrumentation.
+    /// Never reinterpret missing historical measurements as zero-cost phases.
+    #[serde(default)]
+    pub phase_times: Option<TunePhaseTimes>,
+    /// Actual private allocation requests; absent for historical/skipped work.
+    #[serde(default)]
+    pub scratch: Option<TuneScratchUsage>,
     pub baseline_ms: Vec<f64>,
     pub candidate_ms: Vec<f64>,
     pub baseline_median_ms: Option<f64>,
@@ -217,15 +655,74 @@ pub struct TuneOutcome {
     pub noise_margin_ms: Option<f64>,
 }
 
+impl TuneOutcome {
+    pub(crate) fn new(
+        class: TuneClass,
+        dispatches: usize,
+        initial: MatmulTile,
+        candidate: MatmulTile,
+    ) -> Self {
+        Self {
+            class,
+            dispatches,
+            initial,
+            candidate,
+            selected: initial,
+            candidate_split_k: None,
+            decision: TuneDecision::KeepBaseline,
+            qualified: false,
+            failure: None,
+            elapsed: Duration::ZERO,
+            compile_time: Duration::ZERO,
+            phase_times: Some(Default::default()),
+            scratch: None,
+            baseline_ms: Vec::new(),
+            candidate_ms: Vec::new(),
+            baseline_median_ms: None,
+            candidate_median_ms: None,
+            noise_margin_ms: None,
+        }
+    }
+}
+
+/// Per-comparison buffer requests, not driver heap sizes or peak VRAM.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TuneScratchUsage {
+    pub binding_bytes: Vec<usize>,
+    pub staging_bytes: usize,
+    pub staging_reused: bool,
+}
+
+/// Private staging lifetime and peak simultaneous scratch requests in one call.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TuneScratchStats {
+    pub staging_allocations: usize,
+    pub staging_reuses: usize,
+    pub staging_releases: usize,
+    /// Binding requests plus the one staging buffer, never pipelines/driver heaps.
+    pub peak_bytes: usize,
+    /// Must be zero when `tune_with` returns, including bounded/failed searches.
+    pub retained_staging_bytes: usize,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct TuneReport {
     pub options: TuneOptions,
     pub outcomes: Vec<TuneOutcome>,
     pub eligible_classes: usize,
+    /// Live tile search has up to two challengers per class; explicit split-K
+    /// probes accept up to four counts against the same unsplit control.
+    pub visited_classes: usize,
     pub excluded_dispatches: usize,
     pub class_limit_reached: bool,
     pub time_budget_exhausted: bool,
     pub elapsed: Duration,
+    /// Release of staging retained across comparisons, within total `elapsed`.
+    /// None for historical reports or when no buffer remained to release.
+    #[serde(default)]
+    pub final_cleanup: Option<Duration>,
+    #[serde(default)]
+    pub scratch: Option<TuneScratchStats>,
 }
 
 pub(crate) fn median(values: &[f64]) -> f64 {
@@ -304,7 +801,7 @@ pub(crate) fn decide(outcome: &mut TuneOutcome, options: &TuneOptions) {
         && baseline - candidate > baseline * options.min_improvement + noise
         && gain > baseline * options.min_improvement + noise
     {
-        outcome.selected = outcome.initial.other();
+        outcome.selected = outcome.candidate;
         outcome.decision = TuneDecision::FasterCandidate;
     } else {
         outcome.decision = TuneDecision::KeepBaseline;
@@ -328,7 +825,7 @@ mod tests {
     #[test]
     fn complete_geometry_handles_edges_in_both_directions() {
         let mut d = dispatch();
-        let class = TuneClass::from_dispatch(&d).unwrap();
+        let class = TuneClass::from_dispatch(&d, None).unwrap();
         assert_eq!((class.m, class.n, class.k), (33, 65, 17));
         MatmulTile::Tile32.apply(&mut d, &class);
         assert_eq!(d.workgroups, [3, 2, 1]);
@@ -341,7 +838,7 @@ mod tests {
     #[test]
     fn class_separates_shape_direction_precision_and_placement() {
         let d = dispatch();
-        let base = TuneClass::from_dispatch(&d).unwrap();
+        let base = TuneClass::from_dispatch(&d, None).unwrap();
         let mut changed = base.clone();
         changed.k += 1;
         assert_ne!(base, changed);
@@ -351,10 +848,13 @@ mod tests {
         changed = base.clone();
         changed.requires_full_precision = true;
         assert_ne!(base, changed);
+        changed = base.clone();
+        changed.binding_bytes = vec![4096; 3];
+        assert_ne!(base, changed);
         let mut at = d;
         at.shader = ShaderEntry::MatMulAT;
         at.params = vec![33, 65, 17, 0];
-        let at_class = TuneClass::from_dispatch(&at).unwrap();
+        let at_class = TuneClass::from_dispatch(&at, None).unwrap();
         assert_eq!((at_class.m, at_class.n, at_class.k), (33, 65, 17));
         assert_ne!(base, at_class);
     }
@@ -374,11 +874,175 @@ mod tests {
         variants[8].params[0] = 32 * 65_535 + 1;
         variants[9].workgroups = [1, 2, 1]; // wrong row/column geometry
         for d in variants {
-            assert!(TuneClass::from_dispatch(&d).is_none());
+            assert!(TuneClass::from_dispatch(&d, None).is_none());
         }
-        let mut class = TuneClass::from_dispatch(&base).unwrap();
+        let mut class = TuneClass::from_dispatch(&base, None).unwrap();
         class.m = u32::MAX;
         assert!(class.buffer_sizes().is_none());
+    }
+
+    fn conv_dispatch(shader: ShaderEntry) -> Dispatch {
+        let mut d = dispatch();
+        d.shader = shader;
+        d.use_small_tiles = false;
+        d.params = vec![2, 3, 7, 9, 5, 3, 2, 2, 0, 3, 5, 1];
+        d.workgroups = if d.shader == ShaderEntry::Conv2dGradInputGemm {
+            [1, 1, 2]
+        } else {
+            [1, 1, 1]
+        };
+        d
+    }
+
+    #[test]
+    fn conv_tiles_preserve_complete_nchw_contracts() {
+        for shader in [
+            ShaderEntry::Conv2dGradInputGemm,
+            ShaderEntry::Conv2dGradWeightGemm,
+        ] {
+            let mut d = conv_dispatch(shader.clone());
+            let original = d.clone();
+            let mut class = TuneClass::from_dispatch(&d, None).unwrap();
+            let dx = shader == ShaderEntry::Conv2dGradInputGemm;
+            assert_eq!(
+                (class.m, class.n, class.k),
+                if dx { (3, 63, 30) } else { (5, 18, 30) }
+            );
+            class.binding_bytes = class.buffer_sizes().unwrap();
+            assert_eq!(
+                class.binding_bytes,
+                if dx {
+                    vec![600, 360, 1512]
+                } else {
+                    vec![600, 1512, 360]
+                }
+            );
+            assert_eq!(class.output_elements(), if dx { 378 } else { 90 });
+            assert_eq!(
+                class.challengers(MatmulTile::Tile64, Some(&native_config(16))),
+                [MatmulTile::Tile32]
+            );
+            assert!(!MatmulTile::CooperativeF32 { tile_size: 16 }.fits(&class));
+            MatmulTile::Tile32.apply(&mut d, &class);
+            assert_eq!(
+                d.shader,
+                if dx {
+                    ShaderEntry::Conv2dGradInputGemmSmall
+                } else {
+                    ShaderEntry::Conv2dGradWeightGemmSmall
+                }
+            );
+            assert_eq!(d.workgroups, if dx { [2, 1, 2] } else { [1, 1, 1] });
+            assert!(!d.use_small_tiles && !d.use_coop && d.scalar_fallback.is_none());
+            assert_eq!(MatmulTile::selected(&d, None), Some(MatmulTile::Tile32));
+            let small = TuneClass::from_dispatch(&d, None).unwrap();
+            let mut expected = class.clone();
+            expected.binding_bytes.clear();
+            assert_eq!(small, expected);
+            MatmulTile::Tile64.apply(&mut d, &class);
+            assert_eq!(d, original);
+            for binding in 0..3 {
+                let mut short = class.clone();
+                short.binding_bytes[binding] -= 4;
+                assert!(!MatmulTile::Tile32.fits(&short));
+                assert!(!MatmulTile::Tile64.fits(&short));
+            }
+            let mut swapped_kernel = class.clone();
+            let shape = swapped_kernel.conv2d.as_mut().unwrap();
+            std::mem::swap(&mut shape.kernel_h, &mut shape.kernel_w);
+            assert_ne!(swapped_kernel, class); // same GEMM shape is insufficient
+        }
+    }
+
+    #[test]
+    fn malformed_or_unsupported_convolutions_are_excluded() {
+        for shader in [
+            ShaderEntry::Conv2dGradInputGemm,
+            ShaderEntry::Conv2dGradWeightGemm,
+        ] {
+            let base = conv_dispatch(shader);
+            let mut variants = vec![base; 17];
+            variants[0].use_small_tiles = true;
+            variants[1].use_coop = true;
+            variants[2].scalar_fallback = Some((ShaderEntry::MatMul, [1; 3]));
+            variants[3].params.pop();
+            variants[4].params[7] = 0;
+            variants[5].params[9] += 1;
+            variants[6].params[11] = u32::MAX;
+            variants[7].params[2] = u32::MAX;
+            variants[8].workgroups[0] += 1;
+            variants[9].workgroups[2] += 1;
+            variants[10].params[0] = 0;
+            variants[11].params[1] = u32::MAX;
+            variants[12].weight_format = crate::compile::WeightFormat::F16;
+            variants[13].shader = ShaderEntry::Conv2dGradInputGemmCoopGen(3, 2, 2);
+            variants[14].shader = ShaderEntry::Conv2dGemm;
+            variants[15].input_buffers.pop();
+            variants[16].params[5] = 100;
+            for d in variants {
+                assert!(TuneClass::from_dispatch(&d, None).is_none(), "{d:?}");
+            }
+        }
+        let mut d = conv_dispatch(ShaderEntry::Conv2dGradInputGemm);
+        d.params[0] = 65_536;
+        d.workgroups[2] = 65_536;
+        assert!(TuneClass::from_dispatch(&d, None).is_none());
+    }
+
+    #[test]
+    fn convolution_indexing_does_not_require_exact_f32_reciprocals() {
+        for divisor in [41, 47, 55] {
+            assert_eq!((divisor as f32 * (1.0 / divisor as f32)) as u32, 0);
+            for shader in [
+                ShaderEntry::Conv2dGradInputGemm,
+                ShaderEntry::Conv2dGradWeightGemm,
+            ] {
+                let mut d = conv_dispatch(shader);
+                d.params = vec![2, 3, 1, divisor, 5, 1, 1, 1, 0, 1, divisor, 0];
+                assert!(TuneClass::from_dispatch(&d, None).is_some(), "{d:?}");
+            }
+        }
+        // No f32 integer-domain limit, but a padded K loop must not wrap u32.
+        let mut d = conv_dispatch(ShaderEntry::Conv2dGradWeightGemm);
+        for (batch, width, admitted) in [(2, (1 << 23) + 1, true), (65_535, 65_537, false)] {
+            d.params = vec![batch, 1, 1, width, 1, 1, 1, 1, 0, 1, width, 0];
+            assert_eq!(TuneClass::from_dispatch(&d, None).is_some(), admitted);
+        }
+    }
+
+    #[test]
+    fn scope_and_convolution_contracts_preserve_historical_reports() {
+        assert_eq!(TuneOptions::default().scope, TuneScope::All);
+        let dense = class(3, 5, 7);
+        let conv = TuneClass::from_dispatch(&conv_dispatch(ShaderEntry::Conv2dGradInputGemm), None)
+            .unwrap();
+        for scope in [TuneScope::Dense, TuneScope::ConvDerivatives, TuneScope::All] {
+            assert_eq!(scope.includes(&dense), scope != TuneScope::ConvDerivatives);
+            assert_eq!(scope.includes(&conv), scope != TuneScope::Dense);
+            let options = TuneOptions {
+                scope,
+                ..Default::default()
+            };
+            let mut json = serde_json::to_value(&options).unwrap();
+            assert_eq!(
+                serde_json::from_value::<TuneOptions>(json.clone())
+                    .unwrap()
+                    .scope,
+                scope
+            );
+            json.as_object_mut().unwrap().remove("scope");
+            assert_eq!(
+                serde_json::from_value::<TuneOptions>(json).unwrap().scope,
+                TuneScope::Dense
+            );
+        }
+        let old = serde_json::to_value(&dense).unwrap();
+        assert!(old.get("conv2d").is_none());
+        assert_eq!(serde_json::from_value::<TuneClass>(old).unwrap(), dense);
+        assert_eq!(
+            serde_json::from_value::<TuneClass>(serde_json::to_value(&conv).unwrap()).unwrap(),
+            conv
+        );
     }
 
     #[test]
@@ -395,14 +1059,19 @@ mod tests {
 
     fn outcome() -> TuneOutcome {
         TuneOutcome {
-            class: TuneClass::from_dispatch(&dispatch()).unwrap(),
+            class: TuneClass::from_dispatch(&dispatch(), None).unwrap(),
             dispatches: 3,
             initial: MatmulTile::Tile32,
+            candidate: MatmulTile::Tile64,
             selected: MatmulTile::Tile32,
+            candidate_split_k: None,
             decision: TuneDecision::KeepBaseline,
             qualified: true,
+            failure: None,
             elapsed: Duration::ZERO,
             compile_time: Duration::ZERO,
+            phase_times: None,
+            scratch: None,
             baseline_ms: vec![10.0; 6],
             candidate_ms: vec![8.0; 6],
             baseline_median_ms: None,
@@ -420,6 +1089,7 @@ mod tests {
         assert_eq!(win.decision, TuneDecision::FasterCandidate);
         let mut reverse = outcome();
         reverse.initial = MatmulTile::Tile64;
+        reverse.candidate = MatmulTile::Tile32;
         reverse.selected = MatmulTile::Tile64;
         decide(&mut reverse, &options);
         assert_eq!(reverse.selected, MatmulTile::Tile32);
@@ -481,5 +1151,221 @@ mod tests {
         );
         assert_eq!(restored.options.max_time, report.options.max_time);
         assert_eq!(restored.outcomes[0].class, report.outcomes[0].class);
+    }
+
+    #[test]
+    fn phase_times_distinguish_legacy_missing_unreached_and_measured() {
+        let mut outcome = outcome();
+        outcome.phase_times = Some(TunePhaseTimes {
+            preparation: Some(Duration::from_millis(3)),
+            preparation_breakdown: Some(TunePreparationTimes {
+                buffers: Some(Duration::from_millis(1)),
+                ..Default::default()
+            }),
+            qualification: Some(Duration::ZERO),
+            cleanup: Some(Duration::from_millis(1)),
+            qualification_breakdown: Some(TuneQualificationTimes {
+                upload_host_copy: Some(Duration::ZERO),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        let mut json = serde_json::to_value(&outcome).unwrap();
+        let restored: TuneOutcome = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(restored.phase_times, outcome.phase_times);
+        for key in ["preparation_breakdown", "cleanup"] {
+            json["phase_times"].as_object_mut().unwrap().remove(key);
+        }
+        let older: TuneOutcome = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(older.phase_times.unwrap().preparation_breakdown, None);
+        assert_eq!(older.phase_times.unwrap().cleanup, None);
+        json["phase_times"]
+            .as_object_mut()
+            .unwrap()
+            .remove("qualification_breakdown");
+        let older: TuneOutcome = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(older.phase_times.unwrap().qualification_breakdown, None);
+        json.as_object_mut().unwrap().remove("phase_times");
+        let legacy: TuneOutcome = serde_json::from_value(json).unwrap();
+        assert_eq!(legacy.phase_times, None);
+    }
+
+    #[test]
+    fn staging_round_trips_and_missing_historical_policy_is_shared() {
+        assert_eq!(TuneOptions::default().staging, TuneStaging::Download);
+        assert_eq!(TuneStaging::default(), TuneStaging::Shared);
+        for staging in [TuneStaging::Shared, TuneStaging::Download] {
+            let options = TuneOptions {
+                staging,
+                ..Default::default()
+            };
+            let mut value = serde_json::to_value(&options).unwrap();
+            let restored: TuneOptions = serde_json::from_value(value.clone()).unwrap();
+            assert_eq!(restored.staging, staging);
+            value.as_object_mut().unwrap().remove("staging");
+            let historical: TuneOptions = serde_json::from_value(value).unwrap();
+            assert_eq!(historical.staging, TuneStaging::Shared);
+        }
+    }
+
+    #[test]
+    fn missing_historical_reuse_and_scratch_accounting_stay_distinct() {
+        assert_eq!(
+            TuneOptions::default().staging_reuse,
+            TuneStagingReuse::SameSize
+        );
+        assert_eq!(TuneStagingReuse::default(), TuneStagingReuse::Fresh);
+        for staging_reuse in [TuneStagingReuse::Fresh, TuneStagingReuse::SameSize] {
+            let mut value = serde_json::to_value(TuneReport {
+                options: TuneOptions {
+                    staging_reuse,
+                    ..Default::default()
+                },
+                scratch: Some(Default::default()),
+                final_cleanup: Some(Duration::ZERO),
+                ..Default::default()
+            })
+            .unwrap();
+            let restored: TuneReport = serde_json::from_value(value.clone()).unwrap();
+            assert_eq!(restored.options.staging_reuse, staging_reuse);
+            assert!(restored.scratch.is_some());
+            value["options"]
+                .as_object_mut()
+                .unwrap()
+                .remove("staging_reuse");
+            for key in ["scratch", "final_cleanup"] {
+                value.as_object_mut().unwrap().remove(key);
+            }
+            let old: TuneReport = serde_json::from_value(value).unwrap();
+            assert_eq!(old.options.staging_reuse, TuneStagingReuse::Fresh);
+            assert_eq!(old.scratch, None);
+            assert_eq!(old.final_cleanup, None);
+        }
+        let mut value = serde_json::to_value(outcome()).unwrap();
+        value.as_object_mut().unwrap().remove("scratch");
+        let old: TuneOutcome = serde_json::from_value(value).unwrap();
+        assert_eq!(old.scratch, None);
+    }
+
+    fn native_config(tile_size: u32) -> CoopConfig {
+        CoopConfig {
+            tile_size,
+            use_f16_input: false,
+            compensated: false,
+        }
+    }
+
+    fn class(m: u32, n: u32, k: u32) -> TuneClass {
+        let mut class = TuneClass {
+            shader: ShaderEntry::MatMul,
+            m,
+            n,
+            k,
+            conv2d: None,
+            requires_full_precision: true,
+            device_local: [false; 4],
+            binding_bytes: Vec::new(),
+        };
+        class.binding_bytes = class.buffer_sizes().unwrap();
+        class
+    }
+
+    #[test]
+    fn native_candidates_ignore_profitability_but_obey_capability_and_precision() {
+        let config = native_config(8);
+        let native = MatmulTile::CooperativeF32 { tile_size: 8 };
+        // One workgroup, and then a dimension above the static 1024 veto.
+        for class in [class(16, 16, 8), class(2048, 32, 17)] {
+            assert!(
+                class
+                    .challengers(MatmulTile::Tile64, Some(&config))
+                    .contains(&native)
+            );
+            assert!(
+                !class
+                    .challengers(MatmulTile::Tile64, None)
+                    .contains(&native)
+            );
+            let f16 = CoopConfig {
+                use_f16_input: true,
+                ..config
+            };
+            assert!(
+                !class
+                    .challengers(MatmulTile::Tile64, Some(&f16))
+                    .contains(&native)
+            );
+            let compensated = CoopConfig {
+                compensated: true,
+                ..config
+            };
+            assert!(
+                !class
+                    .challengers(MatmulTile::Tile64, Some(&compensated))
+                    .contains(&native)
+            );
+        }
+        assert!(MatmulTile::native_cooperative(Some(&native_config(4))).is_none());
+    }
+
+    #[test]
+    fn native_padding_and_addend_capacity_are_legality_not_allocation_requests() {
+        let native = MatmulTile::CooperativeF32 { tile_size: 8 };
+        let mut class = class(33, 32, 17);
+        assert!(!native.fits(&class));
+        let required = native.buffer_sizes(&class).unwrap();
+        assert_eq!(required, [33 * 17 * 4, 17 * 32 * 4, 48 * 32 * 4]);
+        class.binding_bytes = required;
+        assert!(native.fits(&class));
+        class.shader = ShaderEntry::FusedMatMulAdd;
+        class.binding_bytes = class.buffer_sizes().unwrap();
+        class.binding_bytes[3] = 48 * 32 * 4;
+        assert!(!native.fits(&class)); // output fits, addend does not
+        class.binding_bytes[2] = 48 * 32 * 4;
+        assert!(native.fits(&class));
+        class.n = 17;
+        assert!(native.buffer_sizes(&class).is_none());
+        class.n = 32;
+        class.k = 1;
+        assert!(native.buffer_sizes(&class).is_none());
+        class.shader = ShaderEntry::MatMulBT;
+        assert!(native.buffer_sizes(&class).is_some());
+    }
+
+    #[test]
+    fn native_geometry_flags_and_scalar_fallback_move_together() {
+        let config = native_config(8);
+        let native = MatmulTile::CooperativeF32 { tile_size: 8 };
+        let class = class(32, 64, 17);
+        let mut d = dispatch();
+        d.params = vec![class.m, class.k, class.n, 0];
+        native.apply(&mut d, &class);
+        assert_eq!(d.workgroups, [2, 4, 1]);
+        assert!(d.use_coop && !d.use_coop_compensated && !d.use_small_tiles);
+        assert_eq!(d.scalar_fallback, Some((ShaderEntry::MatMul, [1, 1, 1])));
+        assert!(TuneClass::from_dispatch(&d, Some(&config)).is_some());
+        assert!(TuneClass::from_dispatch(&d, None).is_none());
+        MatmulTile::Tile32.apply(&mut d, &class);
+        assert_eq!(d.workgroups, [2, 1, 1]);
+        assert!(!d.use_coop && d.use_small_tiles && d.scalar_fallback.is_none());
+        assert!(TuneClass::from_dispatch(&d, Some(&config)).is_some());
+    }
+
+    #[test]
+    fn an_incomplete_next_challenger_keeps_the_completed_winner() {
+        let options = TuneOptions::default();
+        let mut first = outcome();
+        decide(&mut first, &options);
+        let mut next = outcome();
+        next.initial = first.selected;
+        next.selected = first.selected;
+        next.candidate = MatmulTile::CooperativeF32 { tile_size: 8 };
+        next.candidate_ms.pop();
+        decide(&mut next, &options);
+        assert_eq!(next.selected, first.selected);
+        assert_eq!(next.decision, TuneDecision::TimeBudget);
+        next.candidate_ms.push(8.0);
+        decide(&mut next, &options);
+        assert_eq!(next.selected, next.candidate);
     }
 }

--- a/tests/checkpoint_validation.rs
+++ b/tests/checkpoint_validation.rs
@@ -1,21 +1,89 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
-use meganeura::Graph;
+use meganeura::{CoopPolicy, Graph, Mode, Session, SessionConfig, SessionOptions};
 use safetensors::tensor::{Dtype, TensorView};
 
-fn training_session() -> meganeura::Session {
+struct TestFile(PathBuf);
+
+impl TestFile {
+    fn new() -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "meganeura-checkpoint-{}-{}.safetensors",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap();
+        Self(path)
+    }
+}
+
+impl Drop for TestFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn graph() -> Graph {
     let mut graph = Graph::new();
     let x = graph.input("x", &[1, 2]);
     let w = graph.parameter("w", &[2, 2]);
     let y = graph.matmul(x, w);
     let loss = graph.mean_all(y);
     graph.set_outputs(vec![loss]);
-    meganeura::build(&graph, meganeura::SessionConfig::from_env()).0
+    graph
+}
+
+fn training_session() -> Session {
+    let mut session = meganeura::build(
+        &graph(),
+        SessionConfig {
+            runtime: SessionOptions {
+                coop: CoopPolicy::Disabled,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .0;
+    session.set_parameter("w", &[0.5, 0.6, 0.7, 0.8]);
+    session.set_input("x", &[1.0, 0.75]);
+    session
+}
+
+#[derive(Debug, PartialEq)]
+struct Snapshot {
+    parameters: Vec<Vec<f32>>,
+    moments: Vec<(Vec<f32>, Vec<f32>)>,
+    gradient: Vec<f32>,
+    step: u32,
+    moment_bytes: usize,
+}
+
+fn snapshot(session: &Session) -> Snapshot {
+    let mut gradient = vec![0.0; 4];
+    session.read_param_grad("w", &mut gradient);
+    Snapshot {
+        parameters: session.read_params(&["w"]),
+        moments: session.read_adam_states(&["w"]),
+        gradient,
+        step: session.adam_step_count(),
+        moment_bytes: session.memory_summary().adam_state_bytes,
+    }
 }
 
 #[test]
 fn checkpoint_rejects_oversized_adam_state() {
     let mut session = training_session();
+    let before = snapshot(&session);
     let parameter = vec![0_u8; 4 * 4];
     let oversized_moment = vec![0_u8; 8 * 4];
     let moment = vec![0_u8; 4 * 4];
@@ -38,19 +106,20 @@ fn checkpoint_rejects_oversized_adam_state() {
         ("adam_step".to_string(), "1".to_string()),
     ]));
     let bytes = safetensors::tensor::serialize(views, &metadata).unwrap();
-    let path = std::env::temp_dir().join("meganeura_oversized_adam.safetensors");
-    std::fs::write(&path, bytes).unwrap();
+    let path = TestFile::new();
+    std::fs::write(&path.0, bytes).unwrap();
 
-    let error = session.load_checkpoint(&path).unwrap_err();
+    let error = session.load_checkpoint(&path.0).unwrap_err();
     assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
     assert!(error.to_string().contains("adam_m.w"));
     assert!(error.to_string().contains("expected 16"));
-    let _ = std::fs::remove_file(path);
+    assert_eq!(snapshot(&session), before);
 }
 
 #[test]
 fn checkpoint_rejects_invalid_step_metadata() {
     let mut session = training_session();
+    let before = snapshot(&session);
     let parameter = vec![0_u8; 4 * 4];
     let views = vec![(
         "w".to_string(),
@@ -61,11 +130,281 @@ fn checkpoint_rejects_invalid_step_metadata() {
         ("adam_step".to_string(), "not-a-number".to_string()),
     ]));
     let bytes = safetensors::tensor::serialize(views, &metadata).unwrap();
-    let path = std::env::temp_dir().join("meganeura_bad_adam_step.safetensors");
-    std::fs::write(&path, bytes).unwrap();
+    let path = TestFile::new();
+    std::fs::write(&path.0, bytes).unwrap();
 
-    let error = session.load_checkpoint(&path).unwrap_err();
+    let error = session.load_checkpoint(&path.0).unwrap_err();
     assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
     assert!(error.to_string().contains("adam_step"));
-    let _ = std::fs::remove_file(path);
+    assert_eq!(snapshot(&session), before);
+}
+
+#[test]
+fn logical_checkpoint_rejections_never_write_or_allocate_moments() {
+    let mut source = training_session();
+    source.set_adam(0.02, 0.9, 0.999, 1e-8);
+    source.step();
+    let saved = TestFile::new();
+    source.save_checkpoint(&saved.0).unwrap();
+    let bytes = std::fs::read(&saved.0).unwrap();
+    let original = safetensors::SafeTensors::deserialize(&bytes).unwrap();
+    let (_, header) = safetensors::SafeTensors::read_metadata(&bytes).unwrap();
+    for initialized in [false, true] {
+        let mut target = training_session();
+        target.set_parameter("w", &[3.0; 4]);
+        target.set_adam_step_count(11);
+        if initialized {
+            target.set_adam(0.005, 0.9, 0.999, 1e-8);
+            target.step();
+            target.wait();
+        }
+        let before = snapshot(&target);
+        for case in 0..5 {
+            let mut tensors: Vec<_> = original
+                .tensors()
+                .into_iter()
+                .map(|(name, t)| (name, t.dtype(), t.shape().to_vec(), t.data().to_vec()))
+                .collect();
+            let mut metadata = header.metadata().clone().unwrap();
+            match case {
+                0 => {
+                    metadata.insert("adam_step".into(), "invalid".into());
+                }
+                1 => {
+                    let t = tensors.iter_mut().find(|t| t.0 == "adam_v.w").unwrap();
+                    t.2 = vec![5];
+                    t.3.resize(20, 0);
+                }
+                2 => {
+                    tensors.iter_mut().find(|t| t.0 == "w").unwrap().2 = vec![1, 4];
+                }
+                3 => {
+                    tensors.retain(|t| t.0 != "adam_v.w");
+                }
+                _ => {
+                    metadata.insert("meganeura_checkpoint_format".into(), "99".into());
+                }
+            }
+            let views: Vec<_> = tensors
+                .iter()
+                .map(|t| {
+                    (
+                        t.0.clone(),
+                        TensorView::new(t.1, t.2.clone(), &t.3).unwrap(),
+                    )
+                })
+                .collect();
+            let path = TestFile::new();
+            std::fs::write(
+                &path.0,
+                safetensors::tensor::serialize(views, &Some(metadata)).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(
+                target.load_checkpoint(&path.0).unwrap_err().kind(),
+                std::io::ErrorKind::InvalidData
+            );
+            assert_eq!(
+                snapshot(&target),
+                before,
+                "case {case}, initialized={initialized}"
+            );
+        }
+    }
+}
+
+#[test]
+fn checkpoint_without_moments_stays_lazy_or_resets_existing_moments() {
+    let mut source = training_session();
+    let path = TestFile::new();
+    source.save_checkpoint(&path.0).unwrap();
+    let mut fresh = training_session();
+    fresh.load_checkpoint(&path.0).unwrap();
+    assert_eq!(fresh.memory_summary().adam_state_bytes, 0);
+    let mut reused = training_session();
+    reused.set_adam(0.001, 0.9, 0.999, 1e-8);
+    reused.step();
+    reused.load_checkpoint(&path.0).unwrap();
+    assert_eq!(reused.adam_step_count(), 0);
+    assert_eq!(
+        reused.read_adam_states(&["w"]),
+        vec![(vec![0.0; 4], vec![0.0; 4])]
+    );
+    fresh.set_adam(0.001, 0.9, 0.999, 1e-8);
+    for s in [&mut fresh, &mut reused] {
+        s.step();
+        s.wait();
+    }
+    assert_eq!(snapshot(&fresh), snapshot(&reused));
+}
+
+#[test]
+fn training_checkpoint_loads_into_inference_without_optimizer_allocation() {
+    let mut source = training_session();
+    source.set_adam(0.001, 0.9, 0.999, 1e-8);
+    source.step();
+    let file = TestFile::new();
+    source.save_checkpoint(&file.0).unwrap();
+    let (mut target, _) = meganeura::build(
+        &graph(),
+        SessionConfig {
+            mode: Mode::Inference,
+            runtime: SessionOptions {
+                coop: CoopPolicy::Disabled,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+    target.load_checkpoint(&file.0).unwrap();
+    assert_eq!(target.read_params(&["w"]), source.read_params(&["w"]));
+    assert_eq!(target.memory_summary().adam_state_bytes, 0);
+}
+
+fn padded_session(padding: usize, debug: bool) -> Session {
+    let mut graph = Graph::new();
+    let weight = graph.parameter("w", &[2, 3]);
+    let loss = graph.mean_all(weight);
+    graph.set_outputs(vec![loss]);
+    let mut plan = meganeura::compile::compile(&meganeura::autodiff::differentiate(&graph));
+    let (parameter, gradient) = plan.param_grad_pairs[0];
+    plan.buffers[parameter.0 as usize] += padding;
+    plan.buffers[gradient.0 as usize] += padding;
+    Session::with_context_opts(
+        plan,
+        std::sync::Arc::new(meganeura::init_gpu_context().unwrap()),
+        SessionOptions {
+            debug,
+            coop: CoopPolicy::Disabled,
+            ..Default::default()
+        },
+    )
+}
+
+#[test]
+fn logical_checkpoint_round_trips_across_padding_and_preserves_next_update() {
+    for (from, to) in [(64, 0), (0, 128), (64, 128)] {
+        let mut source = padded_session(from, true);
+        source.set_parameter("w", &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        source.write_adam_m("w", &[0.125; 6]);
+        source.write_adam_v("w", &[0.25; 6]);
+        source.set_adam_step_count(7);
+        let file = TestFile::new();
+        source.save_checkpoint(&file.0).unwrap();
+        let bytes = std::fs::read(&file.0).unwrap();
+        let tensors = safetensors::SafeTensors::deserialize(&bytes).unwrap();
+        for name in ["w", "adam_m.w", "adam_v.w"] {
+            let tensor = tensors.tensor(name).unwrap();
+            assert_eq!(tensor.shape(), &[2, 3]);
+            assert_eq!(tensor.data().len(), 24);
+        }
+        let mut target = padded_session(to, false);
+        target.set_parameter("w", &vec![-99.0; (24 + to) / 4]);
+        target.load_checkpoint(&file.0).unwrap();
+        assert_eq!(target.param_size("w"), Some(6));
+        assert_eq!(target.read_params(&["w"]), source.read_params(&["w"]));
+        assert_eq!(
+            target.read_adam_states(&["w"]),
+            source.read_adam_states(&["w"])
+        );
+        let mut physical = vec![1.0; (24 + to) / 4];
+        target.read_buffer(target.param_buffer("w").unwrap(), &mut physical);
+        assert!(physical[6..].iter().all(|v| *v == 0.0));
+        for s in [&mut source, &mut target] {
+            s.set_adam(0.001, 0.9, 0.999, 1e-8);
+            s.step();
+            s.wait();
+        }
+        assert_eq!(target.adam_step_count(), 8);
+        assert_eq!(target.read_params(&["w"]), source.read_params(&["w"]));
+        assert_eq!(
+            target.read_adam_states(&["w"]),
+            source.read_adam_states(&["w"])
+        );
+    }
+}
+
+#[test]
+fn quantized_checkpoint_preserves_storage_identity_and_payload() {
+    for q8 in [false, true] {
+        let mut graph = Graph::new();
+        let x = graph.input("x", &[2, 32]);
+        let w = if q8 {
+            graph.parameter_q8("w", &[32, 3])
+        } else {
+            graph.parameter_q4("w", &[32, 3])
+        };
+        let y = graph.matmul(x, w);
+        graph.set_outputs(vec![y]);
+        let make = || {
+            meganeura::build(
+                &graph,
+                SessionConfig {
+                    mode: Mode::Inference,
+                    ..Default::default()
+                },
+            )
+            .0
+        };
+        let mut source = make();
+        let weights: Vec<_> = (0..96).map(|i| ((i % 17) as f32 - 8.0) * 0.1).collect();
+        source.set_parameter("w", &weights);
+        source.set_input("x", &[0.25; 64]);
+        source.step();
+        source.wait();
+        let expected = source.read_output(6);
+        let file = TestFile::new();
+        source.save_checkpoint(&file.0).unwrap();
+        let bytes = std::fs::read(&file.0).unwrap();
+        let tensors = safetensors::SafeTensors::deserialize(&bytes).unwrap();
+        assert_eq!(tensors.tensor("w").unwrap().dtype(), Dtype::U8);
+        assert_eq!(
+            tensors.tensor("w").unwrap().data().len(),
+            if q8 { 108 } else { 60 }
+        );
+        let mut target = make();
+        target.load_checkpoint(&file.0).unwrap();
+        assert_eq!(target.param_size("w"), Some(96));
+        target.set_input("x", &[0.25; 64]);
+        target.step();
+        target.wait();
+        assert_eq!(target.read_output(6), expected);
+    }
+}
+
+#[test]
+fn checkpoint_refreshes_derived_f16_staging_before_later_source_updates() {
+    let mut graph = Graph::new();
+    graph.parameter("a", &[2, 1]);
+    graph.parameter("b", &[2, 1]);
+    let w = graph.parameter_f16("joined", &[2, 2]);
+    let x = graph.input("x", &[1, 2]);
+    let y = graph.matmul(x, w);
+    graph.set_outputs(vec![y]);
+    let mut plan = meganeura::compile::compile(&graph);
+    let joined = plan
+        .param_buffers
+        .iter()
+        .find(|p| p.0 == "joined")
+        .unwrap()
+        .1;
+    plan.derived_params.push((
+        joined,
+        vec![("a".into(), 1), ("b".into(), 1)],
+        meganeura::graph::ParamTransform::HorizontalConcat,
+    ));
+    let mut source = Session::new(plan.clone());
+    source.set_parameter("a", &[1.0, 2.0]);
+    source.set_parameter("b", &[3.0, 4.0]);
+    let file = TestFile::new();
+    source.save_checkpoint(&file.0).unwrap();
+    let mut target = Session::new(plan);
+    target.set_parameter("a", &[10.0, 20.0]);
+    target.set_parameter("b", &[30.0, 40.0]);
+    target.load_checkpoint(&file.0).unwrap();
+    target.set_parameter("a", &[5.0, 6.0]);
+    target.set_input("x", &[1.0; 2]);
+    target.step();
+    target.wait();
+    assert_eq!(target.read_output(2), vec![11.0, 7.0]);
 }

--- a/tests/conv_derivatives.rs
+++ b/tests/conv_derivatives.rs
@@ -1,0 +1,1130 @@
+//! Full f64 oracle for convolution derivatives; no finite-difference cancellation.
+use meganeura::{
+    CoopPolicy, Graph, Session, SessionOptions,
+    compile::{BufferRef, ExecutionPlan, ShaderEntry},
+};
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug)]
+struct Shape {
+    batch: u32,
+    ci: u32,
+    h: u32,
+    w: u32,
+    co: u32,
+    kh: u32,
+    kw: u32,
+    stride: u32,
+    ph: u32,
+    pw: u32,
+}
+
+impl Shape {
+    fn output(self) -> (u32, u32) {
+        (
+            (self.h + 2 * self.ph - self.kh) / self.stride + 1,
+            (self.w + 2 * self.pw - self.kw) / self.stride + 1,
+        )
+    }
+
+    fn sizes(self) -> [usize; 3] {
+        let (oh, ow) = self.output();
+        [
+            (self.batch * self.ci * self.h * self.w) as usize,
+            (self.co * self.ci * self.kh * self.kw) as usize,
+            (self.batch * self.co * oh * ow) as usize,
+        ]
+    }
+}
+
+fn data(n: usize, seed: u32, scale: f32) -> Vec<f32> {
+    let mut state = seed;
+    (0..n)
+        .map(|_| {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            ((state >> 8) as f32 / 16777216.0 - 0.5) * scale
+        })
+        .collect()
+}
+
+fn reference(s: Shape, x: &[f32], w: &[f32], dy: &[f32]) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
+    let mut output = vec![0.0; dy.len()];
+    let mut dx = vec![0.0; x.len()];
+    let mut dw = vec![0.0; w.len()];
+    let (out_h, out_w) = s.output();
+    // Scatter the forward cross-correlation's contributions. This independent
+    // indexing does not use either GPU kernel's implicit-GEMM/gather formula.
+    for n in 0..s.batch {
+        for co in 0..s.co {
+            for oh in 0..out_h {
+                for ow in 0..out_w {
+                    let yi = (((n * s.co + co) * out_h + oh) * out_w + ow) as usize;
+                    for ci in 0..s.ci {
+                        for kh in 0..s.kh {
+                            for kw in 0..s.kw {
+                                let ih = (oh * s.stride + kh) as i32 - s.ph as i32;
+                                let iw = (ow * s.stride + kw) as i32 - s.pw as i32;
+                                if ih < 0 || iw < 0 || ih >= s.h as i32 || iw >= s.w as i32 {
+                                    continue;
+                                }
+                                let xi = (((n * s.ci + ci) * s.h + ih as u32) * s.w + iw as u32)
+                                    as usize;
+                                let wi = (((co * s.ci + ci) * s.kh + kh) * s.kw + kw) as usize;
+                                output[yi] += f64::from(x[xi]) * f64::from(w[wi]);
+                                dx[xi] += f64::from(dy[yi]) * f64::from(w[wi]);
+                                dw[wi] += f64::from(dy[yi]) * f64::from(x[xi]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    (output, dx, dw)
+}
+
+fn check(label: &str, actual: &[f32], expected: &[f64], scale: f32) {
+    qualification(label, actual, expected, scale).unwrap();
+}
+
+fn qualification(label: &str, actual: &[f32], expected: &[f64], scale: f32) -> Result<(), String> {
+    assert_eq!(actual.len(), expected.len());
+    let mut error = 0.0;
+    let mut norm = 0.0;
+    for (i, (&a, &b)) in actual.iter().zip(expected).enumerate() {
+        let difference = (f64::from(a) - b).abs();
+        if !(a.is_finite()
+            && b.is_finite()
+            && difference <= f64::from(scale) * 1e-5 + b.abs() * 2e-4)
+        {
+            return Err(format!("{label}[{i}] = {a:e}, reference {b:e}"));
+        }
+        error += difference * difference;
+        norm += b * b;
+    }
+    if !(norm > 0.0 && (error / norm).sqrt() <= 2e-4) {
+        return Err(format!(
+            "{label}: reference norm {norm:e}, relative L2 {}",
+            (error / norm).sqrt()
+        ));
+    }
+    Ok(())
+}
+
+fn run(
+    s: Shape,
+    tile: u32,
+    gpu: &Arc<blade_graphics::Context>,
+    policy: CoopPolicy,
+    tune: bool,
+) -> Session {
+    let (session, rejected) = run_split(s, tile, gpu, policy, tune, 1);
+    assert!(rejected.is_empty());
+    session
+}
+
+fn plan(s: Shape, tile: u32, splits: u32) -> (ExecutionPlan, Option<BufferRef>) {
+    let [nx, nw, ny] = s.sizes();
+    let mut graph = Graph::new();
+    let x = graph.parameter("x", &[nx]);
+    let w = graph.parameter("w", &[nw]);
+    let y = graph.conv2d_hw(
+        x, w, s.batch, s.ci, s.h, s.w, s.co, s.kh, s.kw, s.stride, s.ph, s.pw,
+    );
+    let dy = graph.input("dy", &[ny]);
+    let weighted = graph.mul(y, dy);
+    let loss = graph.sum_all(weighted);
+    graph.set_outputs(vec![loss]);
+    let mut plan = meganeura::compile::compile(&meganeura::autodiff::differentiate(&graph));
+    let mut forced = 0;
+    for d in &mut plan.dispatches {
+        match d.shader {
+            ShaderEntry::Conv2dGemm | ShaderEntry::Conv2dGemmSmall => {
+                d.shader = if tile == 32 {
+                    ShaderEntry::Conv2dGemmSmall
+                } else {
+                    ShaderEntry::Conv2dGemm
+                };
+                let (oh, ow) = s.output();
+                d.workgroups = [(oh * ow).div_ceil(tile), s.co.div_ceil(tile), s.batch];
+                forced += 1;
+            }
+            ShaderEntry::Conv2dGradInputGemm | ShaderEntry::Conv2dGradInputGemmSmall => {
+                d.shader = if tile == 32 {
+                    ShaderEntry::Conv2dGradInputGemmSmall
+                } else {
+                    ShaderEntry::Conv2dGradInputGemm
+                };
+                d.workgroups = [(s.h * s.w).div_ceil(tile), s.ci.div_ceil(tile), s.batch];
+                forced += 1;
+            }
+            ShaderEntry::Conv2dGradWeightGemm | ShaderEntry::Conv2dGradWeightGemmSmall => {
+                d.shader = if tile == 32 {
+                    ShaderEntry::Conv2dGradWeightGemmSmall
+                } else {
+                    ShaderEntry::Conv2dGradWeightGemm
+                };
+                d.workgroups = [(s.ci * s.kh * s.kw).div_ceil(tile), s.co.div_ceil(tile), 1];
+                forced += 1;
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(forced, 3);
+    let partial = if splits > 1 {
+        let index = plan
+            .dispatches
+            .iter()
+            .position(|d| {
+                matches!(
+                    d.shader,
+                    ShaderEntry::Conv2dGradWeightGemm | ShaderEntry::Conv2dGradWeightGemmSmall
+                )
+            })
+            .unwrap();
+        let buffer = BufferRef(plan.buffers.len() as u32);
+        let bytes = nw * splits as usize * 4;
+        assert_eq!(
+            plan.split_conv_weight_gradients(&[(index, splits)], bytes),
+            Ok(bytes)
+        );
+        Some(buffer)
+    } else {
+        None
+    };
+    (plan, partial)
+}
+
+fn run_split(
+    s: Shape,
+    tile: u32,
+    gpu: &Arc<blade_graphics::Context>,
+    policy: CoopPolicy,
+    tune: bool,
+    splits: u32,
+) -> (Session, Vec<String>) {
+    let [nx, nw, ny] = s.sizes();
+    let (plan, partial) = plan(s, tile, splits);
+    let mut session = Session::with_context_opts(
+        plan,
+        Arc::clone(gpu),
+        SessionOptions {
+            coop: policy,
+            no_alias: true, // Keep forward output available for the independent full oracle.
+            ..Default::default()
+        },
+    );
+    let cooperative = policy != CoopPolicy::Disabled;
+    let half_inputs = cooperative && gpu.capabilities().cooperative_matrix.f32_tile == 0;
+    if cooperative {
+        assert!(
+            session
+                .plan()
+                .dispatches
+                .iter()
+                .any(|d| d.use_coop
+                    && matches!(d.shader, ShaderEntry::Conv2dGradInputGemmCoopGen(..))),
+            "generated dX kernel must actually execute"
+        );
+    }
+    let values = |n, seed, scale| {
+        let mut values = data(n, seed, scale);
+        if half_inputs {
+            for value in &mut values {
+                *value = half::f16::from_f32(*value).to_f32();
+            }
+        }
+        values
+    };
+    let x = values(nx, 7, 1.0);
+    let w = values(nw, 19, 1.0);
+    session.set_parameter("x", &x);
+    session.set_parameter("w", &w);
+    let mut searched = false;
+    let mut rejected = Vec::new();
+    for scale in [1.0, 1e-12] {
+        if half_inputs && scale < 1.0 {
+            continue;
+        }
+        let dy = values(ny, 37, scale);
+        session.set_input("dy", &dy);
+        session.step();
+        session.wait();
+        if tune && !searched {
+            let state = |s: &Session| {
+                let mut values = vec![s.adam_step_count()];
+                for (i, bytes) in s.plan().buffers.iter().enumerate() {
+                    let mut data = vec![0.0; bytes / 4];
+                    s.read_buffer(meganeura::compile::BufferRef(i as u32), &mut data);
+                    values.extend(data.into_iter().map(f32::to_bits));
+                }
+                values
+            };
+            let before = state(&session);
+            let keys = session.dispatch_pipeline_keys();
+            for mut options in [
+                meganeura::TuneOptions {
+                    max_scratch_bytes: 0,
+                    ..Default::default()
+                },
+                meganeura::TuneOptions {
+                    max_time: std::time::Duration::ZERO,
+                    ..Default::default()
+                },
+            ] {
+                options.scope = meganeura::TuneScope::ConvDerivatives;
+                let report = session.tune_with(options).unwrap();
+                assert_eq!(report.eligible_classes, 2, "{s:?}");
+                assert_eq!(session.dispatch_pipeline_keys(), keys);
+                assert_eq!(state(&session), before);
+                assert_eq!(report.scratch.unwrap().retained_staging_bytes, 0);
+            }
+            let report = session
+                .tune_with(meganeura::TuneOptions {
+                    scope: meganeura::TuneScope::ConvDerivatives,
+                    max_time: std::time::Duration::from_secs(60),
+                    ..Default::default()
+                })
+                .unwrap();
+            assert_eq!(report.outcomes.len(), 2, "{s:?}: {report:?}");
+            assert!(
+                report.outcomes.iter().all(|o| o.qualified
+                    && o.class.conv2d.is_some()
+                    && matches!(
+                        o.decision,
+                        meganeura::TuneDecision::KeepBaseline
+                            | meganeura::TuneDecision::FasterCandidate
+                    )),
+                "{report:?}"
+            );
+            assert_eq!(report.scratch.unwrap().retained_staging_bytes, 0);
+            assert_eq!(state(&session), before);
+            session.step();
+            session.wait();
+            searched = true;
+        }
+        let (output, dx, dw) = reference(s, &x, &w, &dy);
+        if let Some(buffer) = partial {
+            let mut actual = vec![f32::NAN; nw * splits as usize];
+            session.read_buffer(buffer, &mut actual);
+            let (oh, ow) = s.output();
+            let spatial = oh * ow;
+            let tiles = (s.batch * spatial).div_ceil(16);
+            for split in 0..splits {
+                let first = split * (tiles / splits) + split.min(tiles % splits);
+                let last = first + tiles / splits + u32::from(split < tiles % splits);
+                let mut masked = dy.clone();
+                for n in 0..s.batch {
+                    for co in 0..s.co {
+                        for hw in 0..spatial {
+                            if !(first * 16..last * 16).contains(&(n * spatial + hw)) {
+                                masked[((n * s.co + co) * spatial + hw) as usize] = 0.0;
+                            }
+                        }
+                    }
+                }
+                let expected = reference(s, &x, &w, &masked).2;
+                let offset = split as usize * nw;
+                if let Err(error) = qualification(
+                    &format!("{s:?}, tile={tile}, scale={scale:e}, partial {split}/{splits}"),
+                    &actual[offset..offset + nw],
+                    &expected,
+                    scale,
+                ) {
+                    rejected.push(error);
+                }
+            }
+        }
+        let forward = session
+            .plan()
+            .dispatches
+            .iter()
+            .find(|d| {
+                matches!(
+                    d.shader,
+                    ShaderEntry::Conv2dGemm
+                        | ShaderEntry::Conv2dGemmSmall
+                        | ShaderEntry::Conv2dGemmCoopGen(..)
+                )
+            })
+            .unwrap();
+        assert_eq!(forward.workgroups[2], s.batch);
+        let mut actual = vec![f32::NAN; ny];
+        session.read_buffer(forward.output_buffer, &mut actual);
+        check(&format!("{s:?}, forward"), &actual, &output, 1.0);
+        for (name, expected) in [("x", dx), ("w", dw)] {
+            let mut actual = vec![f32::NAN; expected.len()];
+            session.read_param_grad(name, &mut actual);
+            check(
+                &format!("{s:?}, tile={tile}, d{name}, scale={scale:e}"),
+                &actual,
+                &expected,
+                scale,
+            );
+        }
+    }
+    (session, rejected)
+}
+
+#[test]
+fn split_weight_gradients_and_every_partial_match_full_f64_oracles() {
+    let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+    for (batch, ci, h, w, co, kh, kw, stride, ph, pw) in [
+        (3, 5, 7, 9, 7, 2, 3, 1, 1, 0),
+        (2, 17, 9, 11, 19, 3, 3, 2, 0, 1),
+        (2, 65, 5, 13, 33, 2, 2, 1, 1, 0),
+        (2, 3, 1, 41, 5, 1, 1, 1, 0, 0),
+    ] {
+        let s = Shape {
+            batch,
+            ci,
+            h,
+            w,
+            co,
+            kh,
+            kw,
+            stride,
+            ph,
+            pw,
+        };
+        let (oh, ow) = s.output();
+        for tile in [32, 64] {
+            run(s, tile, &gpu, CoopPolicy::Disabled, false);
+            for splits in [2, 3, 7, 16]
+                .into_iter()
+                .filter(|&count| count <= (batch * oh * ow).div_ceil(16))
+            {
+                let (_, rejected) = run_split(s, tile, &gpu, CoopPolicy::Disabled, false, splits);
+                assert!(rejected.is_empty(), "{rejected:?}");
+            }
+        }
+    }
+}
+
+#[test]
+fn long_split_weight_gradients_report_partial_rejections_without_relaxing_the_gate() {
+    let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+    let s = Shape {
+        batch: 2,
+        ci: 3,
+        h: 1,
+        w: 32771,
+        co: 5,
+        kh: 1,
+        kw: 1,
+        stride: 1,
+        ph: 0,
+        pw: 0,
+    };
+    for tile in [32, 64] {
+        run(s, tile, &gpu, CoopPolicy::Disabled, false);
+        let mut qualified = 0;
+        for splits in [2, 3, 7, 16] {
+            let (_, rejected) = run_split(s, tile, &gpu, CoopPolicy::Disabled, false, splits);
+            qualified += usize::from(rejected.is_empty());
+            eprintln!(
+                "long split-K tile={tile}, splits={splits}, qualified={}, rejections={rejected:?}",
+                rejected.is_empty()
+            );
+        }
+        assert!(
+            qualified > 0,
+            "no fully qualified partition count for tile {tile}"
+        );
+    }
+}
+
+#[test]
+fn observed_tiny_partial_error_is_rejected_by_the_original_gate() {
+    assert!(
+        qualification(
+            "observed partial",
+            &[-8.967522e-14],
+            &[-8.963817608922598e-14],
+            1e-12
+        )
+        .is_err()
+    );
+    for (actual, expected, scale) in [
+        (f32::NAN, 1.0, 1.0),
+        (1.0, f64::INFINITY, 1.0),
+        (1.0, 1.0, f32::NAN),
+        (0.0, 0.0, 1.0),
+        (0.0, 1e-12, 1e-12),
+    ] {
+        assert!(qualification("gate", &[actual], &[expected], scale).is_err());
+    }
+}
+
+fn qualification_inputs(n: usize, operand: u32, pattern: usize, scale: f32) -> Vec<f32> {
+    match pattern {
+        0 => (0..n)
+            .map(|index| {
+                let mut bits =
+                    (index as u32).wrapping_add(0x9e37_79b9u32.wrapping_mul(operand + 1));
+                bits ^= bits >> 16;
+                bits = bits.wrapping_mul(0x85eb_ca6b);
+                bits ^= bits >> 13;
+                ((bits >> 8) as f32 / 16_777_216.0 - 0.5) * scale
+            })
+            .collect(),
+        1 => data(n, if operand == 0 { 37 } else { 7 }, scale),
+        2 => (0..n)
+            .map(|i| {
+                let magnitude = 0.25 + (i % 29) as f32 / 1024.0;
+                let sign = if operand == 0 && i % 2 == 0 {
+                    -1.0
+                } else {
+                    1.0
+                };
+                sign * magnitude * scale
+            })
+            .collect(),
+        _ => unreachable!(),
+    }
+}
+
+fn weight_partial_reference(s: Shape, x: &[f32], dy: &[f32], splits: u32) -> Vec<f64> {
+    let [_, nw, _] = s.sizes();
+    let (oh, ow) = s.output();
+    let tiles = (s.batch * oh * ow).div_ceil(16);
+    let owners: Vec<_> = (0..splits)
+        .flat_map(|split| {
+            std::iter::repeat_n(
+                split as usize,
+                (tiles / splits + u32::from(split < tiles % splits)) as usize,
+            )
+        })
+        .collect();
+    let mut expected = vec![0.0; nw * splits as usize];
+    for batch in 0..s.batch {
+        for co in 0..s.co {
+            for y in 0..oh {
+                for z in 0..ow {
+                    let yi = (((batch * s.co + co) * oh + y) * ow + z) as usize;
+                    let owner = owners[((batch * oh * ow + y * ow + z) / 16) as usize];
+                    for ci in 0..s.ci {
+                        for ky in 0..s.kh {
+                            for kx in 0..s.kw {
+                                let iy = (y * s.stride + ky) as i32 - s.ph as i32;
+                                let ix = (z * s.stride + kx) as i32 - s.pw as i32;
+                                if iy < 0 || ix < 0 || iy >= s.h as i32 || ix >= s.w as i32 {
+                                    continue;
+                                }
+                                let xi = (((batch * s.ci + ci) * s.h + iy as u32) * s.w + ix as u32)
+                                    as usize;
+                                let wi = (((co * s.ci + ci) * s.kh + ky) * s.kw + kx) as usize;
+                                expected[owner * nw + wi] += f64::from(dy[yi]) * f64::from(x[xi]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    expected
+}
+
+#[test]
+fn weight_partial_scatter_agrees_with_independent_full_reference() {
+    let s = Shape {
+        batch: 3,
+        ci: 5,
+        h: 7,
+        w: 9,
+        co: 7,
+        kh: 2,
+        kw: 3,
+        stride: 1,
+        ph: 1,
+        pw: 0,
+    };
+    let [nx, nw, ny] = s.sizes();
+    let (x, w, dy) = (data(nx, 7, 1.0), data(nw, 19, 1.0), data(ny, 37, 1.0));
+    let expected = reference(s, &x, &w, &dy).2;
+    assert_eq!(weight_partial_reference(s, &x, &dy, 1), expected);
+    for splits in [2, 3, 4, 8] {
+        let partials = weight_partial_reference(s, &x, &dy, splits);
+        for (i, &value) in expected.iter().enumerate() {
+            let total: f64 = partials.chunks(nw).map(|p| p[i]).sum();
+            assert!((total - value).abs() <= 1e-12 * value.abs().max(1.0));
+        }
+    }
+}
+
+#[test]
+fn compensated_tile_rejection_matches_cpu_and_keeps_the_original_gate() {
+    let spatial = 32771;
+    let x = qualification_inputs(2 * 3 * spatial, 1, 2, 1.0);
+    let dy = qualification_inputs(2 * 5 * spatial, 0, 2, 1e-12);
+    let (mut total, mut error) = (0.0f32, 0.0f32);
+    let mut exact = 0.0f64;
+    for start in (0..2 * spatial).step_by(16) {
+        let mut block = 0.0f32;
+        for k in start..(start + 16).min(2 * spatial) {
+            let (batch, offset) = (k / spatial, k % spatial);
+            let a = dy[(batch * 5 + 2) * spatial + offset];
+            let b = x[batch * 3 * spatial + offset];
+            block = a.mul_add(b, block);
+            exact += f64::from(a) * f64::from(b);
+        }
+        let corrected = block - error;
+        let next = total + corrected;
+        error = (next - total) - corrected;
+        total = next;
+    }
+    let observed = 1.9869085e-15f32;
+    assert_eq!(total.to_bits(), observed.to_bits());
+    assert_eq!(exact, 1.9731522921401375e-15);
+    assert!(
+        qualification(
+            "retained compensated final[6]",
+            &[observed],
+            &[exact],
+            1e-12
+        )
+        .is_err()
+    );
+}
+
+#[test]
+#[ignore = "Full GPU/f64 accuracy experiment; reports all rejections without timing"]
+fn report_bounded_weight_accumulation_qualification() {
+    #[path = "../examples/support/experiment_io.rs"]
+    #[allow(dead_code)]
+    mod experiment_io;
+    use experiment_io::{command, sha256};
+    use serde_json::json;
+
+    let mut output = std::env::var_os("MEGANEURA_ACCUMULATION_RECORD").map(|path| {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .unwrap()
+    });
+    let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+    let info = gpu.device_information();
+    let mut record = json!({
+        "protocol": "bounded-dw-accuracy-v1", "revision": command("git", &["rev-parse", "HEAD"]).unwrap(),
+        "tracked_source_clean": command("git", &["status", "--porcelain", "--untracked-files=no"]).unwrap().is_empty(),
+        "executable_sha256": sha256(&std::env::current_exe().unwrap()).unwrap(),
+        "cargo_lock_sha256": sha256(std::path::Path::new("Cargo.lock")).unwrap(),
+        "device": info.device_name, "driver": info.driver_info, "rows": []
+    });
+    for shape in [
+        [1, 3, 224, 224, 64, 7, 7, 2, 3, 3],
+        [1, 256, 56, 56, 64, 1, 1, 1, 0, 0],
+        [3, 5, 7, 9, 7, 2, 3, 1, 1, 0],
+        [2, 3, 1, 32771, 5, 1, 1, 1, 0, 0],
+    ] {
+        let [batch, ci, h, w, co, kh, kw, stride, ph, pw] = shape;
+        let s = Shape {
+            batch,
+            ci,
+            h,
+            w,
+            co,
+            kh,
+            kw,
+            stride,
+            ph,
+            pw,
+        };
+        let [nx, nw, ny] = s.sizes();
+        let mut sessions = Vec::new();
+        for splits in [1, 2, 3, 4, 8] {
+            for tile in [32, 64] {
+                let (plan, partial) = plan(s, tile, splits);
+                let mut session = Session::with_context_opts(
+                    plan,
+                    Arc::clone(&gpu),
+                    SessionOptions {
+                        coop: CoopPolicy::Disabled,
+                        no_alias: true,
+                        ..Default::default()
+                    },
+                );
+                session.set_parameter("w", &data(nw, 19, 1.0));
+                sessions.push((splits, tile, partial, session));
+            }
+        }
+        for pattern in 0..3 {
+            let x = qualification_inputs(nx, 1, pattern, 1.0);
+            for scale in [1.0, 1e-12] {
+                let dy = qualification_inputs(ny, 0, pattern, scale);
+                let expected = weight_partial_reference(s, &x, &dy, 1);
+                for pair in sessions.chunks_mut(2) {
+                    let splits = pair[0].0;
+                    let partials = if splits == 1 {
+                        Vec::new()
+                    } else {
+                        weight_partial_reference(s, &x, &dy, splits)
+                    };
+                    for (splits, tile, partial, session) in pair {
+                        session.set_parameter("x", &x);
+                        session.set_input("dy", &dy);
+                        session.step();
+                        session.wait();
+                        let mut dw = vec![f32::NAN; nw];
+                        session.read_param_grad("w", &mut dw);
+                        let mut errors = Vec::new();
+                        if let Err(error) = qualification("final", &dw, &expected, scale) {
+                            errors.push(error);
+                        }
+                        if let Some(buffer) = partial {
+                            let mut actual = vec![f32::NAN; partials.len()];
+                            session.read_buffer(*buffer, &mut actual);
+                            for (index, (a, b)) in
+                                actual.chunks(nw).zip(partials.chunks(nw)).enumerate()
+                            {
+                                if let Err(error) =
+                                    qualification(&format!("partial {index}/{splits}"), a, b, scale)
+                                {
+                                    errors.push(error);
+                                }
+                            }
+                        }
+                        eprintln!(
+                            "shape={shape:?}, pattern={pattern}, scale={scale:e}, tile={tile}, splits={splits}: {errors:?}"
+                        );
+                        record["rows"].as_array_mut().unwrap().push(json!({
+                            "shape": shape, "pattern": pattern, "scale": scale, "tile": tile, "splits": splits,
+                            "final_elements": nw, "partial_elements": partials.len(), "qualified": errors.is_empty(), "errors": errors
+                        }));
+                        if let Some(file) = output.as_mut() {
+                            experiment_io::write_record(file, &record).unwrap();
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let rows = record["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 240);
+    let qualified = rows.iter().filter(|r| r["qualified"] == true).count();
+    eprintln!(
+        "Qualified {qualified}/240; this reporting test does not turn rejection into qualification"
+    );
+    record["qualified"] = json!(qualified);
+    record["status"] = json!(if qualified == 240 {
+        "qualified"
+    } else {
+        "rejected"
+    });
+    if let Some(file) = output.as_mut() {
+        experiment_io::write_record(file, &record).unwrap();
+    }
+}
+
+fn training_state(session: &Session) -> Vec<(String, Vec<f32>)> {
+    let loss = session.plan().loss_buffer.unwrap();
+    let mut partials = vec![f32::NAN; session.plan().buffers[loss.0 as usize] / 4];
+    session.read_buffer(loss, &mut partials);
+    let mut state = vec![
+        ("loss".into(), vec![session.read_loss()]),
+        ("loss_partials".into(), partials),
+    ];
+    for name in ["x", "w"] {
+        let n = session.param_size(name).unwrap();
+        let mut parameter = vec![f32::NAN; n];
+        let mut gradient = vec![f32::NAN; n];
+        session.read_param(name, &mut parameter);
+        session.read_param_grad(name, &mut gradient);
+        state.push((format!("parameter.{name}"), parameter));
+        state.push((format!("gradient.{name}"), gradient));
+        if session.memory_summary().adam_state_bytes != 0 {
+            let mut m = vec![f32::NAN; n];
+            let mut v = vec![f32::NAN; n];
+            session.read_adam_m(name, &mut m);
+            session.read_adam_v(name, &mut v);
+            state.push((format!("adam_m.{name}"), m));
+            state.push((format!("adam_v.{name}"), v));
+        }
+    }
+    state
+}
+
+#[test]
+fn split_weight_gradients_preserve_optimizer_updates_with_and_without_aliasing() {
+    optimizer_updates(false, 32);
+}
+
+#[test]
+#[ignore = "GPU isolated sequence qualification/timing; requires idle device"]
+fn split_sequence_measurement_preserves_state_budgets_and_subsequent_updates() {
+    for tile in [32, 64] {
+        optimizer_updates(true, tile);
+    }
+}
+
+fn optimizer_updates(measure: bool, tile: u32) {
+    let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+    let s = Shape {
+        batch: 3,
+        ci: 5,
+        h: 7,
+        w: 9,
+        co: 7,
+        kh: 2,
+        kw: 3,
+        stride: 1,
+        ph: 1,
+        pw: 0,
+    };
+    let [nx, nw, ny] = s.sizes();
+    for adam in [false, true] {
+        let mut sessions: Vec<_> = [(1, true), (3, true), (3, false)]
+            .into_iter()
+            .map(|(splits, no_alias)| {
+                let mut session = Session::with_context_opts(
+                    plan(s, tile, splits).0,
+                    Arc::clone(&gpu),
+                    SessionOptions {
+                        coop: CoopPolicy::Disabled,
+                        no_alias,
+                        ..Default::default()
+                    },
+                );
+                session.set_parameter("x", &data(nx, 7, 1.0));
+                session.set_parameter("w", &data(nw, 19, 1.0));
+                if adam {
+                    session.set_adam(1e-4, 0.9, 0.999, 1e-8);
+                } else {
+                    session.set_learning_rate(1e-3);
+                }
+                session.set_grad_clip_norm(1.0);
+                session
+            })
+            .collect();
+        for step in 1..=4 {
+            for session in &mut sessions {
+                session.set_input("dy", &data(ny, 37 + step, 1.0));
+                session.step();
+                session.wait();
+                assert_eq!(session.adam_step_count(), if adam { step } else { 0 });
+                assert_eq!(
+                    session.memory_summary().adam_state_bytes,
+                    if adam { (nx + nw) * 8 } else { 0 }
+                );
+                for (name, n, seed) in [("x", nx, 7), ("w", nw, 19)] {
+                    let mut actual = vec![f32::NAN; n];
+                    session.read_param(name, &mut actual);
+                    assert_ne!(actual, data(n, seed, 1.0), "{name} must update");
+                }
+            }
+            let control = training_state(&sessions[0]);
+            if measure && step == 2 {
+                let session = &mut sessions[0];
+                let index = session
+                    .plan()
+                    .dispatches
+                    .iter()
+                    .position(|d| {
+                        matches!(
+                            d.shader,
+                            ShaderEntry::Conv2dGradWeightGemm
+                                | ShaderEntry::Conv2dGradWeightGemmSmall
+                        )
+                    })
+                    .unwrap();
+                let keys = session.dispatch_pipeline_keys();
+                let bytes = session.memory_summary().total_allocated_bytes();
+                for counts in [
+                    vec![],
+                    vec![1],
+                    vec![2, 2],
+                    vec![2, 3, 4, 7, 8],
+                    vec![2, u32::MAX],
+                ] {
+                    assert!(
+                        session
+                            .measure_conv_weight_splits(index, &counts, Default::default())
+                            .is_err()
+                    );
+                }
+                for options in [
+                    meganeura::TuneOptions {
+                        max_time: std::time::Duration::ZERO,
+                        ..Default::default()
+                    },
+                    meganeura::TuneOptions {
+                        max_classes: 0,
+                        ..Default::default()
+                    },
+                    meganeura::TuneOptions {
+                        max_scratch_bytes: 0,
+                        ..Default::default()
+                    },
+                    meganeura::TuneOptions {
+                        max_scratch_bytes: (ny + nx + nw + 2 * nw) * 4 + ny.max(nx).max(2 * nw) * 4
+                            - 1,
+                        ..Default::default()
+                    },
+                ] {
+                    let report = session
+                        .measure_conv_weight_splits(index, &[2, 3], options)
+                        .unwrap();
+                    assert!(
+                        report
+                            .outcomes
+                            .iter()
+                            .all(|o| o.decision == meganeura::TuneDecision::ScratchLimit)
+                    );
+                    assert_eq!(report.scratch.unwrap().peak_bytes, 0);
+                }
+                let report = session
+                    .measure_conv_weight_splits(
+                        index,
+                        &[2, 3, 7, 8],
+                        meganeura::TuneOptions {
+                            max_time: std::time::Duration::from_secs(60),
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap();
+                assert_eq!(report.outcomes.len(), 4);
+                for (outcome, splits) in report.outcomes.iter().zip([2, 3, 7, 8]) {
+                    assert!(outcome.qualified, "{outcome:?}");
+                    assert_eq!(outcome.candidate_split_k, Some(splits));
+                    assert_eq!(outcome.initial, outcome.candidate);
+                    assert_eq!(outcome.selected, outcome.initial);
+                    assert_eq!(outcome.baseline_ms.len(), 6);
+                    assert_eq!(outcome.candidate_ms.len(), 6);
+                    let scratch = outcome.scratch.as_ref().unwrap();
+                    assert_eq!(
+                        scratch.binding_bytes,
+                        [ny * 4, nx * 4, nw * 4, nw * splits as usize * 4]
+                    );
+                    assert_eq!(
+                        scratch.staging_bytes,
+                        *scratch.binding_bytes.iter().max().unwrap()
+                    );
+                }
+                let scratch = report.scratch.unwrap();
+                assert_eq!(scratch.staging_allocations, scratch.staging_releases);
+                assert_eq!(scratch.retained_staging_bytes, 0);
+                assert_eq!(scratch.staging_allocations, 3);
+                assert_eq!(scratch.staging_reuses, 1);
+                assert_eq!(
+                    scratch.peak_bytes,
+                    (ny + nx + nw + 8 * nw) * 4 + (8 * nw * 4).max(ny * 4).max(nx * 4)
+                );
+                assert_eq!(session.dispatch_pipeline_keys(), keys);
+                assert_eq!(session.memory_summary().total_allocated_bytes(), bytes);
+                assert_eq!(training_state(session), control);
+                assert_eq!(session.adam_step_count(), if adam { step } else { 0 });
+            }
+            for session in &mut sessions[1..] {
+                let before = training_state(session);
+                assert_eq!(before.len(), control.len());
+                for ((name, actual), (other, expected)) in before.iter().zip(&control) {
+                    assert_eq!(name, other);
+                    check(
+                        &format!("Adam={adam}, step={step}, {name}"),
+                        actual,
+                        &expected.iter().copied().map(f64::from).collect::<Vec<_>>(),
+                        1.0,
+                    );
+                }
+                let keys = session.dispatch_pipeline_keys();
+                let report = session
+                    .tune_with(meganeura::TuneOptions {
+                        scope: meganeura::TuneScope::ConvDerivatives,
+                        max_time: std::time::Duration::ZERO,
+                        ..Default::default()
+                    })
+                    .unwrap();
+                assert_eq!(
+                    report.eligible_classes, 1,
+                    "only unsplit dX is tile-tunable"
+                );
+                assert_eq!(session.dispatch_pipeline_keys(), keys);
+                assert_eq!(training_state(session), before);
+            }
+            let keys: Vec<_> = sessions
+                .iter()
+                .map(Session::dispatch_pipeline_keys)
+                .collect();
+            let before: Vec<_> = sessions.iter().map(training_state).collect();
+            let (control, split) = sessions.split_at_mut(1);
+            for session in split {
+                assert!(control[0].swap_tuning_with(session).is_err());
+            }
+            for (i, session) in sessions.iter().enumerate() {
+                assert_eq!(session.dispatch_pipeline_keys(), keys[i]);
+                assert_eq!(training_state(session), before[i]);
+                assert_eq!(session.adam_step_count(), if adam { step } else { 0 });
+            }
+        }
+        assert!(
+            sessions[2].memory_summary().allocated_buffer_bytes
+                < sessions[1].memory_summary().allocated_buffer_bytes
+        );
+    }
+}
+
+#[test]
+fn scalar_conv_derivatives_match_full_oracle_across_padding_stride_and_tile_edges() {
+    scalar_oracles(false);
+}
+
+#[test]
+fn scalar_conv_indexing_matches_full_oracle_at_reciprocal_boundaries() {
+    reciprocal_boundary_oracles(false);
+}
+
+#[test]
+#[ignore = "GPU scalar convolution tuning qualification; requires idle device"]
+fn tuned_conv_indexing_matches_full_oracle_at_reciprocal_boundaries() {
+    reciprocal_boundary_oracles(true);
+}
+
+fn reciprocal_boundary_oracles(tune: bool) {
+    let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+    for divisor in [41, 47, 55] {
+        // Old f32 reciprocal multiplication maps divisor/divisor to zero.
+        // Cover spatial/batch boundaries, then kernel/channel decomposition.
+        for (h, w, kh, kw, ph, pw) in [
+            (1, divisor, 1, 1, 0, 0),
+            (3, divisor + 6, 2, divisor, 1, divisor / 2),
+        ] {
+            for tile in [32, 64] {
+                run(
+                    Shape {
+                        batch: 2,
+                        ci: 3,
+                        h,
+                        w,
+                        co: 5,
+                        kh,
+                        kw,
+                        stride: 1,
+                        ph,
+                        pw,
+                    },
+                    tile,
+                    &gpu,
+                    CoopPolicy::Disabled,
+                    tune,
+                );
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "GPU scalar convolution tuning qualification; requires idle device"]
+fn tuned_conv_derivatives_match_full_oracle_and_preserve_state_and_budgets() {
+    scalar_oracles(true);
+}
+
+fn scalar_oracles(tune: bool) {
+    let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+    for (batch, ci, h, w, co, kh, kw, stride, ph, pw) in [
+        (2, 3, 5, 7, 5, 3, 3, 1, 0, 0),
+        (2, 3, 7, 9, 5, 2, 4, 1, 0, 1),
+        (2, 5, 5, 9, 7, 3, 2, 1, 2, 0),
+        (2, 3, 7, 9, 5, 3, 2, 2, 0, 1),
+        (1, 17, 9, 11, 19, 3, 3, 1, 1, 1),
+        (2, 65, 5, 13, 33, 2, 2, 1, 1, 0),
+        (3, 5, 7, 9, 3, 1, 1, 1, 0, 0),
+        (2, 3, 9, 7, 5, 1, 3, 2, 0, 1),
+    ] {
+        for tile in [32, 64] {
+            run(
+                Shape {
+                    batch,
+                    ci,
+                    h,
+                    w,
+                    co,
+                    kh,
+                    kw,
+                    stride,
+                    ph,
+                    pw,
+                },
+                tile,
+                &gpu,
+                CoopPolicy::Disabled,
+                tune,
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "Requires cooperative hardware; verifies actual generated dX execution"]
+fn generated_conv_derivatives_match_oracle_without_assuming_same_padding() {
+    let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+    let policy = cooperative_policy(&gpu);
+    for (kh, kw, stride, ph, pw) in [(3, 3, 1, 0, 0), (2, 4, 1, 0, 1), (3, 2, 2, 0, 1)] {
+        run(
+            Shape {
+                batch: 2,
+                ci: 64,
+                h: 8,
+                w: 16,
+                co: 5,
+                kh,
+                kw,
+                stride,
+                ph,
+                pw,
+            },
+            64,
+            &gpu,
+            policy,
+            false,
+        );
+    }
+}
+
+fn cooperative_policy(gpu: &blade_graphics::Context) -> CoopPolicy {
+    assert!(gpu.capabilities().cooperative_matrix.is_supported());
+    if gpu.capabilities().cooperative_matrix.f32_tile > 0 {
+        CoopPolicy::Auto
+    } else {
+        // Exactly representable bounded operands isolate indexing on f16-only
+        // hardware. This is not qualification of tiny f32 derivatives on f16.
+        CoopPolicy::AllowF16
+    }
+}
+
+#[test]
+#[ignore = "Requires cooperative hardware; verifies generated dX and admitted forward execution"]
+fn generated_conv_indexing_matches_full_oracle_at_reciprocal_boundaries() {
+    let gpu = Arc::new(meganeura::init_gpu_context().unwrap());
+    let policy = cooperative_policy(&gpu);
+    for width in [41, 47, 55] {
+        let session = run(
+            Shape {
+                batch: 2,
+                ci: 64,
+                h: 16,
+                w: width,
+                co: 128,
+                kh: 1,
+                kw: 1,
+                stride: 1,
+                ph: 0,
+                pw: 0,
+            },
+            64,
+            &gpu,
+            policy,
+            false,
+        );
+        // The native tile-8 policy deliberately keeps forward convolution scalar.
+        if gpu.capabilities().cooperative_matrix.f32_tile != 8 {
+            assert!(
+                session
+                    .plan()
+                    .dispatches
+                    .iter()
+                    .any(|d| d.use_coop && matches!(d.shader, ShaderEntry::Conv2dGemmCoopGen(..)))
+            );
+        }
+    }
+}

--- a/tests/optimizer_memory.rs
+++ b/tests/optimizer_memory.rs
@@ -1,0 +1,234 @@
+use meganeura::{CoopPolicy, Graph, SessionConfig, SessionOptions};
+
+fn session(debug: bool) -> meganeura::Session {
+    let mut graph = Graph::new();
+    let a = graph.parameter("a", &[3]);
+    let b = graph.parameter("b", &[5]);
+    let c = graph.parameter("c", &[7]);
+    let a = graph.mean_all(a);
+    let b = graph.mean_all(b);
+    let c = graph.mean_all(c);
+    let sum = graph.add(a, b);
+    let loss = graph.add(sum, c);
+    graph.set_outputs(vec![loss]);
+    meganeura::build(
+        &graph,
+        SessionConfig {
+            runtime: SessionOptions {
+                debug,
+                coop: CoopPolicy::Disabled,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .0
+}
+
+#[test]
+fn moments_are_lazy_and_accumulators_are_counted_once() {
+    for debug in [false, true] {
+        let mut s = session(debug);
+        let before = s.memory_summary();
+        assert_eq!(before.adam_state_bytes, 0);
+        assert_eq!(before.grad_accumulator_bytes, 0);
+        assert_eq!(before.optimizer_aux_bytes, 4);
+        assert_eq!(
+            s.read_adam_states(&["b"]),
+            vec![(vec![0.0; 5], vec![0.0; 5])]
+        );
+        let mut m = [9.0; 3];
+        s.read_adam_m("a", &mut m);
+        assert_eq!(m, [0.0; 3]);
+        s.read_adam_v("a", &mut m);
+        assert_eq!(m, [0.0; 3]);
+        s.set_learning_rate(0.01);
+        s.step();
+        s.wait();
+        assert_eq!(s.memory_summary().adam_state_bytes, 0);
+
+        s.set_grad_accumulate(3);
+        let accumulated = s.memory_summary();
+        assert_eq!(accumulated.grad_accumulator_bytes, (3 + 5 + 7) * 4);
+        assert_eq!(
+            accumulated.total_allocated_bytes() - before.total_allocated_bytes(),
+            60
+        );
+        assert_eq!(
+            accumulated.device_local_bytes - before.device_local_bytes,
+            if debug { 0 } else { 60 }
+        );
+
+        s.set_adam_grouped_grad_norm("b", 1);
+        assert_eq!(s.memory_summary().optimizer_aux_bytes, 24);
+        assert_eq!(s.memory_summary().adam_state_bytes, 0);
+        s.set_adam(0.001, 0.9, 0.999, 1e-8);
+        let allocated = s.memory_summary();
+        assert_eq!(allocated.adam_state_bytes, (3 + 5 + 7) * 4 * 2);
+        assert_eq!(
+            allocated.device_local_bytes - accumulated.device_local_bytes,
+            if debug { 0 } else { 120 }
+        );
+        s.step();
+        s.wait();
+        let states = s.read_adam_states(&["a", "b", "c"]);
+        s.clear_optimizer();
+        s.set_learning_rate(0.01);
+        s.set_laprop(0.001, 0.9, 0.999, 1e-8);
+        assert_eq!(s.read_adam_states(&["a", "b", "c"]), states);
+        assert_eq!(
+            s.memory_summary().total_allocated_bytes(),
+            allocated.total_allocated_bytes()
+        );
+        println!(
+            "debug={debug}: graph={} B, no-Adam={} B, Adam={} B, accumulators={} B",
+            before.allocated_buffer_bytes,
+            before.total_allocated_bytes(),
+            allocated.adam_state_bytes,
+            allocated.grad_accumulator_bytes
+        );
+    }
+}
+
+#[test]
+fn explicit_moment_write_initializes_storage_without_configuring_updates() {
+    let mut s = session(false);
+    s.write_adam_m("a", &[1.0, 2.0, 3.0]);
+    assert_eq!(
+        s.read_adam_states(&["a"]),
+        vec![(vec![1.0, 2.0, 3.0], vec![0.0; 3])]
+    );
+    assert_eq!(s.memory_summary().adam_state_bytes, 120);
+    s.step();
+    s.wait();
+    assert_eq!(s.adam_step_count(), 0);
+    assert_eq!(s.read_adam_states(&["a"])[0].0, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn a_million_f32_parameters_do_not_reserve_eight_mib_of_unused_moments() {
+    let mut graph = Graph::new();
+    let p = graph.parameter("p", &[1024, 1024]);
+    let loss = graph.mean_all(p);
+    graph.set_outputs(vec![loss]);
+    let mut s = meganeura::build(&graph, SessionConfig::default()).0;
+    let before = s.memory_summary();
+    assert_eq!(before.adam_state_bytes, 0);
+    s.set_adam(0.001, 0.9, 0.999, 1e-8);
+    let after = s.memory_summary();
+    assert_eq!(after.adam_state_bytes, 8 * 1024 * 1024);
+    assert_eq!(
+        after.total_allocated_bytes() - before.total_allocated_bytes(),
+        8 * 1024 * 1024
+    );
+    println!(
+        "1,048,576 F32 parameters: {} -> {} requested resident bytes; Adam adds {} bytes",
+        before.total_allocated_bytes(),
+        after.total_allocated_bytes(),
+        after.adam_state_bytes
+    );
+}
+
+#[test]
+fn optimizer_clipping_and_diagnostics_ignore_poisoned_allocation_padding() {
+    for debug in [false, true] {
+        for mode in 0..6 {
+            let run = |param_padding, grad_padding| {
+                let mut graph = Graph::new();
+                let p = graph.parameter("p", &[2, 3]);
+                let loss = graph.mean_all(p);
+                graph.set_outputs(vec![loss]);
+                let mut plan =
+                    meganeura::compile::compile(&meganeura::autodiff::differentiate(&graph));
+                let (parameter, gradient) = plan.param_grad_pairs[0];
+                plan.buffers[parameter.0 as usize] += param_padding;
+                plan.buffers[gradient.0 as usize] += grad_padding;
+                // Seed the whole gradient slot; backward overwrites only its
+                // logical prefix, leaving finite poison in the allocation tail.
+                let poison = vec![1000.0f32; (24 + grad_padding) / 4];
+                plan.constant_buffers
+                    .push((gradient, bytemuck::cast_slice(&poison).to_vec()));
+                let mut s = meganeura::Session::with_context_opts(
+                    plan,
+                    std::sync::Arc::new(meganeura::init_gpu_context().unwrap()),
+                    SessionOptions {
+                        debug,
+                        coop: CoopPolicy::Disabled,
+                        ..Default::default()
+                    },
+                );
+                let mut weights = vec![1000.0f32; (24 + param_padding) / 4];
+                weights[..6].copy_from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+                s.set_parameter("p", &weights);
+                if mode < 3 {
+                    s.set_grad_accumulate(2);
+                    s.step();
+                    match mode {
+                        0 => s.set_learning_rate(0.1),
+                        1 => s.set_adam(0.01, 0.9, 0.999, 1e-8),
+                        _ => s.set_laprop(0.01, 0.9, 0.999, 1e-8),
+                    }
+                    if mode == 2 {
+                        s.set_adaptive_grad_clip(0.01, 0.001);
+                    } else {
+                        s.set_grad_clip_norm(0.1);
+                    }
+                    if mode != 0 {
+                        s.set_adam_grouped_grad_norm("p", 2);
+                    }
+                    s.step();
+                } else {
+                    s.step();
+                    let (norm, clipped) = s.clip_grad_norm_cpu(0.1);
+                    assert!((norm - (1.0f32 / 6.0).sqrt()).abs() < 1e-6);
+                    assert!(clipped);
+                    match mode {
+                        3 => s.sgd_step(0.1),
+                        4 => s.sgd_step_cpu(0.1),
+                        _ => s.adam_step(0.01, 0.9, 0.999, 1e-8),
+                    }
+                }
+                s.wait();
+                s.read_buffer(parameter, &mut weights);
+                assert!(weights[6..].iter().all(|v| *v == 1000.0));
+                let mut gradient_slot = vec![0.0; (24 + grad_padding) / 4];
+                s.read_buffer(gradient, &mut gradient_slot);
+                assert!(gradient_slot[6..].iter().all(|v| *v == 1000.0));
+                let diagnostic = if mode == 1 || mode == 2 {
+                    s.read_adam_grouped_grad_norm("p")
+                } else {
+                    Vec::new()
+                };
+                (
+                    s.read_params(&["p"]),
+                    s.read_adam_states(&["p"]),
+                    diagnostic,
+                )
+            };
+            let expected = run(0, 0);
+            for (param_padding, grad_padding) in [(64, 128), (64, 0), (0, 128)] {
+                assert_eq!(
+                    run(param_padding, grad_padding),
+                    expected,
+                    "mode={mode}, debug={debug}, padding=({param_padding},{grad_padding})"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn parameter_reads_reject_wrong_storage_and_oversized_views() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    let s = session(false);
+    let buffer = s.param_buffer("a").unwrap();
+    assert!(catch_unwind(AssertUnwindSafe(|| s.read_buffer(buffer, &mut [0.0; 4]))).is_err());
+    let mut graph = Graph::new();
+    let p = graph.parameter_f16("p", &[3]);
+    graph.set_outputs(vec![p]);
+    let s = meganeura::Session::new(meganeura::compile::compile(&graph));
+    assert_eq!(s.param_size("p"), Some(3));
+    assert!(catch_unwind(AssertUnwindSafe(|| s.read_param("p", &mut [0.0; 3]))).is_err());
+    assert!(catch_unwind(AssertUnwindSafe(|| s.read_params(&["p"]))).is_err());
+    assert!(catch_unwind(AssertUnwindSafe(|| s.read_all_param_norms())).is_err());
+}

--- a/tests/tune.rs
+++ b/tests/tune.rs
@@ -1,9 +1,46 @@
-//! Real-device scalar tile qualification. These tests execute GPU timings;
+//! Real-device tile qualification. These tests execute GPU timings;
 //! run explicitly on an idle device with `--ignored --test-threads=1`.
 
 use meganeura::graph::Graph;
-use meganeura::{CoopPolicy, Mode, SessionConfig, SessionOptions, TuneOptions, build};
+use meganeura::{
+    CoopPolicy, MatmulTile, Mode, SessionConfig, SessionOptions, TuneDecision, TuneOptions,
+    TuneStaging, TuneStagingReuse, build,
+};
 use std::time::Duration;
+
+fn matmul_graph(shader: &meganeura::compile::ShaderEntry, m: usize, n: usize, k: usize) -> Graph {
+    use meganeura::compile::ShaderEntry;
+    let mut graph = Graph::new();
+    let a = graph.input(
+        "a",
+        &if *shader == ShaderEntry::MatMulAT {
+            [k, m]
+        } else {
+            [m, k]
+        },
+    );
+    let b = graph.input(
+        "b",
+        &if *shader == ShaderEntry::MatMulBT {
+            [n, k]
+        } else {
+            [k, n]
+        },
+    );
+    let y = match shader {
+        ShaderEntry::MatMulAT => graph.matmul_at(a, b),
+        ShaderEntry::MatMulBT => graph.matmul_bt(a, b),
+        _ => graph.matmul(a, b),
+    };
+    let y = if *shader == ShaderEntry::FusedMatMulAdd {
+        let addend = graph.input("addend", &[m, n]);
+        graph.add(y, addend)
+    } else {
+        y
+    };
+    graph.set_outputs(vec![y]);
+    graph
+}
 
 #[test]
 #[ignore = "GPU tuning requires an idle device"]
@@ -52,6 +89,42 @@ fn tune_preserves_correctness() {
         assert!(o.qualified, "qualification failed: {o:?}");
         assert!(o.baseline_median_ms.unwrap() > 0.0);
         assert!(o.candidate_median_ms.unwrap() > 0.0);
+        let phases = o.phase_times.expect("new reports must account for phases");
+        let preparation = phases.preparation.unwrap();
+        let qualification = phases.qualification.unwrap();
+        let warmup = phases.warmup.unwrap();
+        let sampling = phases.sampling.unwrap();
+        assert!(o.compile_time <= preparation);
+        assert!(
+            preparation + qualification + warmup + sampling + phases.cleanup.unwrap() <= o.elapsed
+        );
+        let prep = phases.preparation_breakdown.unwrap();
+        assert_eq!(prep.pipelines.unwrap(), o.compile_time);
+        let sum: Duration = [
+            prep.checks,
+            prep.pipelines,
+            prep.buffers,
+            prep.staging,
+            prep.encoder,
+            prep.bindings,
+        ]
+        .into_iter()
+        .map(Option::unwrap)
+        .sum();
+        assert!(sum <= preparation);
+        assert!(!qualification.is_zero() && !sampling.is_zero());
+        let detail = phases.qualification_breakdown.unwrap();
+        let parts = [
+            detail.input_preparation,
+            detail.upload_host_copy,
+            detail.upload_transfer,
+            detail.dispatch,
+            detail.readback_transfer,
+            detail.readback_host_copy,
+            detail.validation,
+        ];
+        let sum: Duration = parts.into_iter().map(Option::unwrap).sum();
+        assert!(sum <= qualification);
     }
     // Tuning must not execute the graph or overwrite the previous output.
     assert_eq!(
@@ -76,6 +149,14 @@ fn tune_preserves_correctness() {
 #[test]
 #[ignore = "GPU tuning requires an idle device"]
 fn tune_preserves_training_parameters_gradients_and_moments() {
+    for staging in [TuneStaging::Shared, TuneStaging::Download] {
+        for reuse in [TuneStagingReuse::Fresh, TuneStagingReuse::SameSize] {
+            preserves_training_state(staging, reuse);
+        }
+    }
+}
+
+fn preserves_training_state(staging: TuneStaging, staging_reuse: TuneStagingReuse) {
     let mut graph = Graph::new();
     let x = graph.input("x", &[33, 17]);
     let weight = graph.parameter("weight", &[17, 65]);
@@ -97,6 +178,28 @@ fn tune_preserves_training_parameters_gradients_and_moments() {
     session.set_parameter("weight", &vec![0.125; 17 * 65]);
     session.set_adam(0.001, 0.9, 0.999, 1.0e-8);
     session.set_grad_accumulate(2);
+    session.set_grad_clip_norm(0.05);
+    session.set_grad_clip_every(3);
+    let (mut control, _) = build(
+        &graph,
+        SessionConfig {
+            gpu: Some(session.context()),
+            runtime: SessionOptions {
+                debug: true,
+                coop: CoopPolicy::Disabled,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+    control.set_input("x", &vec![0.25; 33 * 17]);
+    control.set_parameter("weight", &vec![0.125; 17 * 65]);
+    control.set_adam(0.001, 0.9, 0.999, 1.0e-8);
+    control.set_grad_accumulate(2);
+    control.set_grad_clip_norm(0.05);
+    control.set_grad_clip_every(3);
+    control.step();
+    control.wait();
     session.step();
     session.wait();
     let snapshot = |s: &meganeura::Session| {
@@ -114,10 +217,267 @@ fn tune_preserves_training_parameters_gradients_and_moments() {
     let before = snapshot(&session);
     let report = session
         .tune_with(TuneOptions {
+            staging,
+            staging_reuse,
             max_time: Duration::from_secs(60),
             ..Default::default()
         })
         .unwrap();
     assert!(report.outcomes.iter().any(|o| o.qualified), "{report:?}");
     assert_eq!(before, snapshot(&session));
+
+    // Observe hidden accumulator/clip-cadence state through subsequent updates.
+    for value in [0.5, -0.125, 0.75] {
+        for s in [&mut control, &mut session] {
+            s.set_input("x", &vec![value; 33 * 17]);
+            s.step();
+            s.wait();
+        }
+        assert_eq!(session.adam_step_count(), control.adam_step_count());
+        let state = |s: &meganeura::Session| {
+            let mut data = s.read_params(&["weight"]).remove(0);
+            for (m, v) in s.read_adam_states(&["weight"]) {
+                data.extend(m.into_iter().chain(v));
+            }
+            data
+        };
+        for (index, (a, b)) in state(&session).into_iter().zip(state(&control)).enumerate() {
+            assert!(
+                a.is_finite() && b.is_finite() && (a - b).abs() <= 1e-6 + b.abs() * 1e-4,
+                "optimizer state[{index}]: {a} != {b}"
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "GPU tuning requires an idle device"]
+fn tune_qualifies_all_four_scalar_entries_on_rectangular_edges() {
+    for staging in [TuneStaging::Shared, TuneStaging::Download] {
+        for reuse in [TuneStagingReuse::Fresh, TuneStagingReuse::SameSize] {
+            qualify_scalar_entries(staging, reuse);
+        }
+    }
+}
+
+fn qualify_scalar_entries(staging: TuneStaging, staging_reuse: TuneStagingReuse) {
+    use meganeura::compile::ShaderEntry;
+    for shader in [
+        ShaderEntry::MatMul,
+        ShaderEntry::MatMulAT,
+        ShaderEntry::MatMulBT,
+        ShaderEntry::FusedMatMulAdd,
+    ] {
+        for (m, n, k) in [(33, 65, 17), (64, 32, 1), (17, 16, 65)] {
+            let g = matmul_graph(&shader, m, n, k);
+            let (mut session, _) = build(
+                &g,
+                SessionConfig {
+                    mode: Mode::Inference,
+                    runtime: SessionOptions {
+                        coop: CoopPolicy::Disabled,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            );
+            let report = session
+                .tune_with(TuneOptions {
+                    staging,
+                    staging_reuse,
+                    max_time: Duration::from_secs(60),
+                    ..Default::default()
+                })
+                .unwrap();
+            assert_eq!(
+                report.outcomes.len(),
+                1,
+                "{shader:?} {m}x{n}x{k}: {report:?}"
+            );
+            let outcome = &report.outcomes[0];
+            assert_eq!(report.scratch.unwrap().retained_staging_bytes, 0);
+            assert_eq!(
+                report.scratch.unwrap().staging_allocations,
+                report.scratch.unwrap().staging_releases
+            );
+            assert!(report.scratch.unwrap().peak_bytes <= report.options.max_scratch_bytes);
+            assert_eq!(outcome.class.shader, shader);
+            assert!(outcome.qualified, "{outcome:?}");
+            assert!(matches!(
+                outcome.decision,
+                TuneDecision::FasterCandidate | TuneDecision::KeepBaseline
+            ));
+        }
+    }
+}
+
+#[test]
+#[ignore = "GPU tuning requires an idle device"]
+fn tune_budget_skips_leave_selection_unchanged() {
+    let mut graph = Graph::new();
+    let a = graph.input("a", &[33, 17]);
+    let b = graph.input("b", &[17, 65]);
+    let y = graph.matmul(a, b);
+    graph.set_outputs(vec![y]);
+    let (mut session, _) = build(
+        &graph,
+        SessionConfig {
+            mode: Mode::Inference,
+            runtime: SessionOptions {
+                coop: CoopPolicy::Disabled,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+    let before = session.dispatch_pipeline_keys();
+    for options in [
+        TuneOptions {
+            max_classes: 0,
+            ..Default::default()
+        },
+        TuneOptions {
+            max_time: Duration::ZERO,
+            ..Default::default()
+        },
+        TuneOptions {
+            max_scratch_bytes: 0,
+            ..Default::default()
+        },
+    ] {
+        let report = session.tune_with(options).unwrap();
+        assert_eq!(report.scratch.unwrap(), Default::default());
+        assert_eq!(report.final_cleanup, None);
+        assert_eq!(report.eligible_classes, 1);
+        assert!(
+            report.class_limit_reached
+                || report.time_budget_exhausted
+                || report
+                    .outcomes
+                    .iter()
+                    .all(|o| o.decision == TuneDecision::ScratchLimit)
+        );
+        assert_eq!(before, session.dispatch_pipeline_keys());
+        for outcome in &report.outcomes {
+            assert_eq!(outcome.decision, TuneDecision::ScratchLimit);
+            let phases = outcome.phase_times.unwrap();
+            assert!(phases.preparation.unwrap() <= outcome.elapsed);
+            assert_eq!(phases.qualification, None);
+            assert_eq!(phases.warmup, None);
+            assert_eq!(phases.sampling, None);
+            assert_eq!(phases.cleanup, None);
+            let preparation = phases.preparation_breakdown.unwrap();
+            assert!(preparation.checks.is_some());
+            assert_eq!(preparation.buffers, None);
+            assert_eq!(preparation.staging, None);
+        }
+    }
+}
+
+#[test]
+#[ignore = "GPU tuning requires an idle device"]
+fn tuning_releases_retained_staging_after_a_later_scratch_skip() {
+    let mut graph = Graph::new();
+    let a = graph.input("a", &[32, 4096]);
+    let b = graph.parameter("b", &[4096, 32]);
+    let small = graph.matmul(a, b);
+    let x = graph.input("x", &[1024, 1]);
+    let y = graph.parameter("y", &[1, 1024]);
+    let large = graph.matmul(x, y);
+    graph.set_outputs(vec![small, large]);
+    let (mut session, _) = build(
+        &graph,
+        SessionConfig {
+            mode: Mode::Inference,
+            runtime: SessionOptions {
+                coop: CoopPolicy::Disabled,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+    let report = session
+        .tune_with(TuneOptions {
+            staging_reuse: TuneStagingReuse::SameSize,
+            max_scratch_bytes: 2 * 1024 * 1024,
+            max_time: Duration::from_secs(60),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(report.outcomes.len(), 2);
+    assert!(report.outcomes[0].qualified);
+    assert_eq!(report.outcomes[1].decision, TuneDecision::ScratchLimit);
+    assert_eq!(report.outcomes[1].scratch, None);
+    let stats = report.scratch.unwrap();
+    assert_eq!(stats.staging_allocations, 1);
+    assert_eq!(stats.staging_releases, 1);
+    assert_eq!(stats.staging_reuses, 0);
+    assert_eq!(stats.retained_staging_bytes, 0);
+    assert_eq!(stats.peak_bytes, 3 * 32 * 4096 * 4 + 32 * 32 * 4);
+    assert!(report.final_cleanup.is_some());
+    let keys = session.dispatch_pipeline_keys();
+    let report = session
+        .tune_with(TuneOptions {
+            staging_reuse: TuneStagingReuse::SameSize,
+            max_time: Duration::ZERO,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(report.scratch.unwrap(), Default::default());
+    assert_eq!(report.final_cleanup, None);
+    assert_eq!(keys, session.dispatch_pipeline_keys());
+}
+
+#[test]
+#[ignore = "GPU tuning requires an idle device"]
+fn tune_native_cooperative_f32() {
+    use meganeura::compile::ShaderEntry;
+    // Deliberately fail on unsupported hardware: a scalar fallback must not
+    // masquerade as native-f32 qualification. Run this test only on a device
+    // advertising f32 tiles, separately from the portable qualification tests.
+    let gpu = std::sync::Arc::new(meganeura::init_gpu_context().unwrap());
+    assert!(
+        gpu.capabilities().cooperative_matrix.f32_tile > 0,
+        "native f32 matrix hardware required; this test cannot qualify a scalar fallback"
+    );
+    for shader in [
+        ShaderEntry::MatMul,
+        ShaderEntry::MatMulAT,
+        ShaderEntry::MatMulBT,
+        ShaderEntry::FusedMatMulAdd,
+    ] {
+        // Below occupancy threshold, already-promoted padded rows, above
+        // the static large-shape veto, respectively. Never force a winner.
+        for (m, n, k) in [(32, 32, 17), (97, 128, 17), (2048, 32, 17)] {
+            let graph = matmul_graph(&shader, m, n, k);
+            let (mut session, _) = build(
+                &graph,
+                SessionConfig {
+                    gpu: Some(std::sync::Arc::clone(&gpu)),
+                    mode: Mode::Inference,
+                    ..Default::default()
+                },
+            );
+            let report = session
+                .tune_with(TuneOptions {
+                    max_time: Duration::from_secs(60),
+                    ..Default::default()
+                })
+                .unwrap();
+            assert_eq!(report.visited_classes, 1, "{report:?}");
+            assert_eq!(report.outcomes.len(), 2, "{report:?}");
+            let native = report
+                .outcomes
+                .iter()
+                .find(|o| {
+                    matches!(o.initial, MatmulTile::CooperativeF32 { .. })
+                        || matches!(o.candidate, MatmulTile::CooperativeF32 { .. })
+                })
+                .expect(
+                    "native-f32 implementation must participate despite profitability thresholds",
+                );
+            assert!(native.qualified, "{native:?}");
+            assert!(native.candidate_median_ms.unwrap() > 0.0);
+        }
+    }
 }


### PR DESCRIPTION
Smaller version of #158 without the experiments

Implement state-isolated measured selection, phase and scratch accounting, published Blade 0.9 support, logical checkpoint preflight, lazy optimizer state, and exact convolution indexing. Keep split-K experimental and defer the rejected accumulation candidate.