### PR TITLE
Expose native capture support and descriptive pipeline labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ win, so explicit code always has the last word.
 | `MEGANEURA_FLASH_BWD_EPT_CAP=<n>` | Shared fallback cap for both flash backward kernels. |
 | `MEGANEURA_DEVICE_ID=0x744c` | Adapter selection by numeric device id. |
 | `MEGANEURA_GPU_TIMING` | Enable hardware timestamp pools (set before context creation). |
+| `MEGANEURA_GPU_CAPTURE` | Enable Blade's native-tool labels and shader debug information before context creation; independent of GPU timing. |
 
 `Session::tune_with(TuneOptions)` searches 32/64 scalar and legal native-f32
 cooperative tiles for exact dense matmul classes, qualifies nonzero scratch outputs, interleaves measurements,

--- a/docs/study/observability.md
+++ b/docs/study/observability.md
@@ -232,6 +232,25 @@ backend exposes them, are supporting diagnostics, not a timing model.
 [profiling protocol](../performance-profiling.md),
 [GPU example](../../examples/profile_session.rs)
 
+For native tools, set `GpuOptions { capture: true, ..Default::default() }`
+before creating the context, or use `MEGANEURA_GPU_CAPTURE=1` with a
+`from_env` caller. This exposes Blade's capture support independently of
+`timing` and `Session::set_profiling`: leave both timing switches off when
+examining the production grouped schedule. It does not start a profiler.
+Pipeline object names now reuse the same variant keys as the structured
+profile, instead of ambiguous entry-point names such as `main`.
+
+On Vulkan, Blade 0.9 emits shader debug information and WGSL files under the
+process temporary directory's `blade` subdirectory. Its SPIR-V source-language
+tag is GLSL for Nsight compatibility; the retained source is still WGSL.
+Keep those files outside Git with the diagnostic capture. Debug information
+and pipeline names do not guarantee source correlation or loss-free hardware
+events: verify both in the native tool, and preserve numeric qualification.
+The initial Nsight pilot had hardware-event overflow, so it cannot support a
+complete per-dispatch breakdown. GPU/host memory budgets must include the
+profiler, not just the model. See Inferena's
+[bounded workflow and evidence limits](https://github.com/kvark/inferena/blob/experiment/p3hpc-cuda-graphs/EXPERIMENT.md#nvidia-paper-analysis-captures).
+
 `MemorySummary` separates plan capacities (including padding), graph
 allocations after aliasing, and actually allocated moments, accumulators and
 auxiliary buffers. `total_allocated_bytes()` sums those retained buffer

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,6 +179,8 @@ registry! {
         "Adapter selection by backend-reported numeric device id (decimal or 0x-hex).";
     GPU_TIMING: "MEGANEURA_GPU_TIMING", Bool, Selection,
         "Enable hardware timestamp query pools (must be set before the GPU context is created).";
+    GPU_CAPTURE: "MEGANEURA_GPU_CAPTURE", Bool, Selection,
+        "Enable Blade's shader debug information and native-tool capture support; independent of timestamps.";
 
     // --- Read by tests/examples, not the library ---
     TRACE: "MEGANEURA_TRACE", Text, External,
@@ -306,7 +308,7 @@ impl SessionOptions {
 }
 
 impl GpuOptions {
-    /// Adapter selection and timestamp collection from the environment.
+    /// Adapter selection, timestamps and native capture from the environment.
     pub fn from_env() -> Self {
         log_overrides();
         let device_id = DEVICE_ID.text().and_then(|value| {
@@ -322,6 +324,7 @@ impl GpuOptions {
         Self {
             device_id,
             timing: GPU_TIMING.bool_or(false),
+            capture: GPU_CAPTURE.bool_or(false),
         }
     }
 }
@@ -330,9 +333,9 @@ impl SessionConfig<'_> {
     /// A [`SessionConfig`] with every environment override applied — the
     /// one-liner for harnesses, examples, and env-driven test runs:
     /// compile options, tuning knobs, optimizer mode, diagnostic switches,
-    /// coop policy, `MEGANEURA_TUNE`, and (only when `MEGANEURA_DEVICE_ID`
-    /// or `MEGANEURA_GPU_TIMING` is set) a GPU context created with those
-    /// options. Also installs the WGSL dump directory when
+    /// coop policy, `MEGANEURA_TUNE`, and a GPU context when device selection,
+    /// `MEGANEURA_GPU_TIMING` or `MEGANEURA_GPU_CAPTURE` is enabled.
+    /// Also installs the WGSL dump directory when
     /// `MEGANEURA_DUMP_WGSL` is set.
     ///
     /// Fields assigned *after* this call win — precedence is simply
@@ -343,7 +346,7 @@ impl SessionConfig<'_> {
             crate::codegen::set_wgsl_dump_dir(dir);
         }
         let gpu_opts = GpuOptions::from_env();
-        let gpu = if gpu_opts.device_id.is_some() || gpu_opts.timing {
+        let gpu = if gpu_opts.device_id.is_some() || gpu_opts.timing || gpu_opts.capture {
             match crate::runtime::init_gpu_context_with(gpu_opts) {
                 Ok(context) => Some(std::sync::Arc::new(context)),
                 Err(e) => {
@@ -461,16 +464,27 @@ mod tests {
     }
 
     #[test]
-    fn no_winograd_reaches_the_typed_option() {
-        // Not set: the rewrite stays on.
-        unsafe { std::env::remove_var("MEGANEURA_NO_WINOGRAD") };
-        assert!(!crate::optimize::OptimizeConfig::from_env().no_winograd);
-        // Set: it turns off, and "0" means off in the uniform semantics.
-        unsafe { std::env::set_var("MEGANEURA_NO_WINOGRAD", "1") };
-        assert!(crate::optimize::OptimizeConfig::from_env().no_winograd);
-        unsafe { std::env::set_var("MEGANEURA_NO_WINOGRAD", "0") };
-        assert!(!crate::optimize::OptimizeConfig::from_env().no_winograd);
-        unsafe { std::env::remove_var("MEGANEURA_NO_WINOGRAD") };
+    fn boolean_overrides_reach_typed_options() {
+        for (value, enabled) in [(None, false), (Some("1"), true), (Some("0"), false)] {
+            for name in ["MEGANEURA_NO_WINOGRAD", "MEGANEURA_GPU_CAPTURE"] {
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(name, value),
+                        None => std::env::remove_var(name),
+                    }
+                }
+            }
+            assert_eq!(
+                crate::optimize::OptimizeConfig::from_env().no_winograd,
+                enabled
+            );
+            assert_eq!(GpuOptions::from_env().capture, enabled);
+            assert!(!GpuOptions::default().capture);
+        }
+        unsafe {
+            std::env::remove_var("MEGANEURA_NO_WINOGRAD");
+            std::env::remove_var("MEGANEURA_GPU_CAPTURE");
+        }
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1143,12 +1143,13 @@ impl Pipelines {
                 if let Some(entries) = entries_for_group.get(&group) {
                     for entry in entries {
                         let layout = shader_data_layout(entry);
+                        let variant = key(entry.clone());
                         let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                            name: entry.entry_point(),
+                            name: &variant.label(),
                             data_layouts: &[&layout],
                             compute: shader.at(entry.entry_point()),
                         });
-                        target.insert(key(entry.clone()), pipeline);
+                        target.insert(variant, pipeline);
                     }
                 }
             };
@@ -1215,12 +1216,13 @@ impl Pipelines {
                 naga_module: Some(sm.module),
             });
             let layout = shader_data_layout(&entry);
+            let key = Variant::Attention(entry.clone(), hd);
             let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                name: entry.entry_point(),
+                name: &key.label(),
                 data_layouts: &[&layout],
                 compute: shader.at(entry.entry_point()),
             });
-            map.insert(Variant::Attention(entry, hd), pipeline);
+            map.insert(key, pipeline);
         }
         // Conv2d coop dispatches were rewritten by `select_variants` to
         // generated per-(kernel, stride) entries, compiled individually
@@ -1282,12 +1284,13 @@ impl Pipelines {
                     naga_module: Some(sm.module),
                 });
                 let layout = shader_data_layout(entry);
+                let key = Variant::Coop(entry.clone());
                 let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                    name: entry.entry_point(),
+                    name: &key.label(),
                     data_layouts: &[&layout],
                     compute: shader.at(entry.entry_point()),
                 });
-                map.insert(Variant::Coop(entry.clone()), pipeline);
+                map.insert(key, pipeline);
             }
         }
 
@@ -1303,12 +1306,13 @@ impl Pipelines {
             });
             let entry = ShaderEntry::MatMulGemv;
             let layout = <MatMulRmsNormData as blade_graphics::ShaderData>::layout();
+            let key = Variant::GemvRmsNorm(entry.clone());
             let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                name: "matmul_gemv_rmsnorm",
+                name: &key.label(),
                 data_layouts: &[&layout],
                 compute: shader.at(entry.entry_point()),
             });
-            map.insert(Variant::GemvRmsNorm(entry), pipeline);
+            map.insert(key, pipeline);
         }
 
         // Compile weight-format-specific pipelines (f16, Q4, Q8).
@@ -1345,7 +1349,7 @@ impl Pipelines {
                 });
                 let layout = shader_data_layout(&dispatch.shader);
                 let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                    name: dispatch.shader.entry_point(),
+                    name: &slot.key().label(),
                     data_layouts: &[&layout],
                     compute: shader.at(dispatch.shader.entry_point()),
                 });
@@ -1370,7 +1374,7 @@ impl Pipelines {
                 });
                 let layout = shader_data_layout(&dispatch.shader);
                 let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                    name: dispatch.shader.entry_point(),
+                    name: &coop_key.label(),
                     data_layouts: &[&layout],
                     compute: shader.at(dispatch.shader.entry_point()),
                 });
@@ -1408,7 +1412,7 @@ impl Pipelines {
                 });
                 let layout = matmul_with_prologue_layout(prologue.factors.len());
                 let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                    name: dispatch.shader.entry_point(),
+                    name: &key.label(),
                     data_layouts: &[&layout],
                     compute: shader.at(dispatch.shader.entry_point()),
                 });
@@ -1441,7 +1445,7 @@ impl Pipelines {
             });
             let layout = pointwise_data_layout(dag.n_inputs);
             let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                name: crate::schedule::POINTWISE_ENTRY,
+                name: &key.label(),
                 data_layouts: &[&layout],
                 compute: shader.at(crate::schedule::POINTWISE_ENTRY),
             });
@@ -1465,7 +1469,7 @@ impl Pipelines {
             });
             let layout = reduction_data_layout(kernel);
             let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                name: crate::schedule::REDUCTION_ENTRY,
+                name: &key.label(),
                 data_layouts: &[&layout],
                 compute: shader.at(crate::schedule::REDUCTION_ENTRY),
             });
@@ -1501,7 +1505,7 @@ impl Pipelines {
             });
             let layout = horizontal_matmul_layout(count);
             let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-                name: "horizontal_matmul",
+                name: &key.label(),
                 data_layouts: &[&layout],
                 compute: shader.at("main"),
             });
@@ -3420,18 +3424,8 @@ impl Session {
     }
 }
 
-/// Convenience: create a Blade GPU context with the same defaults
-/// `Session::new` uses, honoring the `MEGANEURA_DEVICE_ID` env var.
-///
-/// Use this when you need a context for [`auto_tune`] before any
-/// session exists. The returned context can be dropped after the tune
-/// or shared with sessions via `Session::with_context`.
-///
-/// # Safety
-/// Wraps `blade_graphics::Context::init`, which is `unsafe` because it
-/// loads the system graphics driver.
 /// GPU context creation options. The library never reads the environment;
-/// map `MEGANEURA_DEVICE_ID` / `MEGANEURA_GPU_TIMING` with
+/// map device, timing and capture overrides with
 /// [`GpuOptions::from_env`] if you want env-driven selection.
 #[derive(Clone, Debug, Default)]
 pub struct GpuOptions {
@@ -3440,8 +3434,14 @@ pub struct GpuOptions {
     /// Enable hardware timestamp query pools (needed before the context
     /// exists; feeds `dump_gpu_timings` and the profiler).
     pub timing: bool,
+    /// Enable Blade's native-tool capture support, including shader debug
+    /// information and command labels. Independent of pass timestamps;
+    /// does not change Meganeura's dispatch grouping. Off by default.
+    pub capture: bool,
 }
 
+/// Create a GPU context with the same environment-independent defaults as
+/// [`Session::new`]. Use [`init_gpu_context_with`] for explicit options.
 pub fn init_gpu_context() -> Result<blade_graphics::Context, blade_graphics::NotSupportedError> {
     init_gpu_context_with(GpuOptions::default())
 }
@@ -3458,7 +3458,7 @@ pub fn init_gpu_context_with(
             // when a command buffer is re-begun; on slow GPUs the previous
             // submission may still be in flight. Keep this off by default.
             timing: options.timing,
-            capture: false,
+            capture: options.capture,
             overlay: false,
             device_id: dev_id,
             ..Default::default()

--- a/src/runtime/tuning.rs
+++ b/src/runtime/tuning.rs
@@ -52,7 +52,7 @@ impl Pipelines {
             .map_err(|error| error.to_string())?;
         let layout = super::shader_data_layout(&selected_entry);
         let pipeline = gpu.create_compute_pipeline(bg::ComputePipelineDesc {
-            name: selected_entry.entry_point(),
+            name: &key.label(),
             data_layouts: &[&layout],
             compute: shader.at(selected_entry.entry_point()),
         });


### PR DESCRIPTION
## Summary

- Reuse existing `Variant::label()` keys for Blade pipeline object names, including tuned/generated variants, instead of ambiguous names such as `main`.
- Expose Blade's default-off capture support through `GpuOptions::capture` / `MEGANEURA_GPU_CAPTURE`, independent of pass timestamps and dispatch grouping.
- Document source correlation and capture-memory limits in the study guide. Extend the existing CPU boolean-option check; no new test binary or artifact fixtures.

This prepares Nsight shader-level gap analysis. No shader arithmetic, precision policy, allocation plan or barrier schedule changes. `GpuOptions` gains a public field; explicit struct literals should use `capture: false` or `..Default::default()`.

## Validation

`cargo fmt --all` and `git diff --check` passed locally. [CI is green](https://github.com/kvark/meganeura/actions/runs/34363214875): Linux/lavapipe and macOS/Metal tests, Windows compilation, Rust 1.92 MSRV, all-target/all-feature checks, clippy, docs, package verification, dependency audit and frozen-paper verification. Rust host coverage was generated from the same Linux test run and retained by revision; WGSL is not coverage-instrumented and the existing CI backprop/bit-exact skips still apply.

Build/tests ran in CI because the local host remains memory-constrained following the earlier profiler OOM. No new local GPU work, driver change or reboot.

Draft pending a short, bounded hardware capture verifying labels/source correlation and unchanged numerical outputs. Inferena's collection pin and existing measurement tags are unchanged. No performance improvement claimed.