### PR TITLE
Emphasize integrated compile-time tuning and scope the evidence

### DIFF
--- a/docs/study/p3hpc-questions.md
+++ b/docs/study/p3hpc-questions.md
@@ -152,12 +152,23 @@ state evidence and limited transfer, not “automatic tuning makes training
 faster.” More representative kernel families and controlled confirmation come
 before default-on or persistent winners.
 
+This is not a negative result across the paper's models and platforms. The
+tests used one RTX 5070 and a narrow tile search, not the full Inferena matrix;
+the role-reversed dense follow-up accepted a 1.177× whole-step gain. Greedy
+rewriting is shared by both arms: empirical kernel selection augments it,
+rather than competing with it. Broader search and cross-device transfer have
+not been measured.
+
 For the paper's proposed compile-and-tune emphasis, see
 [cheap compilation as a search budget](performance-plan.md#cheap-compilation-as-a-search-budget).
 One preparation API already combines the stages, but graph rewriting and
 kernel selection are not a joint search today. Naga-only timing is not
 end-to-end pipeline preparation, and low compilation cost alone does not
 establish tuning amortization or novelty over TVM/Triton.
+We should emphasize the integrated compile-and-tune deployment workflow and
+measure the inexpensive Naga stage explicitly. Native driver compilation is
+an additional cost to report, not a reason to suppress that architectural
+argument or the value of cheap candidate generation.
 
 ## Numerical behavior
 

--- a/docs/study/performance-plan.md
+++ b/docs/study/performance-plan.md
@@ -37,6 +37,14 @@ MLP Adam to 1.052× for MLP inference. These are synthetic engineering results,
 not new cross-engine or convergence evidence. This limits the pilot's scope;
 it does not justify default-on tuning or lowering the threshold.
 
+These experiments do **not** show that empirical tuning cannot improve our
+measured models on any target platform. All ran on one RTX 5070, chiefly over
+the existing scalar 32/64 tiles; the device cannot exercise native-f32
+cooperative challengers. Synthetic holdouts are not the complete Inferena
+model/shape matrix. The later role-reversed dense confirmation accepted a
+1.177× whole-step gain. Other devices, broader kernel choices and full-size
+model transfer remain unmeasured, not negative results.
+
 ## The objective
 
 Win useful workloads under a matched numerical and workload contract, without
@@ -89,8 +97,9 @@ Suggested paper/talk framing: **a compact compiler makes hardware measurement
 part of on-device executable preparation, under one numerical contract**.
 Fast specialization is useful both for deployment startup and for trying legal
 implementations before committing to a plan. This is a stronger design argument
-than code size alone, but a hypothesis about broader performance gains, not a
-new result in the frozen matrix.
+than code size alone: the deployed compiler can automatically specialize to
+the actual device without an offline, per-model tuning workflow. Broader
+performance gains remain a hypothesis, not a new result in the frozen matrix.
 
 We already have one preparation entry point: `SessionConfig { tune: true }`
 runs measured selection before `build` returns, including on a semantic-cache
@@ -98,6 +107,14 @@ hit. It is not yet joint graph-and-kernel search: greedy graph rewrites and the
 allocation plan are fixed before the tuner compares compatible implementations.
 The selected variants live only in that session. `runtime::auto_tune` is a
 capability probe, not this measured search.
+
+It is fair to call this **autotuning inside compilation/session preparation**:
+the caller asks for a ready executable, not a separate tuning exercise. It is
+not fair to describe the experiment as empirical tuning *versus* greedy graph
+search. Both arms use the same greedy rewrites; tuning adds measured kernel
+selection afterward. Fusion/layout/graph alternatives are not being searched
+by today's tuner. A negative tile-search result cannot evaluate that broader
+design.
 
 The proposed **100 µs Naga / 10,000× Triton** comparison is not established by
 our records. Naga parses, validates and translates shaders; Blade still asks
@@ -108,6 +125,14 @@ scratch/qualification, and timing/selection separately; declare cold versus
 warm compiler and driver caches. The paper's existing 0.08–2.36 s figures
 cover whole-workload preparation, not a single shader or measured tuning.
 [Naga's documented stages](https://docs.rs/naga/30.0.1/naga/)
+
+We should explicitly report Naga's inexpensive stage as well as native
+pipeline creation. The latter does not negate the former's value: inexpensive
+candidate generation is precisely what can make a useful search affordable.
+A measured 100 µs translation result would support that stage-level claim;
+only matched end-to-end measurements could support a 10,000× compile advantage.
+The paper can make the architectural argument now without waiting for that
+ratio, and show an untuned/tuned ablation as separate evidence when available.
 
 Why not always search? Compilation is only one cost. Private inputs, uploads,
 full-output readback/checks, warmups and enough interleaved trials to distinguish

--- a/paper/p3hpc/REVISION.md
+++ b/paper/p3hpc/REVISION.md
@@ -13,6 +13,12 @@ graph-and-kernel search and keeps it outside the frozen matrix. Neither a
 boundaries and amortized whole-step gains need matched measurements before
 making this the paper's central performance result.
 
+The follow-up states the positive architectural argument explicitly: empirical
+tuning runs automatically inside session construction when enabled, without a
+separate offline workflow. The study guide now limits the negative transfer
+evidence to the one-device, narrow tile-search experiment; it is not an
+all-model/all-platform result, nor a comparison against greedy graph rewriting.
+
 The response matrix below paraphrases `review1.txt`, `review2.txt` and
 `review3.txt` supplied at `/home/kvark/Documents/P3HPC`; private review text
 is not copied into Git. The CUDA Graph concern is confirmed in the frozen

--- a/paper/p3hpc/main.tex
+++ b/paper/p3hpc/main.tex
@@ -735,14 +735,15 @@ deployment-closure comparison rather than a feature-equivalence or
 developer-productivity claim; Section~\ref{sec:edge} supplies the physical
 application check.
 
-Short specialization also creates a budget for on-device autotuning. A
-post-freeze, opt-in path qualifies and measures compatible kernel variants
-after graph rewriting, before returning the session; it does not explain the
-frozen timings. Compilation with autotuning is established
-\cite{chen2018tvm,tillet2019triton}. The question here is whether useful
-whole-step gains repay native pipeline creation, numerical qualification and
-measurement---not shader translation alone---within a compact deployment's
-startup budget.
+Cheap specialization enables empirical autotuning inside compilation:
+our post-freeze opt-in path automatically qualifies and measures compatible
+kernels on the deployment device before returning a session, without a
+separate offline workflow. Selection follows greedy rewriting; it neither
+jointly searches graphs nor explains the frozen timings. Compile-time
+autotuning is established \cite{chen2018tvm,tillet2019triton}; here the
+opportunity is compact, portable deployment. Native pipeline creation,
+qualification and measurement join shader translation in a preparation budget
+that whole-step gains must repay.
 
 \section{Related Work}
 


### PR DESCRIPTION
Follow-up to merged #168 and the author's clarification.

- State the positive architectural argument: empirical tuning runs automatically inside executable/session preparation when enabled, without a separate offline workflow.
- Clarify that the RTX 5070 tile-search holdouts are not an all-model/all-platform negative result, and that both tuned/untuned arms share greedy graph rewrites. Retain the accepted synthetic dense wins.
- Explain why Naga-stage timing is worth reporting alongside native pipeline creation; do not conflate it with an unmeasured end-to-end 10,000× ratio.

Documentation only: no new benchmark data, binaries, test targets, or runtime policy changes. The artifact verifier passes and frozen tables are unchanged. The PDF builds with resolved citations/references and no overfull boxes (11 pages including references). Inferena repeatability/qualification work is separate on its experiment branch.