### PR TITLE
Separate arithmetic from preparation policy

### DIFF
--- a/docs/study/p3hpc-questions.md
+++ b/docs/study/p3hpc-questions.md
@@ -263,6 +263,30 @@ max-autotune. Say exactly that: automatic search was requested, and PyTorch's
 stock policy did not make it available on those targets. The records expose
 the decision; we do not patch in a benchmark-specific threshold.
 
+Do not mix this with precision. Strict versus accelerated defines permitted
+arithmetic; light versus searched defines preparation policy. The primary CUDA
+deployment points both use whole-phase replay, and default/no-graph remains an
+ablation. Light pairs default PyTorch compilation with Meganeura measured
+search off. Searched requests PyTorch max-autotune and enables Meganeura's
+bounded tuner.
+
+The completed pre-recollection NVIDIA records show why both matter. Across 30
+model--phase--precision cells, requested max-autotune improves the geometric
+mean over default/graph by 5.7% on RTX 5070 and 4.3% on RTX 3050, while adding
+roughly 20--200 seconds of compilation per model. Strict ResNet is the useful
+exception: its large gains repay search after about 20k--40k calls; most other
+cells need tens of thousands to millions of calls or regress. By contrast,
+adding whole-phase replay to default compilation improves the geometric mean
+by about 21% on both GPUs for roughly one second of measured capture plus the
+harness's heavy validation. These are diagnostic old-revision results; replace
+the numbers with the common new cohort before publication.
+
+Present the outcome as a preparation--throughput frontier. For any phase with
+a positive steady-state gain, the break-even count is
+`(searched preparation - light preparation) / (light step - searched step)`.
+Report `never` when the searched step is not faster, and report failed or timed
+out search as availability rather than inventing a timing.
+
 The [CUDA Graph follow-up](../../paper/p3hpc/CUDA-GRAPHS.md) explains the repair,
 the exact timed boundary and the new collection plan. Do not claim that the
 submitted measurements already used this repaired baseline.

--- a/paper/p3hpc/CUDA-GRAPHS.md
+++ b/paper/p3hpc/CUDA-GRAPHS.md
@@ -84,6 +84,13 @@ is authoritative. Each additional machine must pass its own qualification.
 These new records remain outside Git and do not silently replace the paper's
 frozen timings.
 
+The campaign does not add a third arithmetic mode. It crosses strict and
+accelerated arithmetic with two preparation policies: `light` uses default
+PyTorch compilation with Meganeura measured search disabled, while `searched`
+requests PyTorch max-autotune and enables Meganeura's bounded tuner. Both CUDA
+policies use whole-phase replay; default/no-graph is the replay ablation. The
+manifest records the requested policy and effective Meganeura search state.
+
 The campaign requests stock max-autotune on every NVIDIA target. Pinned
 Inductor then declines GEMM template search below its fixed 68-SM threshold,
 recording `inductor_is_big_gpu=false` on the 48-SM RTX 5070 and 20-SM RTX 3050.
@@ -99,8 +106,9 @@ process per condition is not a replicated performance claim or a new engine
 comparison. See that branch's `EXPERIMENT.md` for the small result table and
 the substantial graph-pool residency cost observed in the pilot.
 
-On each machine, first qualify all workloads. NVIDIA collects default
-compiled/no-graph, default compiled/graph, and requested max-autotune/graph.
+On each machine, first qualify all workloads. NVIDIA collects light/no-graph,
+light/graph, and searched/graph; the underlying PyTorch modes are default,
+default, and requested max-autotune respectively.
 ROCm has no qualified explicit graph condition. Both AMD systems enter the
 requested max-autotune search and fail while compiling diffusion training, so
 the failed attempts are portability evidence and the runnable default/no-graph

--- a/paper/p3hpc/REVISION.md
+++ b/paper/p3hpc/REVISION.md
@@ -39,6 +39,14 @@ search as part of the portability surface. AMD default-mode collection remains
 valid as an explicitly labeled availability subset; no eager timing replaces
 the failed condition.
 
+The refreshed collection keeps arithmetic and preparation orthogonal. Its
+light policy pairs default PyTorch compilation with Meganeura measured search
+off; its searched policy requests PyTorch max-autotune and enables Meganeura's
+bounded tuner. Both CUDA policies use qualified whole-phase replay, with the
+no-graph condition retained as an ablation. The new analysis will report
+preparation cost, steady-state gain, and break-even call count rather than a
+single winner that assumes search is free.
+
 The Arc B570 follow-up at Inferena `f4255c4b` completes all 10 default/no-graph
 qualification pairs and 30 replicated measurements. Its pinned XPU build has a
 repeatable native dense-embedding backward defect; a shape-derived probe selects

--- a/paper/p3hpc/main.tex
+++ b/paper/p3hpc/main.tex
@@ -724,7 +724,13 @@ measure of installation effort.
 
 A post-submission controlled qualification for the camera-ready cohort pins
 one PyTorch source revision across vendor builds and requests its strongest
-stock automatic conditions on every target. The RTX~5070 completes default
+stock automatic conditions on every target. Arithmetic and preparation remain
+separate axes: the light policy uses default PyTorch compilation and disables
+\system{}'s empirical search; the searched policy requests PyTorch max-autotune
+and enables \system{}'s bounded on-device tuner. Both retain the strict and
+accelerated arithmetic controls, while no-graph execution is a replay ablation.
+This exposes preparation--throughput tradeoffs without treating search as free.
+The RTX~5070 completes default
 compilation with and without whole-phase CUDA Graph replay and requested
 max-autotune with replay. Despite that request, pinned Inductor declines GEMM
 template search below a fixed 68-SM threshold, excluding both the 48-SM


### PR DESCRIPTION
## Summary

- keep strict/accelerated arithmetic separate from light/searched preparation
- define the existing default+graph point as the light deployment policy and default/no-graph as its replay ablation
- pair requested PyTorch max-autotune with Meganeura's bounded tuner in the searched policy
- document provisional NVIDIA search gains, preparation costs, and the break-even metric for the refreshed cohort

This adds no benchmark condition; Inferena campaign v7 records the policy explicitly.

## Validation

- frozen paper artifact tests (6 passed)
- repository artifact verification
- full pdflatex/bibtex/pdflatex/pdflatex build (11 pages)