### PR TITLE
Explain cheap specialization as a budget for on-device tuning

### DIFF
--- a/docs/study/p3hpc-questions.md
+++ b/docs/study/p3hpc-questions.md
@@ -152,6 +152,13 @@ state evidence and limited transfer, not “automatic tuning makes training
 faster.” More representative kernel families and controlled confirmation come
 before default-on or persistent winners.
 
+For the paper's proposed compile-and-tune emphasis, see
+[cheap compilation as a search budget](performance-plan.md#cheap-compilation-as-a-search-budget).
+One preparation API already combines the stages, but graph rewriting and
+kernel selection are not a joint search today. Naga-only timing is not
+end-to-end pipeline preparation, and low compilation cost alone does not
+establish tuning amortization or novelty over TVM/Triton.
+
 ## Numerical behavior
 
 ### 13. Does strict f32 mean identical results?

--- a/docs/study/performance-plan.md
+++ b/docs/study/performance-plan.md
@@ -83,6 +83,59 @@ The diagnostic's old fixed barrier-cost estimate was removed. The absence of
 matches in its narrow legacy fusion matcher does not establish absence of
 optimization opportunities.
 
+## Cheap compilation as a search budget
+
+Suggested paper/talk framing: **a compact compiler makes hardware measurement
+part of on-device executable preparation, under one numerical contract**.
+Fast specialization is useful both for deployment startup and for trying legal
+implementations before committing to a plan. This is a stronger design argument
+than code size alone, but a hypothesis about broader performance gains, not a
+new result in the frozen matrix.
+
+We already have one preparation entry point: `SessionConfig { tune: true }`
+runs measured selection before `build` returns, including on a semantic-cache
+hit. It is not yet joint graph-and-kernel search: greedy graph rewrites and the
+allocation plan are fixed before the tuner compares compatible implementations.
+The selected variants live only in that session. `runtime::auto_tune` is a
+capability probe, not this measured search.
+
+The proposed **100 µs Naga / 10,000× Triton** comparison is not established by
+our records. Naga parses, validates and translates shaders; Blade still asks
+the native driver to create executable pipelines. Comparing Naga alone with
+Triton's entire lowering/native-compilation path mixes boundaries. Measure
+graph rewriting, WGSL generation/Naga processing, native pipeline creation,
+scratch/qualification, and timing/selection separately; declare cold versus
+warm compiler and driver caches. The paper's existing 0.08–2.36 s figures
+cover whole-workload preparation, not a single shader or measured tuning.
+[Naga's documented stages](https://docs.rs/naga/30.0.1/naga/)
+
+Why not always search? Compilation is only one cost. Private inputs, uploads,
+full-output readback/checks, warmups and enough interleaved trials to distinguish
+a gain from noise remain necessary. The read-optimized staging work below has
+already removed much of the old readback penalty: dense-only synthetic searches
+take about 32–45 ms in the SameSize experiment. The later ResNet convolution
+search still takes about 640 ms, mostly sampling, without a guarded whole-step
+win. Cheap shaders cannot make an unprofitable or incomplete candidate space
+profitable; repeated shapes help, but different bindings/precision still matter.
+
+Use `extra preparation / (baseline step − tuned step)` for break-even uses
+when the denominator is positive. Keep compilation, search and ordinary whole
+steps visible separately. Default-on needs representative whole-step gains that
+repay the budget, not just isolated kernel winners. An eventual persistent
+cache must include device/driver, generator, exact class and validation contract;
+it must not transfer a winner merely because a marketing name matches.
+
+The lean next step is to widen the existing generator's legal choices where
+profiles justify them, reuse exact classes, and allocate a bounded preparation
+budget. Do not enumerate the cross-product of every graph rewrite and tile or
+silently enable tuning in the new Inferena baseline. Collect that pinned
+untuned cohort first; a declared tuned/untuned ablation can test this thesis.
+TVM/Ansor and Triton already integrate compilation and measured search. Our
+distinction would be the cost, scope and portable native implementation, not
+the invention of compile-time autotuning.
+[Ansor](https://www.usenix.org/conference/osdi20/presentation/zheng),
+[Triton autotune](https://triton-lang.org/main/python-api/generated/triton.autotune.html)
+
 ## Implemented search: dense tiles and scalar convolution derivatives
 
 `Session::tune()` uses defaults; `Session::tune_with(TuneOptions)` returns a

--- a/paper/p3hpc/REVISION.md
+++ b/paper/p3hpc/REVISION.md
@@ -5,6 +5,14 @@ This is a revised working draft and preparation kit, not a declaration that
 the camera-ready has been approved or submitted. Acceptance-specific upload
 conditions and talk instructions still need confirmation.
 
+September 10: the deployment discussion now connects short specialization to
+bounded on-device search, with a [study explanation](../../docs/study/performance-plan.md#cheap-compilation-as-a-search-budget).
+It distinguishes today's opt-in, post-rewrite kernel selection from joint
+graph-and-kernel search and keeps it outside the frozen matrix. Neither a
+100 µs end-to-end compile nor a 10,000× Triton advantage is claimed. Those
+boundaries and amortized whole-step gains need matched measurements before
+making this the paper's central performance result.
+
 The response matrix below paraphrases `review1.txt`, `review2.txt` and
 `review3.txt` supplied at `/home/kvark/Documents/P3HPC`; private review text
 is not copied into Git. The CUDA Graph concern is confirmed in the frozen

--- a/paper/p3hpc/main.tex
+++ b/paper/p3hpc/main.tex
@@ -735,6 +735,15 @@ deployment-closure comparison rather than a feature-equivalence or
 developer-productivity claim; Section~\ref{sec:edge} supplies the physical
 application check.
 
+Short specialization also creates a budget for on-device autotuning. A
+post-freeze, opt-in path qualifies and measures compatible kernel variants
+after graph rewriting, before returning the session; it does not explain the
+frozen timings. Compilation with autotuning is established
+\cite{chen2018tvm,tillet2019triton}. The question here is whether useful
+whole-step gains repay native pipeline creation, numerical qualification and
+measurement---not shader translation alone---within a compact deployment's
+startup budget.
+
 \section{Related Work}
 
 Pennycook et al.\ define and later revisit the portability metric and


### PR DESCRIPTION
Connect short specialization to bounded hardware-measured search in the P3HPC draft and study guide.

- Explain today's opt-in build-time kernel selection versus joint graph/kernel search.
- Separate Naga translation, native pipeline creation, qualification and sampling costs; no unmeasured 100 µs end-to-end or 10,000× Triton claim.
- Use the existing staging/search evidence and amortization criterion to explain why tuning is not default-on yet.

Documentation only: no runtime, benchmark data, generated tables or binaries changed. The Inferena dependency update and one-command collection workflow stay on its experiment branch.

Validation: frozen artifact verifier passes; the P3HPC PDF builds to 10 pages with no undefined references/citations or overfull boxes. Inspected the revised page. Only the author merges.