### PR TITLE
Disclose PyTorch's effective GEMM autotune gate

### DIFF
--- a/docs/study/p3hpc-questions.md
+++ b/docs/study/p3hpc-questions.md
@@ -256,6 +256,11 @@ retains default mode and explicitly labels the missing condition. The new sweep
 also charges compile/search cost, memory and accuracy rather than silently
 replacing the old data.
 
+Do not overstate the NVIDIA condition: pinned Inductor's fixed 68-SM policy
+disables GEMM template search on both the 48-SM RTX 5070 and 20-SM RTX 3050.
+The records expose that effective state. We test stock requested max-autotune;
+we do not claim that every internal kernel family actually searched candidates.
+
 The [CUDA Graph follow-up](../../paper/p3hpc/CUDA-GRAPHS.md) explains the repair,
 the exact timed boundary and the new collection plan. Do not claim that the
 submitted measurements already used this repaired baseline.

--- a/paper/p3hpc/CUDA-GRAPHS.md
+++ b/paper/p3hpc/CUDA-GRAPHS.md
@@ -84,6 +84,12 @@ is authoritative. Each additional machine must pass its own qualification.
 These new records remain outside Git and do not silently replace the paper's
 frozen timings.
 
+The pinned Inductor source only enables its GEMM template search at 68 NVIDIA
+SMs. It therefore records `inductor_is_big_gpu=false` on the 48-SM RTX 5070 and
+20-SM RTX 3050. Keep calling this the stock requested max-autotune condition,
+not full GEMM search; the experiment does not override PyTorch's hardware
+policy or silently substitute a hand-tuned configuration.
+
 The September 8 strict ResNet-50 pilot qualified all three captured phases,
 including every element of 108 gradient tensors. Its two process-level records
 remain outside Git, with source frozen at Inferena's

--- a/paper/p3hpc/main.tex
+++ b/paper/p3hpc/main.tex
@@ -725,8 +725,12 @@ measure of installation effort.
 A post-submission controlled qualification for the camera-ready cohort pins
 one PyTorch source revision across vendor builds and tests stronger automatic
 conditions separately. The RTX~5070 completes default compilation with and
-without whole-phase CUDA Graph replay and max-autotune with replay. On both AMD
-systems, however, max-autotune cannot compile the diffusion training graph:
+without whole-phase CUDA Graph replay and requested max-autotune with replay.
+The pinned Inductor policy classifies this 48-SM GPU as too small for GEMM
+template search (its fixed threshold is 68 SMs), so the records distinguish the
+requested mode from that effective limitation rather than overriding PyTorch's
+stock hardware policy. On both AMD systems, max-autotune cannot compile the
+diffusion training graph:
 generated convolution-backward candidates exceed local-memory limits or time
 out, after which Inductor's library fallback is called without a required
 output buffer. The protocol preserves those failures, never substitutes eager


### PR DESCRIPTION
## Summary

- distinguish requested PyTorch max-autotune from its effective GEMM-search coverage
- disclose pinned Inductor's 68-SM gate for the 48-SM RTX 5070 and 20-SM RTX 3050
- keep the stock PyTorch policy instead of overriding it with a benchmark-specific configuration

## Validation

- P3HPC artifact verifier tests
- four-pass `pdflatex`/`bibtex` build
- `git diff --check origin/main..HEAD`