### PR TITLE
Frame failed autotuning as portability evidence

### DIFF
--- a/docs/study/p3hpc-questions.md
+++ b/docs/study/p3hpc-questions.md
@@ -239,8 +239,9 @@ qualified-workaround availability result, not stock native-XPU performance.
 
 ### 20. Why not PyTorch max-autotune or CUDA graphs?
 
-Short: they were absent from the frozen matrix; the controlled follow-up tests
-them and records where they are unavailable.
+Short: they were absent from the frozen matrix; the controlled follow-up
+requests them everywhere and treats declined, failed, or timed-out automatic
+search as a portability result.
 
 Detail: the frozen protocol uses default `torch.compile` on Linux and no
 additional manual capture. Its explicit CUDA Graph helpers were only used by
@@ -256,10 +257,11 @@ retains default mode and explicitly labels the missing condition. The new sweep
 also charges compile/search cost, memory and accuracy rather than silently
 replacing the old data.
 
-Do not overstate the NVIDIA condition: pinned Inductor's fixed 68-SM policy
-disables GEMM template search on both the 48-SM RTX 5070 and 20-SM RTX 3050.
-The records expose that effective state. We test stock requested max-autotune;
-we do not claim that every internal kernel family actually searched candidates.
+Pinned Inductor's fixed 68-SM policy declines GEMM template search on both the
+48-SM RTX 5070 and 20-SM RTX 3050 even though the experiment requests
+max-autotune. Say exactly that: automatic search was requested, and PyTorch's
+stock policy did not make it available on those targets. The records expose
+the decision; we do not patch in a benchmark-specific threshold.
 
 The [CUDA Graph follow-up](../../paper/p3hpc/CUDA-GRAPHS.md) explains the repair,
 the exact timed boundary and the new collection plan. Do not claim that the

--- a/paper/p3hpc/CUDA-GRAPHS.md
+++ b/paper/p3hpc/CUDA-GRAPHS.md
@@ -84,11 +84,12 @@ is authoritative. Each additional machine must pass its own qualification.
 These new records remain outside Git and do not silently replace the paper's
 frozen timings.
 
-The pinned Inductor source only enables its GEMM template search at 68 NVIDIA
-SMs. It therefore records `inductor_is_big_gpu=false` on the 48-SM RTX 5070 and
-20-SM RTX 3050. Keep calling this the stock requested max-autotune condition,
-not full GEMM search; the experiment does not override PyTorch's hardware
-policy or silently substitute a hand-tuned configuration.
+The campaign requests stock max-autotune on every NVIDIA target. Pinned
+Inductor then declines GEMM template search below its fixed 68-SM threshold,
+recording `inductor_is_big_gpu=false` on the 48-SM RTX 5070 and 20-SM RTX 3050.
+That is a measured automatic-search coverage limit, not a missing benchmark
+condition. We retain PyTorch's decision instead of introducing a
+benchmark-specific threshold override.
 
 The September 8 strict ResNet-50 pilot qualified all three captured phases,
 including every element of 108 gradient tensors. Its two process-level records
@@ -99,11 +100,12 @@ comparison. See that branch's `EXPERIMENT.md` for the small result table and
 the substantial graph-pool residency cost observed in the pilot.
 
 On each machine, first qualify all workloads. NVIDIA collects default
-compiled/no-graph, default compiled/graph, and max-autotune/graph. ROCm has no
-qualified explicit graph condition. Both AMD systems reject max-autotune while
-compiling diffusion training, so they collect default/no-graph with
-`--no-max-autotune`; the manifest labels the omitted condition and the failed
-attempts remain evidence. Rotate configuration order across at least three
+compiled/no-graph, default compiled/graph, and requested max-autotune/graph.
+ROCm has no qualified explicit graph condition. Both AMD systems enter the
+requested max-autotune search and fail while compiling diffusion training, so
+the failed attempts are portability evidence and the runnable default/no-graph
+cohort is collected with `--no-max-autotune`. Its manifest labels the omitted
+timing condition. Rotate configuration order across at least three
 fresh processes, keep precision and timing boundaries fixed, and recollect
 Meganeura in each paired campaign. Store records outside main; retain source
 refs and concise conclusions. NVIDIA results cannot establish ROCm/Metal
@@ -115,9 +117,9 @@ dense embedding backward failed an exact `[128, 576]` probe in every SmolLM2
 process, so the probe selected and qualified a standard dense `index_add`
 autograd formulation. Each affected result records both probe outcomes and the
 selection under `execution.embedding_backward`; this must be labelled as a
-qualified workaround. XPU max-autotune did not finish its first ResNet
-qualification within one hour, so it remains an omitted condition rather than
-a hidden fallback or a timing sample.
+qualified workaround. Requested XPU max-autotune did not finish its first
+ResNet qualification within one hour; that timeout is the availability result,
+and no eager fallback or favorable timing sample replaces it.
 
 Do not replace individual favorable cells in the old table or compare new
 PyTorch measurements to old Meganeura timings. A new qualified cohort gets its

--- a/paper/p3hpc/REVISION.md
+++ b/paper/p3hpc/REVISION.md
@@ -27,8 +27,11 @@ evidence to the one-device, narrow tile-search experiment; it is not an
 all-model/all-platform result, nor a comparison against greedy graph rewriting.
 
 September 11: the controlled RTX 5070 campaign completed all 120 paired entries
-(30 qualification and 90 replicated measurements) at Inferena `6f5f94cf`. On
-both AMD systems, PyTorch max-autotune instead fails while compiling the
+(30 qualification and 90 replicated measurements) at Inferena `6f5f94cf`.
+The experiment requests stock max-autotune on every target. Pinned Inductor's
+fixed 68-SM gate then declines GEMM template search on the 48-SM RTX 5070 and
+20-SM RTX 3050; this is measured search coverage, not an omitted control. On
+both AMD systems, requested PyTorch max-autotune instead fails while compiling the
 diffusion training graph:
 generated convolution candidates exhaust local memory or time out, and the
 remaining ATen fallback is malformed. The paper now treats automatic compiler
@@ -40,10 +43,9 @@ The Arc B570 follow-up at Inferena `f4255c4b` completes all 10 default/no-graph
 qualification pairs and 30 replicated measurements. Its pinned XPU build has a
 repeatable native dense-embedding backward defect; a shape-derived probe selects
 and records the qualified dense `index_add` autograd equivalent for SmolLM2.
-Max-autotune did not finish its first ResNet qualification within one hour, so
-the B570 data is also an availability subset. This is useful portability
-evidence, but the workaround and omitted condition must remain visible in any
-new table.
+Requested max-autotune did not finish its first ResNet qualification within one
+hour. The timeout is useful portability evidence; the runnable B570 cohort and
+its qualified workaround must remain visible in any new table.
 
 The response matrix below paraphrases `review1.txt`, `review2.txt` and
 `review3.txt` supplied at `/home/kvark/Documents/P3HPC`; private review text

--- a/paper/p3hpc/main.tex
+++ b/paper/p3hpc/main.tex
@@ -723,20 +723,22 @@ on any machine. These are reproducible configuration facts, not a timed
 measure of installation effort.
 
 A post-submission controlled qualification for the camera-ready cohort pins
-one PyTorch source revision across vendor builds and tests stronger automatic
-conditions separately. The RTX~5070 completes default compilation with and
-without whole-phase CUDA Graph replay and requested max-autotune with replay.
-The pinned Inductor policy classifies this 48-SM GPU as too small for GEMM
-template search (its fixed threshold is 68 SMs), so the records distinguish the
-requested mode from that effective limitation rather than overriding PyTorch's
-stock hardware policy. On both AMD systems, max-autotune cannot compile the
-diffusion training graph:
+one PyTorch source revision across vendor builds and requests its strongest
+stock automatic conditions on every target. The RTX~5070 completes default
+compilation with and without whole-phase CUDA Graph replay and requested
+max-autotune with replay. Despite that request, pinned Inductor declines GEMM
+template search below a fixed 68-SM threshold, excluding both the 48-SM
+RTX~5070 and 20-SM RTX~3050. This is a measured limit of PyTorch's automatic
+search coverage, not an omitted experiment; the protocol preserves the stock
+decision instead of adding a benchmark-specific override. On both AMD systems,
+the requested max-autotune search cannot compile the diffusion training graph:
 generated convolution-backward candidates exceed local-memory limits or time
 out, after which Inductor's library fallback is called without a required
 output buffer. The protocol preserves those failures, never substitutes eager
 timing, and collects default-compiled AMD results only as a labeled
-availability subset. This is not a \system{} speedup; it shows that compiler
-search is itself part of the portability surface. \system{}'s bounded tuner
+availability subset. Together, declined, failed, and timed-out searches show
+that automatic compiler search is itself part of the portability surface.
+\system{}'s bounded tuner
 creates and numerically qualifies candidates on the selected device, measures
 only successful candidates, and retains the incumbent after rejection.
 
@@ -747,10 +749,11 @@ backward populated only 19,968 of 73,728 expected elements in an exact
 unique-index probe. A shape-derived preflight selected PyTorch's equivalent
 dense \code{index\_add} formulation, qualified all expected elements, and
 recorded the substitution with every affected result; the corrected full
-SmolLM gradient agrees with CPU and \system{}. Max-autotune remained in its
-first ResNet qualification after one hour and was omitted. We therefore label
-this an availability cohort using a qualified PyTorch workaround, not an
-unmodified native-XPU or full-condition result. It further illustrates why
+SmolLM gradient agrees with CPU and \system{}. Requested max-autotune remained
+in its first ResNet qualification after one hour; the timeout is retained and
+the runnable default condition forms a labeled availability cohort. It uses a
+qualified PyTorch workaround rather than unmodified native-XPU execution. This
+further illustrates why
 correctness and bounded search are parts of performance portability rather
 than setup details outside it.
 


### PR DESCRIPTION
## Summary

- state that the controlled campaign requests stock max-autotune on every target
- report Inductor's fixed 68-SM gate, ROCm compilation failures, and XPU timeout as measured search-availability outcomes
- contrast those outcomes with Meganeura's bounded, device-qualified candidate search
- align the paper, revision notes, CUDA Graph plan, and study guide

## Validation

- `python3 -m unittest discover -s paper/p3hpc/artifact -p 'test_*.py'`
- `python3 paper/p3hpc/artifact/verify.py --repository`
- `pdflatex`, `bibtex`, and two final `pdflatex` passes