### PR TITLE
Document P3HPC portability findings

### DIFF
--- a/docs/study/p3hpc-questions.md
+++ b/docs/study/p3hpc-questions.md
@@ -230,6 +230,13 @@ and provide GPU-reference-only ratios separately. The complete-machine
 portability score includes CPU because that is the working reference on that
 machine, not because CPU time measures the iGPU's hardware potential.
 
+The camera-ready follow-up adds a different Intel machine: Arc B570 versus the
+common PyTorch 2.13 XPU source. Default/no-graph completes all pairs, but native
+dense embedding backward fails a shape-derived exact probe. The runner selects
+PyTorch's qualified dense `index_add` equivalent and records it in every
+affected result. Keep this separate from the frozen RPL-U/CPU row and call it a
+qualified-workaround availability result, not stock native-XPU performance.
+
 ### 20. Why not PyTorch max-autotune or CUDA graphs?
 
 Short: they were absent from the frozen matrix; the controlled follow-up tests

--- a/docs/study/p3hpc-questions.md
+++ b/docs/study/p3hpc-questions.md
@@ -232,15 +232,22 @@ machine, not because CPU time measures the iGPU's hardware potential.
 
 ### 20. Why not PyTorch max-autotune or CUDA graphs?
 
-Short: they are important stronger automatic baselines that were not tested.
+Short: they were absent from the frozen matrix; the controlled follow-up tests
+them and records where they are unavailable.
 
 Detail: the frozen protocol uses default `torch.compile` on Linux and no
 additional manual capture. Its explicit CUDA Graph helpers were only used by
 the legacy runner, which the paper-v1 path bypassed. A captured compiler IR
-is not a replayed CUDA command graph. `reduce-overhead`/`max-autotune` can change capture
-and selection without model-specific kernels. The paper now states this
-limitation explicitly. A new sweep must verify actual activation and charge
-compile/search cost, memory and accuracy, not silently replace the old data.
+is not a replayed CUDA command graph. `reduce-overhead`/`max-autotune` can
+change capture and selection without model-specific kernels. The RTX 5070
+follow-up completes all default/no-graph, default/graph and max-autotune/graph pairs. On both AMD
+systems, max-autotune fails during diffusion training compilation: generated
+convolution candidates exceed local-memory limits or time out, then Inductor's
+ATen fallback is missing a required output buffer. Those failures are a
+portability result, not permission to substitute eager timing. AMD collection
+retains default mode and explicitly labels the missing condition. The new sweep
+also charges compile/search cost, memory and accuracy rather than silently
+replacing the old data.
 
 The [CUDA Graph follow-up](../../paper/p3hpc/CUDA-GRAPHS.md) explains the repair,
 the exact timed boundary and the new collection plan. Do not claim that the

--- a/paper/p3hpc/CUDA-GRAPHS.md
+++ b/paper/p3hpc/CUDA-GRAPHS.md
@@ -103,6 +103,16 @@ Meganeura in each paired campaign. Store records outside main; retain source
 refs and concise conclusions. NVIDIA results cannot establish ROCm/Metal
 behavior.
 
+The Arc B570 default/no-graph availability cohort is complete at Inferena
+`f4255c4b`: all 10 qualification and 30 measured pairs pass. PyTorch's native
+dense embedding backward failed an exact `[128, 576]` probe in every SmolLM2
+process, so the probe selected and qualified a standard dense `index_add`
+autograd formulation. Each affected result records both probe outcomes and the
+selection under `execution.embedding_backward`; this must be labelled as a
+qualified workaround. XPU max-autotune did not finish its first ResNet
+qualification within one hour, so it remains an omitted condition rather than
+a hidden fallback or a timing sample.
+
 Do not replace individual favorable cells in the old table or compare new
 PyTorch measurements to old Meganeura timings. A new qualified cohort gets its
 own table and provenance. Until then, the submitted table remains a comparison

--- a/paper/p3hpc/CUDA-GRAPHS.md
+++ b/paper/p3hpc/CUDA-GRAPHS.md
@@ -50,13 +50,13 @@ and cross-engine validity gates, and adds explicit **whole-phase** capture:
 - Requested compile/capture failures stop that runner. Records disclose actual
   options and per-phase capture/validation; no eager timing is substituted.
 
-The September 10 replay policy also checks uncaptured repetitions. Strict
-gradients have fixed per-parameter RMS and maximum-error bounds. Accelerated
-gradients add an allowance calibrated from eight uncaptured calls, frozen
-before two held-out calls and two replays. An independent full-gradient error
-ceiling prevents unbounded allowance; output/loss checks remain elementwise.
-All errors are recorded, without forcing deterministic reference algorithms.
-This accommodates documented backward variability, not arbitrary drift. See Inferena's
+The replay policy also checks ordinary repetitions. Strict gradients retain
+the ordinary elementwise bounds. Accelerated training records every tensor and
+uses fixed whole-gradient maximum and RMS bounds over eight ordinary comparisons
+and two consecutive replays; the bounds are not fitted to the observed samples.
+Output/loss checks remain elementwise. All errors are recorded without forcing
+deterministic reference algorithms. This accommodates bounded backward
+variability, not arbitrary drift. See Inferena's
 [policy and qualification status](https://github.com/kvark/inferena/blob/experiment/p3hpc-cuda-graphs/EXPERIMENT.md#replay-qualification-policy);
 this changes replay integrity checks, not cross-engine accuracy gates.
 
@@ -75,12 +75,14 @@ phase, while retaining automatic kernel search in the max-autotune condition.
 
 ## What new evidence is required
 
-September 10: all 30 common-model CUDA qualification conditions pass on the
-RTX 5070 at implementation `24160533`. Inferena's source-only
-[`p3hpc-collection-2026-09-10`](https://github.com/kvark/inferena/tree/p3hpc-collection-2026-09-10)
-tag freezes the handoff. After setup, `python scripts/p3hpc.py` qualifies and
-collects without required arguments. Each additional machine must pass its
-own qualification; these preflight records do not update the paper's timings.
+September 11: the RTX 5070 campaign at Inferena `6f5f94cf` completes all 30
+common-model qualification pairs and 90 fresh-process measurement pairs, with
+no failures. The moving
+[`experiment/p3hpc-cuda-graphs`](https://github.com/kvark/inferena/tree/experiment/p3hpc-cuda-graphs)
+branch is the collection source until all platforms settle; no provisional tag
+is authoritative. Each additional machine must pass its own qualification.
+These new records remain outside Git and do not silently replace the paper's
+frozen timings.
 
 The September 8 strict ResNet-50 pilot qualified all three captured phases,
 including every element of 108 gradient tensors. Its two process-level records
@@ -90,13 +92,16 @@ process per condition is not a replicated performance claim or a new engine
 comparison. See that branch's `EXPERIMENT.md` for the small result table and
 the substantial graph-pool residency cost observed in the pilot.
 
-On each machine, first qualify all workloads. Then collect on an idle device with default
-compiled/no-graph, default compiled/graph, and max-autotune/graph, rotating
-configuration order across at least three fresh processes. Keep the same
-precision settings and timing boundaries. Recollect Meganeura in the same
-campaign, preserve failures, and report per-process dispersion, preparation
-cost and memory. Store records outside main; retain source refs and concise
-conclusions. NVIDIA results cannot establish ROCm/Metal behavior.
+On each machine, first qualify all workloads. NVIDIA collects default
+compiled/no-graph, default compiled/graph, and max-autotune/graph. ROCm has no
+qualified explicit graph condition. Both AMD systems reject max-autotune while
+compiling diffusion training, so they collect default/no-graph with
+`--no-max-autotune`; the manifest labels the omitted condition and the failed
+attempts remain evidence. Rotate configuration order across at least three
+fresh processes, keep precision and timing boundaries fixed, and recollect
+Meganeura in each paired campaign. Store records outside main; retain source
+refs and concise conclusions. NVIDIA results cannot establish ROCm/Metal
+behavior.
 
 Do not replace individual favorable cells in the old table or compare new
 PyTorch measurements to old Meganeura timings. A new qualified cohort gets its

--- a/paper/p3hpc/REVISION.md
+++ b/paper/p3hpc/REVISION.md
@@ -36,6 +36,15 @@ search as part of the portability surface. AMD default-mode collection remains
 valid as an explicitly labeled availability subset; no eager timing replaces
 the failed condition.
 
+The Arc B570 follow-up at Inferena `f4255c4b` completes all 10 default/no-graph
+qualification pairs and 30 replicated measurements. Its pinned XPU build has a
+repeatable native dense-embedding backward defect; a shape-derived probe selects
+and records the qualified dense `index_add` autograd equivalent for SmolLM2.
+Max-autotune did not finish its first ResNet qualification within one hour, so
+the B570 data is also an availability subset. This is useful portability
+evidence, but the workaround and omitted condition must remain visible in any
+new table.
+
 The response matrix below paraphrases `review1.txt`, `review2.txt` and
 `review3.txt` supplied at `/home/kvark/Documents/P3HPC`; private review text
 is not copied into Git. The CUDA Graph concern is confirmed in the frozen
@@ -103,7 +112,7 @@ comparison request.
 
 | Review / concern | Response and evidence | Manuscript location | Status |
 |---|---|---|---|
-| R1, R2: mixed reference versions, execution modes and CPU fallback | Distinguish installed-stack availability from a controlled engine comparison. Pin a common PyTorch release where supported and disclose exceptions separately. | Evaluation setup; result tables; portability metric | RTX controlled cohort complete at Inferena `6f5f94cf`; AMD default-mode collection pending. Both AMD max-autotune failures are retained as availability results. |
+| R1, R2: mixed reference versions, execution modes and CPU fallback | Distinguish installed-stack availability from a controlled engine comparison. Pin a common PyTorch release where supported and disclose exceptions separately. | Evaluation setup; result tables; portability metric | RTX controlled cohort complete at Inferena `6f5f94cf`; Arc B570 default-mode cohort complete at `f4255c4b` with its probe-selected PyTorch workaround labelled; AMD default-mode collection pending. AMD and XPU max-autotune limitations are retained as availability results. |
 | R1: missing CUDA Graph baseline for low latency | Paper-v1 bypassed explicit capture. Inferena now qualifies whole-phase forward, minimal forward and forward/loss/backward replay before a paired campaign. | Abstract; methodology; minimal-latency results; limitations; `CUDA-GRAPHS.md` | RTX 5070 campaign complete: 30 qualification and 90 measurement pairs across default/no-graph, default/graph and max-autotune/graph. No new timings have yet replaced the frozen tables. |
 | R1, R2: small workloads and consumer hardware do not establish datacenter scaling | State the consumer/edge question, reduced shapes and absent optimizer/distributed work. | Abstract; introduction; workloads; limitations; conclusion | Consumer/edge framing and datacenter/distributed-work exclusion revised. No scale extension claimed. |
 | R1, R2, R3: deployment efficiency is not programmer productivity | Separate compile/footprint metrics from qualitative application-author, backend-maintainer and debugging costs. | Deployment/productivity section; introduction; conclusion | Section retitled and rewritten, including the eager-PyTorch comparison and static-debugging costs. [Study guide](../../docs/study/observability.md) supplies detail. No productivity score claimed. |
@@ -119,7 +128,7 @@ Common questions and prepared responses are in
 discussion topics, not a substitute for actual review comments.
 
 Next evidence gate: complete the default-mode AMD availability cohorts and
-qualify each additional platform locally. Keep graph/uncaptured controls on
+qualify Windows/RTX 3050 and macOS locally. Keep graph/uncaptured controls on
 the same device, rotate order across fresh processes, and recollect both engines in
 the same campaign. The larger-model placement experiments are not a silent
 change to that collection tag. Do not interpret 20 samples from one process as 20

--- a/paper/p3hpc/REVISION.md
+++ b/paper/p3hpc/REVISION.md
@@ -26,6 +26,16 @@ separate offline workflow. The study guide now limits the negative transfer
 evidence to the one-device, narrow tile-search experiment; it is not an
 all-model/all-platform result, nor a comparison against greedy graph rewriting.
 
+September 11: the controlled RTX 5070 campaign completed all 120 paired entries
+(30 qualification and 90 replicated measurements) at Inferena `6f5f94cf`. On
+both AMD systems, PyTorch max-autotune instead fails while compiling the
+diffusion training graph:
+generated convolution candidates exhaust local memory or time out, and the
+remaining ATen fallback is malformed. The paper now treats automatic compiler
+search as part of the portability surface. AMD default-mode collection remains
+valid as an explicitly labeled availability subset; no eager timing replaces
+the failed condition.
+
 The response matrix below paraphrases `review1.txt`, `review2.txt` and
 `review3.txt` supplied at `/home/kvark/Documents/P3HPC`; private review text
 is not copied into Git. The CUDA Graph concern is confirmed in the frozen
@@ -93,8 +103,8 @@ comparison request.
 
 | Review / concern | Response and evidence | Manuscript location | Status |
 |---|---|---|---|
-| R1, R2: mixed reference versions, execution modes and CPU fallback | Distinguish installed-stack availability from a controlled engine comparison. Pin a common PyTorch release where supported and disclose exceptions separately. | Evaluation setup; result tables; portability metric | Available-stack scope and GPU/CPU populations now explicit, including the mixed-machine Pennycook score. Controlled cohort pending. |
-| R1: missing CUDA Graph baseline for low latency | Paper-v1 bypassed explicit capture. Inferena now qualifies whole-phase forward, minimal forward and forward/loss/backward replay before a paired campaign. | Abstract; methodology; minimal-latency results; limitations; `CUDA-GRAPHS.md` | All 30 conditions pass on RTX 5070: five common models × two precisions × default/no-graph, default/graph and max-autotune/graph. Collection tag `p3hpc-collection-2026-09-10`; other machines and replicated comparisons remain open. No new timings added to the paper. |
+| R1, R2: mixed reference versions, execution modes and CPU fallback | Distinguish installed-stack availability from a controlled engine comparison. Pin a common PyTorch release where supported and disclose exceptions separately. | Evaluation setup; result tables; portability metric | RTX controlled cohort complete at Inferena `6f5f94cf`; AMD default-mode collection pending. Both AMD max-autotune failures are retained as availability results. |
+| R1: missing CUDA Graph baseline for low latency | Paper-v1 bypassed explicit capture. Inferena now qualifies whole-phase forward, minimal forward and forward/loss/backward replay before a paired campaign. | Abstract; methodology; minimal-latency results; limitations; `CUDA-GRAPHS.md` | RTX 5070 campaign complete: 30 qualification and 90 measurement pairs across default/no-graph, default/graph and max-autotune/graph. No new timings have yet replaced the frozen tables. |
 | R1, R2: small workloads and consumer hardware do not establish datacenter scaling | State the consumer/edge question, reduced shapes and absent optimizer/distributed work. | Abstract; introduction; workloads; limitations; conclusion | Consumer/edge framing and datacenter/distributed-work exclusion revised. No scale extension claimed. |
 | R1, R2, R3: deployment efficiency is not programmer productivity | Separate compile/footprint metrics from qualitative application-author, backend-maintainer and debugging costs. | Deployment/productivity section; introduction; conclusion | Section retitled and rewritten, including the eager-PyTorch comparison and static-debugging costs. [Study guide](../../docs/study/observability.md) supplies detail. No productivity score claimed. |
 | R2: separate host/runtime overhead from GPU kernel costs | Pair synchronized wall time with host/GPU timelines and kernel-family profiles in separate diagnostic runs. Overlap prevents treating wall time minus summed dispatch medians as exact CPU time. | Methodology; minimal-latency results; gap analysis | Qualified Systems/Graphics diagnostics now separate host encoding, GPU execution and parameter placement on RTX 5070. Resident 135M/1.7B pairs retain full CUDA Graph gates. No removable-barrier percentage established; [development analysis](../../docs/experiments.md) remains separate from the frozen matrix. |
@@ -108,9 +118,9 @@ Common questions and prepared responses are in
 [the rehearsal guide](../../docs/study/p3hpc-questions.md); they are anticipated
 discussion topics, not a substitute for actual review comments.
 
-Next evidence gate: collect the qualified common-model cohort and qualify
-each additional platform locally. Keep graph/uncaptured controls on the same
-device, rotate order across fresh processes, and recollect both engines in
+Next evidence gate: complete the default-mode AMD availability cohorts and
+qualify each additional platform locally. Keep graph/uncaptured controls on
+the same device, rotate order across fresh processes, and recollect both engines in
 the same campaign. The larger-model placement experiments are not a silent
 change to that collection tag. Do not interpret 20 samples from one process as 20
 independent experimental replicates. Preserve source refs and concise results,

--- a/paper/p3hpc/main.tex
+++ b/paper/p3hpc/main.tex
@@ -722,6 +722,20 @@ driver --- no per-vendor package source, version pin, or compute runtime
 on any machine. These are reproducible configuration facts, not a timed
 measure of installation effort.
 
+A post-submission controlled qualification for the camera-ready cohort pins
+one PyTorch source revision across vendor builds and tests stronger automatic
+conditions separately. The RTX~5070 completes default compilation with and
+without whole-phase CUDA Graph replay and max-autotune with replay. On both AMD
+systems, however, max-autotune cannot compile the diffusion training graph:
+generated convolution-backward candidates exceed local-memory limits or time
+out, after which Inductor's library fallback is called without a required
+output buffer. The protocol preserves those failures, never substitutes eager
+timing, and collects default-compiled AMD results only as a labeled
+availability subset. This is not a \system{} speedup; it shows that compiler
+search is itself part of the portability surface. \system{}'s bounded tuner
+creates and numerically qualifies candidates on the selected device, measures
+only successful candidates, and retains the incumbent after rejection.
+
 Two deployment costs are quantified. Compilation: \system{} prepares a
 workload (all three sessions, pipelines included) in 0.08--1.52\,s strict
 and 0.08--2.36\,s accelerated across the measured devices; where
@@ -815,9 +829,14 @@ rounded mean at 0.93.
 The frozen protocol uses default \code{torch.compile}, without manual CUDA
 Graph capture. Automated \code{reduce-overhead} and \code{max-autotune}
 modes can change capture and kernel selection~\cite{pytorch2026compile};
-they were not tested. These are stronger automatic baselines, not necessarily
-application-specific tuning. The measured minimal-shape wins therefore do
-not establish superiority over all compiled PyTorch configurations.
+they were not tested in the frozen matrix. These are stronger automatic
+baselines, not necessarily application-specific tuning. The controlled
+follow-up completes CUDA Graph and max-autotune conditions on NVIDIA but finds
+max-autotune unavailable for diffusion training on both AMD systems, as
+described in Section~\ref{sec:productivity}. Those availability observations
+do not retroactively strengthen the frozen timing ratios; the measured
+minimal-shape wins therefore do not establish superiority over all compiled
+PyTorch configurations.
 
 The matrix reports 20 synchronized samples after warmup from one frozen
 process-level run per cell, not independent process replicates; raw samples

--- a/paper/p3hpc/main.tex
+++ b/paper/p3hpc/main.tex
@@ -736,6 +736,20 @@ search is itself part of the portability surface. \system{}'s bounded tuner
 creates and numerically qualifies candidates on the selected device, measures
 only successful candidates, and retains the incumbent after rejection.
 
+The same qualification exposed a different boundary on an Intel Arc B570.
+Default/no-graph XPU completed all ten workload--precision pairs and 30
+replicated measurements, but the pinned build's native dense embedding
+backward populated only 19,968 of 73,728 expected elements in an exact
+unique-index probe. A shape-derived preflight selected PyTorch's equivalent
+dense \code{index\_add} formulation, qualified all expected elements, and
+recorded the substitution with every affected result; the corrected full
+SmolLM gradient agrees with CPU and \system{}. Max-autotune remained in its
+first ResNet qualification after one hour and was omitted. We therefore label
+this an availability cohort using a qualified PyTorch workaround, not an
+unmodified native-XPU or full-condition result. It further illustrates why
+correctness and bounded search are parts of performance portability rather
+than setup details outside it.
+
 Two deployment costs are quantified. Compilation: \system{} prepares a
 workload (all three sessions, pipelines included) in 0.08--1.52\,s strict
 and 0.08--2.36\,s accelerated across the measured devices; where


### PR DESCRIPTION
## Summary

- add the paper-facing interpretation of the observed ROCm max-autotune diffusion failures
- document the Arc B570 XPU embedding-backward probe, qualified workaround, and omitted max-autotune condition
- keep benchmark records outside Git and leave the frozen timing tables unchanged

## Validation

- `python3 paper/p3hpc/artifact/verify.py --repository --show-facts`
- `python3 -m unittest discover -s paper/p3hpc/artifact -p 'test_*.py'`
- four-pass `pdflatex`/`bibtex` build with the documented local TeX packages
- `git diff --check origin/main..HEAD`